### PR TITLE
chore: marketplace polish v1.3.0 — DRY hooks, CHANGELOG, docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.3.0"
+    "version": "1.4.0"
   },
   "plugins": [
     {
       "name": "laws-of-ux",
       "source": "./plugins/laws-of-ux",
       "description": "UX laws knowledge base and frontend code reviewer. Analyzes HTML/CSS/JS/React/Vue/Svelte code against 30 Laws of UX principles with actionable recommendations.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "ForgePlan"
       },
@@ -33,7 +33,7 @@
       "name": "forgeplan-workflow",
       "source": "./plugins/forgeplan-workflow",
       "description": "Structured engineering workflow for forgeplan users. Provides forge-cycle (full dev cycle), forge-audit (multi-expert review), methodology knowledge base, and quality gate hooks. Requires forgeplan CLI.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "ForgePlan"
       },
@@ -54,7 +54,7 @@
       "name": "dev-toolkit",
       "source": "./plugins/dev-toolkit",
       "description": "Universal engineering toolkit: multi-expert audit, wave-based sprints, session context recall, and safety hooks. Works with any project and language.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "ForgePlan"
       },
@@ -74,7 +74,7 @@
       "name": "fpf",
       "source": "./plugins/fpf",
       "description": "First Principles Framework (FPF) \u2014 thinking amplifier for structured reasoning, decomposition, and decision-making. Enhanced plugin with /fpf command, applied patterns, forgeplan integration, and FPF advisor agent. Based on FPF by Anatoly Levenchuk.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "ForgePlan"
       },
@@ -94,7 +94,7 @@
       "name": "forgeplan-orchestra",
       "source": "./plugins/forgeplan-orchestra",
       "description": "Unified workflow: Forgeplan artifacts + Orchestra task tracking + Claude Code AI execution. Bidirectional sync, Session Start Protocol with Inbox Pattern, and methodology knowledge base. Requires forgeplan CLI + Orchestra MCP server.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "ForgePlan"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+All notable changes to the ForgePlan Marketplace will be documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.3.0] - 2026-04-04
+
+### Added
+- CHANGELOG.md for tracking marketplace changes
+- hooks.json schema documentation in CONTRIBUTING.md
+- Mandatory PR workflow rules in CLAUDE.md
+- Version bumping policy in CLAUDE.md
+
+### Changed
+- CONTRIBUTING.md: added hooks.json schema reference and examples
+
+## [1.2.0] - 2026-04-04
+
+### Fixed
+- Python injection vulnerability in validate-all-plugins.sh and CI workflow (use sys.argv)
+- Safety hooks fail-open when jq absent (added python3 fallback, fail-closed)
+- Incomplete rm -rf patterns in safety hooks (broadened regex)
+- set -euo pipefail crash in forge-safety-hook.sh (removed -e)
+- WARN on missing required fields changed to FAIL with error counting
+- Unbound variable $1 in validate script
+- Install commands in 6 README files (3 plugins x EN+RU)
+- GitHub org URL casing in forgeplan-workflow READMEs
+
+### Changed
+- Pinned GitHub Actions to SHA (actions/checkout@11bd719...)
+- Added version field assertion in CI
+- Orchestra unified-workflow sections moved to sections/ subdirectory
+- pre-code-check.sh: matcher narrowed to Write-only, added 5-minute cache
+- FPF update-fpf.sh: added submodule SHA integrity verification
+- All plugins bumped to v1.2.0, marketplace catalog to v1.3.0
+- laws-of-ux plugin.json: added Svelte to description
+
+## [1.1.2] - 2026-04-03
+
+### Changed
+- forgeplan-orchestra bumped to v1.1.2 (milestone approach + sync)
+
+## [1.1.1] - 2026-04-03
+
+### Fixed
+- Hook scripts: sanitize inputs, scope DROP rule, add explicit exit 0
+- All prompt hooks replaced with command hooks (silent when not matching)
+
+### Changed
+- All plugins bumped to v1.1.0-1.1.1
+
+## [1.0.0] - 2026-04-03
+
+### Added
+- Initial marketplace release with 5 plugins
+- laws-of-ux: 30 UX laws, 9 code patterns, 2 commands, 1 agent, 1 hook
+- dev-toolkit: 3 commands (audit, sprint, recall), 1 agent, 2 hooks
+- forgeplan-workflow: 2 commands (forge-cycle, forge-audit), 1 agent, 2 hooks
+- fpf: 4 commands, 1 agent, 224 FPF spec sections + 4 applied patterns
+- forgeplan-orchestra: 2 commands (sync, session), 1 agent, 1 hook
+- Validation script and CI workflow
+- CONTRIBUTING.md with plugin submission guidelines
+- Usage Guide (EN + RU)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,4 +74,33 @@ Add your plugin to `.claude-plugin/marketplace.json`:
 - [ ] Skills have `name` and `description` in SKILL.md frontmatter
 - [ ] `hooks.json` is valid JSON
 - [ ] No hardcoded paths (use `${CLAUDE_PLUGIN_ROOT}` for scripts)
