### PR TITLE
feat: SPARC integration into forge-cycle + advisors

### DIFF
--- a/plugins/dev-toolkit/agents/dev-advisor.md
+++ b/plugins/dev-toolkit/agents/dev-advisor.md
@@ -45,8 +45,16 @@ Provide a brief, relevant security reminder. Be specific, not generic.
 ### 4. Complexity Management
 When a task involves many files or complex cross-cutting changes:
 - Suggest using `/sprint` to break it into manageable waves
+- For Deep/complex tasks: suggest SPARC methodology via `/sprint` Deep scale (if agents-sparc installed)
 - Help identify dependencies between changes
 - Recommend an execution order
+
+### 5. Agent Pack Awareness
+When specialized agents from installed plugins would help:
+- TypeScript code: suggest `typescript-pro` or `typescript-type-auditor` (agents-domain)
+- Security-sensitive code: suggest `security-expert` or `pii-detector` (agents-pro)
+- Architecture decisions: suggest `architect-reviewer` or `ddd-domain-expert` (agents-pro)
+- GitHub workflows: suggest relevant agent from agents-github
 
 ## Guidelines
 

--- a/plugins/forgeplan-workflow/agents/forge-advisor.md
+++ b/plugins/forgeplan-workflow/agents/forge-advisor.md
@@ -39,6 +39,12 @@ Do this at most once per session. Do not nag.
 When the user makes a significant architectural choice (new pattern, technology selection, major refactor direction), suggest:
 > "That's an important architectural decision. Want me to capture it as an ADR with `forgeplan new adr`?"
 
+### 5. SPARC for Deep Tasks
+When the task is routed as Deep or involves architecture + implementation + testing (multi-phase work), suggest:
+> "This is a Deep task. Want to use SPARC methodology via `/sprint`? It structures the work into Specification -> Pseudocode -> Architecture -> Refinement phases with quality gates."
+
+Only suggest if agents-sparc plugin appears to be installed. Do not suggest for Tactical fixes.
+
 ## Guidelines
 
 - Be helpful, not annoying. One suggestion per trigger, no repeats.

--- a/plugins/forgeplan-workflow/commands/forge-cycle.md
+++ b/plugins/forgeplan-workflow/commands/forge-cycle.md
@@ -52,6 +52,17 @@ If depth is Critical, also create ADR with `forgeplan new adr "<title>"` for the
 ## Step 5: Build
 
 Implement the code changes according to the PRD requirements.
+
+**For Deep+ tasks with agents-sparc installed**, use the SPARC methodology:
+1. Specification → spawn `specification` agent for requirements and acceptance criteria
+2. Pseudocode → spawn `pseudocode` agent for algorithm design
+3. Architecture → spawn `architecture` agent for system design and diagrams
+4. Refinement → spawn `refinement` agent for TDD and implementation
+5. Completion → integration and docs
+
+Use `sparc-orchestrator` to coordinate phases. Fall back to direct implementation if agents-sparc is not installed.
+
+**For Standard/Tactical tasks**, implement directly:
 - Write clean, well-structured code following project conventions.
 - Add or update tests to cover the new functionality.
 - Run the project's test suite and ensure all tests pass.


### PR DESCRIPTION
## Summary

- **forge-cycle.md**: Step 5 (Build) now uses SPARC phases for Deep+ tasks when agents-sparc installed
- **dev-advisor.md**: suggests SPARC for complex tasks + awareness of agent packs (typescript-pro, security-expert, etc.)
- **forge-advisor.md**: suggests SPARC methodology when task is routed as Deep

All graceful — falls back to standard behavior if plugins not installed.

## Verification

- [x] `./scripts/validate-all-plugins.sh` — ALL PASSED
- [x] No empty checkboxes
- [x] Graceful fallback documented in each change

🤖 Generated with [Claude Code](https://claude.com/claude-code)