### PR TITLE
feat: plugin.json v2 schema — dependencies, supersedes, components

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.4.1"
+    "version": "1.5.0"
   },
   "plugins": [
     {
       "name": "laws-of-ux",
       "source": "./plugins/laws-of-ux",
       "description": "UX laws knowledge base and frontend code reviewer. Analyzes HTML/CSS/JS/React/Vue/Svelte code against 30 Laws of UX principles with actionable recommendations.",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "author": {
         "name": "ForgePlan"
       },
@@ -33,7 +33,7 @@
       "name": "forgeplan-workflow",
       "source": "./plugins/forgeplan-workflow",
       "description": "Structured engineering workflow for forgeplan users. Provides forge-cycle (full dev cycle), forge-audit (multi-expert review), methodology knowledge base, and quality gate hooks. Requires forgeplan CLI.",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "author": {
         "name": "ForgePlan"
       },
@@ -54,7 +54,7 @@
       "name": "dev-toolkit",
       "source": "./plugins/dev-toolkit",
       "description": "Universal engineering toolkit: multi-expert audit, wave-based sprints, session context recall, and safety hooks. Works with any project and language.",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "author": {
         "name": "ForgePlan"
       },
@@ -74,7 +74,7 @@
       "name": "fpf",
       "source": "./plugins/fpf",
       "description": "First Principles Framework (FPF) \u2014 thinking amplifier for structured reasoning, decomposition, and decision-making. Enhanced plugin with /fpf command, applied patterns, forgeplan integration, and FPF advisor agent. Based on FPF by Anatoly Levenchuk.",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "author": {
         "name": "ForgePlan"
       },
@@ -94,7 +94,7 @@
       "name": "forgeplan-orchestra",
       "source": "./plugins/forgeplan-orchestra",
       "description": "Unified workflow: Forgeplan artifacts + Orchestra task tracking + Claude Code AI execution. Bidirectional sync, Session Start Protocol with Inbox Pattern, and methodology knowledge base. Requires forgeplan CLI + Orchestra MCP server.",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "author": {
         "name": "ForgePlan"
       },

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -34,6 +34,49 @@ jobs:
           done
           [ $errors -eq 0 ] || exit 1
 
+      - name: Check v2 optional fields
+        run: |
+          for f in plugins/*/.claude-plugin/plugin.json; do
+            [ -f "$f" ] || continue
+            plugin=$(dirname "$(dirname "$f")")
+            name=$(basename "$plugin")
+            category=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('category',''))" "$f" 2>/dev/null || true)
+            [ -z "$category" ] && echo "INFO: $name — no 'category' field (v2 schema)"
+            has_components=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print('yes' if 'components' in d else 'no')" "$f" 2>/dev/null || true)
+            [ "$has_components" = "yes" ] && echo "OK: $name — v2 components field present"
+          done
+
+      - name: Check command collisions
+        run: |
+          python3 << 'SCRIPT'
+          import os, re
+          owners = {}
+          collisions = 0
+          plugins_dir = 'plugins'
+          for plugin in sorted(os.listdir(plugins_dir)):
+              cmd_dir = os.path.join(plugins_dir, plugin, 'commands')
+              if not os.path.isdir(cmd_dir):
+                  continue
+              for fname in sorted(os.listdir(cmd_dir)):
+                  if not fname.endswith('.md'):
+                      continue
+                  fpath = os.path.join(cmd_dir, fname)
+                  with open(fpath) as f:
+                      head = ''.join(f.readline() for _ in range(5))
+                  m = re.search(r'^name:\s*["\']?(.+?)["\']?\s*$', head, re.MULTILINE)
+                  if m:
+                      cmd_name = m.group(1).strip()
+                      if cmd_name in owners:
+                          print(f"WARN: Command '{cmd_name}' in '{plugin}' collides with '{owners[cmd_name]}'")
+                          collisions += 1
+                      else:
+                          owners[cmd_name] = plugin
+          if collisions:
+              print(f"FAIL: {collisions} command collision(s) found")
+              exit(1)
+          print(f"OK: No command collisions ({len(owners)} commands checked)")
+          SCRIPT
+
       - name: Check marketplace.json lists all plugins
         run: |
           python3 << 'SCRIPT'

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -19,7 +19,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Validate marketplace.json
-        run: python3 -c "import json, sys; json.load(open(sys.argv[1])); print('marketplace.json: OK')" ".claude-plugin/marketplace.json"
+        run: |
+          python3 -c "import json, sys; json.load(open(sys.argv[1])); print('marketplace.json: OK')" ".claude-plugin/marketplace.json"
 
       - name: Validate all plugin.json files
         run: |

--- a/plugins/dev-toolkit/.claude-plugin/plugin.json
+++ b/plugins/dev-toolkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-toolkit",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Universal engineering toolkit: multi-expert audit, wave-based sprints, session context recall, and safety hooks. Works with any project and language.",
   "author": {
     "name": "ForgePlan"
@@ -16,5 +16,18 @@
     "workflow",
     "quality",
     "universal"
-  ]
+  ],
+  "category": "developer-tools",
+  "requires": {
+    "cli": [],
+    "mcp": [],
+    "plugins": []
+  },
+  "supersedes": {},
+  "components": {
+    "commands": ["audit", "sprint", "recall"],
+    "agents": ["dev-advisor"],
+    "skills": [],
+    "hooks": ["PreToolUse:Bash", "PostToolUse:Write|Edit|MultiEdit"]
+  }
 }

--- a/plugins/forgeplan-orchestra/.claude-plugin/plugin.json
+++ b/plugins/forgeplan-orchestra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forgeplan-orchestra",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Unified workflow: Forgeplan artifacts + Orchestra task tracking + Claude Code AI execution. Bidirectional sync, Session Start Protocol with Inbox Pattern, and methodology knowledge base. Requires forgeplan CLI (private app, access via project admin) + Orchestra MCP server.",
   "author": {
     "name": "ForgePlan"
@@ -16,5 +16,22 @@
     "task-tracking",
     "unified-workflow",
     "session"
-  ]
+  ],
+  "category": "workflow",
+  "requires": {
+    "cli": [{"name": "forgeplan", "optional": false}],
+    "mcp": [{"name": "orch", "optional": false, "reason": "Orchestra task management"}],
+    "plugins": []
+  },
+  "supersedes": {
+    "commands": {
+      "session": {"over": "recall", "from_plugin": "dev-toolkit", "reason": "Extends with Orchestra inbox and forgeplan health"}
+    }
+  },
+  "components": {
+    "commands": ["sync", "session"],
+    "agents": ["orchestra-advisor"],
+    "skills": ["unified-workflow"],
+    "hooks": ["PostToolUse:Bash"]
+  }
 }

--- a/plugins/forgeplan-workflow/.claude-plugin/plugin.json
+++ b/plugins/forgeplan-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forgeplan-workflow",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Structured engineering workflow for forgeplan users. Provides forge-cycle (full dev cycle), forge-audit (multi-expert review), methodology knowledge base, and quality gate hooks. Requires forgeplan CLI (private app, access via project admin).",
   "author": {
     "name": "ForgePlan"
@@ -17,5 +17,22 @@
     "adr",
     "quality-gates",
     "methodology"
-  ]
+  ],
+  "category": "workflow",
+  "requires": {
+    "cli": [{"name": "forgeplan", "optional": false}],
+    "mcp": [],
+    "plugins": [{"name": "dev-toolkit", "version": ">=1.3.0", "optional": true, "reason": "Shared safety hooks"}]
+  },
+  "supersedes": {
+    "commands": {
+      "forge-audit": {"over": "audit", "from_plugin": "dev-toolkit", "reason": "Extends with Performance + Documentation experts and forgeplan evidence"}
+    }
+  },
+  "components": {
+    "commands": ["forge-cycle", "forge-audit"],
+    "agents": ["forge-advisor"],
+    "skills": ["forgeplan-methodology"],
+    "hooks": ["PreToolUse:Bash", "PreToolUse:Write"]
+  }
 }

--- a/plugins/fpf/.claude-plugin/plugin.json
+++ b/plugins/fpf/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fpf",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "First Principles Framework (FPF) \u2014 thinking amplifier for structured reasoning, system decomposition, and decision-making. Enhanced version with applied patterns, forgeplan integration, and practical commands. Based on the FPF specification by Anatoly Levenchuk.",
   "author": {
     "name": "ForgePlan"
@@ -16,5 +16,18 @@
     "decision-making",
     "bounded-contexts",
     "architecture"
-  ]
+  ],
+  "category": "reasoning",
+  "requires": {
+    "cli": [],
+    "mcp": [],
+    "plugins": []
+  },
+  "supersedes": {},
+  "components": {
+    "commands": ["fpf", "fpf-decompose", "fpf-evaluate", "fpf-reason"],
+    "agents": ["fpf-advisor"],
+    "skills": ["fpf-knowledge"],
+    "hooks": []
+  }
 }

--- a/plugins/laws-of-ux/.claude-plugin/plugin.json
+++ b/plugins/laws-of-ux/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "laws-of-ux",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "UX laws knowledge base and frontend code reviewer. Analyzes HTML/CSS/JS/React/Vue/Svelte code against 30 Laws of UX principles. Provides actionable recommendations for improving user experience. Use when building UI components, reviewing frontend code, or learning UX best practices.",
   "author": {
     "name": "ForgePlan"
@@ -16,5 +16,18 @@
     "accessibility",
     "usability",
     "design-principles"
-  ]
+  ],
+  "category": "quality",
+  "requires": {
+    "cli": [],
+    "mcp": [],
+    "plugins": []
+  },
+  "supersedes": {},
+  "components": {
+    "commands": ["ux-review", "ux-law"],
+    "agents": ["ux-reviewer"],
+    "skills": ["ux-laws"],
+    "hooks": ["PostToolUse:Write|Edit|MultiEdit"]
+  }
 }

--- a/scripts/validate-all-plugins.sh
+++ b/scripts/validate-all-plugins.sh
@@ -44,6 +44,18 @@ validate_plugin() {
     [ -z "$version" ] && { echo "  FAIL: Missing 'version' in plugin.json"; ERRORS=$((ERRORS + 1)); }
     [ -z "$desc" ] && { echo "  FAIL: Missing 'description' in plugin.json"; ERRORS=$((ERRORS + 1)); }
 
+    # Check v2 optional fields (warn if missing, don't fail)
+    local category
+    category=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('category',''))" "$plugin_dir/.claude-plugin/plugin.json" 2>/dev/null || true)
+    [ -z "$category" ] && echo "  INFO: No 'category' field (v2 schema)"
+
+    # Validate components if present
+    local has_components
+    has_components=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print('yes' if 'components' in d else 'no')" "$plugin_dir/.claude-plugin/plugin.json" 2>/dev/null || true)
+    if [ "$has_components" = "yes" ]; then
+        echo "  OK: v2 components field present"
+    fi
+
     # Check commands frontmatter
     if [ -d "$plugin_dir/commands" ]; then
         for cmd in "$plugin_dir/commands"/*.md; do
@@ -109,6 +121,38 @@ else
         validate_plugin "$plugin_dir"
     done
 fi
+
+# Check for command name collisions across plugins
+echo ""
+echo "=== Checking command collisions ==="
+python3 - "$PLUGINS_DIR" << 'PYEOF'
+import os, re, sys
+plugins_dir = sys.argv[1]
+owners = {}
+collisions = 0
+for plugin in sorted(os.listdir(plugins_dir)):
+    cmd_dir = os.path.join(plugins_dir, plugin, 'commands')
+    if not os.path.isdir(cmd_dir):
+        continue
+    for fname in sorted(os.listdir(cmd_dir)):
+        if not fname.endswith('.md'):
+            continue
+        fpath = os.path.join(cmd_dir, fname)
+        with open(fpath) as f:
+            head = ''.join(f.readline() for _ in range(5))
+        m = re.search(r'^name:\s*["\']?(.+?)["\']?\s*$', head, re.MULTILINE)
+        if m:
+            cmd_name = m.group(1).strip()
+            if cmd_name in owners:
+                print(f"  WARN: Command '{cmd_name}' in '{plugin}' collides with '{owners[cmd_name]}'")
+                collisions += 1
+            else:
+                owners[cmd_name] = plugin
+if collisions:
+    print(f"  {collisions} command collision(s) found")
+else:
+    print(f"  OK: No command collisions ({len(owners)} commands checked)")
+PYEOF
 
 echo ""
 if [ $ERRORS -gt 0 ]; then


### PR DESCRIPTION
## Summary

- All 5 plugin.json files upgraded to v2 schema with new fields:
  - `category`: quality, developer-tools, workflow, reasoning
  - `requires`: cli/mcp/plugin dependencies declared
  - `supersedes`: forge-audit→audit, session→recall mappings
  - `components`: full inventory of commands, agents, skills, hooks
- Validation script: v2 field checks + command collision detection (13 commands, 0 collisions)
- CI workflow: v2 check step + collision detection step added
- All plugins v1.4.0, catalog v1.5.0

## Verification

- [x] `./scripts/validate-all-plugins.sh` — ALL PASSED with v2 field detection
- [x] Command collision check — 0 collisions across 13 commands
- [x] All JSON files valid
- [x] No empty checkboxes in committed files

## Test plan

- [x] Validation passes with v2 fields
- [x] Collision detection works (13 commands checked)
- [x] CI passes

Refs: PRD-008

🤖 Generated with [Claude Code](https://claude.com/claude-code)