+
+### hooks.json Schema
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/your-hook.sh",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+| Field | Values | Notes |
+|-------|--------|-------|
+| Event | `PreToolUse`, `PostToolUse` | Top-level key |
+| `matcher` | Tool name or `\|`-joined list | e.g. `"Bash"`, `"Write\|Edit"` |
+| `type` | `"command"` | Only supported type |
+| `command` | Shell command | Use `${CLAUDE_PLUGIN_ROOT}` for paths |
+| `timeout` | Integer (seconds) | Recommended: 3-5 |
 - [ ] README.md included in plugin directory

--- a/plugins/dev-toolkit/.claude-plugin/plugin.json
+++ b/plugins/dev-toolkit/.claude-plugin/plugin.json
@@ -1,10 +1,12 @@
 {
   "name": "dev-toolkit",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Universal engineering toolkit: multi-expert audit, wave-based sprints, session context recall, and safety hooks. Works with any project and language.",
   "author": {
     "name": "ForgePlan"
   },
+  "homepage": "https://github.com/ForgePlan/marketplace",
+  "repository": "https://github.com/ForgePlan/marketplace",
   "license": "MIT",
   "keywords": [
     "audit",

--- a/plugins/forgeplan-orchestra/.claude-plugin/plugin.json
+++ b/plugins/forgeplan-orchestra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forgeplan-orchestra",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Unified workflow: Forgeplan artifacts + Orchestra task tracking + Claude Code AI execution. Bidirectional sync, Session Start Protocol with Inbox Pattern, and methodology knowledge base. Requires forgeplan CLI (private app, access via project admin) + Orchestra MCP server.",
   "author": {
     "name": "ForgePlan"

--- a/plugins/forgeplan-workflow/.claude-plugin/plugin.json
+++ b/plugins/forgeplan-workflow/.claude-plugin/plugin.json
@@ -1,10 +1,12 @@
 {
   "name": "forgeplan-workflow",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Structured engineering workflow for forgeplan users. Provides forge-cycle (full dev cycle), forge-audit (multi-expert review), methodology knowledge base, and quality gate hooks. Requires forgeplan CLI (private app, access via project admin).",
   "author": {
     "name": "ForgePlan"
   },
+  "homepage": "https://github.com/ForgePlan/marketplace",
+  "repository": "https://github.com/ForgePlan/marketplace",
   "license": "MIT",
   "keywords": [
     "forgeplan",

--- a/plugins/forgeplan-workflow/hooks/scripts/forge-safety-hook.sh
+++ b/plugins/forgeplan-workflow/hooks/scripts/forge-safety-hook.sh
@@ -1,12 +1,24 @@
 #!/usr/bin/env bash
-# forge-safety-hook.sh
-# PreToolUse hook for Bash commands. Blocks dangerous operations.
-# Reads tool input JSON from stdin, checks the command against a blacklist.
+# forge-safety-hook.sh — Delegates to dev-toolkit safety hook + forgeplan fallback
+# This avoids duplicating the safety logic maintained in dev-toolkit.
 # Exit 0 = allow, Exit 2 = block (with JSON error message).
 
 set -uo pipefail
 
+# Delegate to the canonical safety hook.
+# When both plugins are installed, dev-toolkit's hook runs first via its own hooks.json.
+# This wrapper only runs its own checks if dev-toolkit is NOT installed.
+
+DEVTOOLKIT_HOOK="${CLAUDE_PLUGIN_ROOT:-}/../../dev-toolkit/hooks/scripts/safety-hook.sh"
+if [ -f "$DEVTOOLKIT_HOOK" ]; then
+  # dev-toolkit is installed — its hook handles safety, we skip to avoid double-checking
+  exit 0
+fi
+
+# --- Fallback: dev-toolkit not installed, run safety checks inline ---
+
 INPUT=$(cat)
+
 # Use jq if available for reliable JSON parsing, fallback to python3, fail-closed otherwise
 if command -v jq &>/dev/null; then
   COMMAND=$(echo "$INPUT" | jq -r '.command // empty' 2>/dev/null || true)
@@ -21,47 +33,34 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
-# Normalize: lowercase for matching
-CMD_LOWER=$(echo "$COMMAND" | tr '[:upper:]' '[:lower:]')
-
-# Blocked patterns
-BLOCKED=0
-REASON=""
-
-# git push --force (any variant)
-if echo "$CMD_LOWER" | grep -qE 'git\s+push\s+.*--force|git\s+push\s+-f\b'; then
-  BLOCKED=1
-  REASON="Force push is blocked. Use regular push or discuss with your team first."
-fi
-
-# git reset --hard
-if echo "$CMD_LOWER" | grep -qE 'git\s+reset\s+--hard'; then
-  BLOCKED=1
-  REASON="Hard reset is blocked. This can destroy uncommitted work. Use git stash instead."
-fi
-
-# rm -rf / or rm -rf /*
-if echo "$CMD_LOWER" | grep -qE '(sudo\s+)?rm\s+(-[a-z]*r[a-z]*f|-[a-z]*f[a-z]*r|-r\s+-f|-f\s+-r)\s+(/(\s|$|\*)|~|\.\.|\$HOME|\*)'; then
-  BLOCKED=1
-  REASON="Recursive deletion of root filesystem is blocked."
-fi
-
-# DROP TABLE / DROP DATABASE (only when piped to SQL clients)
-if echo "$CMD_LOWER" | grep -qiE '(mysql|psql|sqlite3|sqlcmd)\s.*drop\s+(table|database)|drop\s+(table|database).*\|\s*(mysql|psql|sqlite3)'; then
-  BLOCKED=1
-  REASON="DROP TABLE/DATABASE detected. This is a destructive database operation. Run it manually if intentional."
-fi
-
-# git clean -fd / -ffd (removes untracked files)
-if echo "$CMD_LOWER" | grep -qE 'git\s+clean\s+-[a-z]*f' && ! echo "$CMD_LOWER" | grep -qE 'git\s+clean\s+-[a-z]*n'; then
-  BLOCKED=1
-  REASON="git clean with force flag is blocked. This permanently deletes untracked files."
-fi
-
-if [ "$BLOCKED" -eq 1 ]; then
-  ESCAPED_REASON=$(printf '%s' "$REASON" | sed 's/\\/\\\\/g; s/"/\\"/g')
-  echo "{\"error\": \"BLOCKED: $ESCAPED_REASON\"}"
+# --- Dangerous git operations ---
+if echo "$COMMAND" | grep -qiE 'git\s+push\s+.*(-f|--force)\b'; then
+  echo '{"error":"Blocked: git push --force can destroy remote history. Use --force-with-lease for a safer alternative."}'
   exit 2
 fi
 
+if echo "$COMMAND" | grep -qiE 'git\s+reset\s+--hard'; then
+  echo '{"error":"Blocked: git reset --hard discards all uncommitted changes permanently. Stash your changes first or use git reset --soft."}'
+  exit 2
+fi
+
+# git clean with force flag — but allow dry-run (-n)
+if echo "$COMMAND" | grep -qiE 'git\s+clean\s+-[a-z]*f' && ! echo "$COMMAND" | grep -qiE 'git\s+clean\s+-[a-z]*n'; then
+  echo '{"error":"Blocked: git clean -f permanently deletes untracked files. Use git clean -n (dry run) first to review what would be removed."}'
+  exit 2
+fi
+
+# --- Destructive filesystem operations ---
+if echo "$COMMAND" | grep -qiE '(sudo\s+)?rm\s+(-[a-z]*r[a-z]*f|-[a-z]*f[a-z]*r|-r\s+-f|-f\s+-r)\s+(/(\s|$|\*)|~|\.\.|\$HOME|\*)'; then
+  echo '{"error":"Blocked: rm -rf on root, home, parent directory, or wildcard is catastrophically destructive."}'
+  exit 2
+fi
+
+# --- Destructive database operations (only when piped to SQL clients) ---
+if echo "$COMMAND" | grep -qiE '(mysql|psql|sqlite3|sqlcmd)\s.*DROP\s+(TABLE|DATABASE)|DROP\s+(TABLE|DATABASE).*\|\s*(mysql|psql|sqlite3)'; then
+  echo '{"error":"Blocked: DROP TABLE/DATABASE detected in SQL client context. Please confirm manually if this is intentional."}'
+  exit 2
+fi
+
+# Command is safe — allow execution
 exit 0

--- a/plugins/fpf/.claude-plugin/plugin.json
+++ b/plugins/fpf/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fpf",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "First Principles Framework (FPF) \u2014 thinking amplifier for structured reasoning, system decomposition, and decision-making. Enhanced version with applied patterns, forgeplan integration, and practical commands. Based on the FPF specification by Anatoly Levenchuk.",
   "author": {
     "name": "ForgePlan"

--- a/plugins/laws-of-ux/.claude-plugin/plugin.json
+++ b/plugins/laws-of-ux/.claude-plugin/plugin.json
@@ -1,10 +1,12 @@
 {
   "name": "laws-of-ux",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "UX laws knowledge base and frontend code reviewer. Analyzes HTML/CSS/JS/React/Vue/Svelte code against 30 Laws of UX principles. Provides actionable recommendations for improving user experience. Use when building UI components, reviewing frontend code, or learning UX best practices.",
   "author": {
     "name": "ForgePlan"
   },
+  "homepage": "https://github.com/ForgePlan/marketplace",
+  "repository": "https://github.com/ForgePlan/marketplace",
   "license": "MIT",
   "keywords": [
     "ux",


### PR DESCRIPTION
## Summary

- DRY: forge-safety-hook.sh delegates to dev-toolkit when installed, inline fallback otherwise
- CHANGELOG.md created (v1.0.0 → v1.3.0, Keep a Changelog format)
- CONTRIBUTING.md: hooks.json schema with JSON example and field reference table
- plugin.json: homepage/repository added to 3 plugins for consistency
- All plugins bumped to v1.3.0, marketplace catalog v1.4.0

## Verification

- [x] `./scripts/validate-all-plugins.sh` — ALL PASSED
- [x] Safety hook delegation test — forge-safety-hook blocks when dev-toolkit absent (exit 2)
- [x] CHANGELOG.md exists with 5 versions documented
- [x] CONTRIBUTING.md has hooks.json schema section
- [x] All 5 plugin.json files have homepage + repository fields

## Test plan

- [x] Validation passes
- [x] Safety hook smoke test (exit 2 on force push)
- [ ] CI passes (validate-plugins workflow)
- [ ] Post-merge: `/plugin marketplace update` pulls v1.3.0

Refs: PRD-007, EVID-013

🤖 Generated with [Claude Code](https://claude.com/claude-code)