### PR TITLE
docs: agent guides + README-RU for all agent plugins

### DIFF
--- a/docs/USAGE-GUIDE-RU.md
+++ b/docs/USAGE-GUIDE-RU.md
@@ -237,6 +237,65 @@
 
 ---
 
+## Агенты-советники
+
+Каждый из 5 основных плагинов включает фонового агента-советника, который активируется автоматически:
+
+| Плагин | Советник | Что делает |
+|--------|----------|-----------|
+| dev-toolkit | `dev-advisor` | Предлагает `/audit` после изменений, напоминает о тестах, предупреждает о безопасности, рекомендует SPARC |
+| forgeplan-workflow | `forge-advisor` | Предлагает `forgeplan route` перед кодингом, evidence после реализации, SPARC для Deep задач |
+| fpf | `fpf-advisor` | Предлагает `/fpf decompose`, `evaluate`, `reason` для сложных решений |
+| laws-of-ux | `ux-reviewer` | Проверяет фронтенд-код по 30 законам UX при изменении UI-файлов |
+| forgeplan-orchestra | `orchestra-advisor` | Предлагает синхронизацию с Orchestra после `forgeplan activate/new` |
+
+Советников не нужно вызывать — они наблюдают за работой и предлагают действия когда это уместно.
+
+---
+
+## Пакеты агентов
+
+5 плагинов с агентами предоставляют 55 специализированных агентов:
+
+| Пакет | Установка | Агентов | Назначение |
+|-------|-----------|:-------:|-----------|
+| **agents-core** | `/plugin install agents-core@ForgePlan-marketplace` | 11 | Ядро: debugger, code-reviewer, planner, tester, coder, researcher, reviewer |
+| **agents-domain** | `/plugin install agents-domain@ForgePlan-marketplace` | 11 | Языки: TypeScript, Go, React, Next.js, Electron, mobile |
+| **agents-pro** | `/plugin install agents-pro@ForgePlan-marketplace` | 21 | Security, архитектура, DDD, creative, research, инфраструктура |
+| **agents-github** | `/plugin install agents-github@ForgePlan-marketplace` | 7 | GitHub: PR, issues, релизы, multi-repo, project boards, workflows |
+| **agents-sparc** | `/plugin install agents-sparc@ForgePlan-marketplace` | 5 | SPARC методология: оркестратор + 4 фазовых специалиста |
+
+---
+
+## Как работают агенты
+
+Claude вызывает агентов автоматически когда задача соответствует их экспертизе. Можно также запросить конкретного агента:
+
+```
+"Используй security-expert для проверки этого кода"
+"Запусти typescript-pro для рефакторинга TypeScript"
+"Используй debugger для этой ошибки"
+```
+
+### SPARC Методология
+
+Когда `/sprint` определяет задачу как **Deep** и установлен `agents-sparc`, используются фазы SPARC:
+
+1. **Specification** — требования и критерии приёмки
+2. **Pseudocode** — алгоритмы и структуры данных
+3. **Architecture** — дизайн системы и файловая структура
+4. **Refinement** — TDD и реализация
+5. **Completion** — интеграция и PR
+
+Каждая фаза имеет **quality gate**. Следующая фаза получает полный вывод всех предыдущих — это предотвращает несогласованности.
+
+Три режима исполнения (определяются автоматически):
+- **Mode A** (Sequential): agents-sparc установлен → фазы по очереди
+- **Mode B** (Team-up): TeamCreate доступен → фазы как команда с зависимостями
+- **Mode C** (Inline): нет плагинов → Claude выполняет фазы сам
+
+---
+
 ## Решение проблем
 
 ### Плагины не загружаются

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -239,6 +239,119 @@ Hooks cannot be disabled per-session. To disable a plugin's hooks, uninstall the
 
 ---
 
+## Advisor Agents
+
+Each of the 5 original plugins includes a background advisor agent:
+
+| Plugin | Advisor | What it does |
+|--------|---------|-------------|
+| dev-toolkit | dev-advisor | Suggests /audit after changes, test reminders, security warnings, SPARC for complex tasks |
+| forgeplan-workflow | forge-advisor | Suggests forgeplan route before coding, evidence after implementation, SPARC for Deep tasks |
+| fpf | fpf-advisor | Suggests /fpf decompose, evaluate, reason for complex decisions |
+| laws-of-ux | ux-reviewer | Reviews frontend code against 30 Laws of UX |
+| forgeplan-orchestra | orchestra-advisor | Suggests Orchestra sync after forgeplan actions |
+
+Advisors activate automatically — you don't need to invoke them. They observe your work and offer suggestions when relevant.
+
+---
+
+## Agent Packs
+
+5 agent plugins provide 55 specialized agents:
+
+| Pack | Agents | Use case |
+|------|:------:|---------|
+| agents-core (11) | debugger, code-reviewer, error-detective, performance-engineer, production-validator, coder, planner, researcher, reviewer, tester, tdd-london | Core development workflow |
+| agents-domain (11) | typescript-pro, type-auditor, golang-pro, frontend-dev, nextjs-dev, electron-pro, embedded-systems, fullstack-dev, game-dev, mobile-dev, websocket-engineer | Language/framework specialists |
+| agents-pro (21) | security-expert, injection-analyst, pii-detector, claims-authorizer, architect-reviewer, microservices-architect, ddd-domain-expert, adr-architect, distributed-systems-expert, goal-planner, ui-designer, prompt-engineer, documentation-engineer, api-docs-engineer, research-analyst, search-specialist, ml-developer, code-analyzer, memory-specialist, mcp-developer, platform-engineer | Professional specialists |
+| agents-github (7) | pr-manager, issue-manager, release-manager, multi-repo-manager, project-board-manager, workflow-engineer, repo-architect | GitHub operations |
+| agents-sparc (5) | sparc-orchestrator, specification, pseudocode, architecture, refinement | SPARC development methodology |
+
+Install: `/plugin install agents-core@ForgePlan-marketplace`
+
+---
+
+## How Agents Work
+
+Agents are invoked automatically by Claude when a task matches their expertise. You can also request a specific agent:
+
+```
+"Use the security-expert agent to review this code"
+"Spawn the typescript-pro agent for this TypeScript refactoring"
+```
+
+### SPARC Methodology
+
+When /sprint detects a Deep task and agents-sparc is installed, it uses SPARC phases:
+1. Specification — requirements and acceptance criteria
+2. Pseudocode — algorithms and data structures
+3. Architecture — system design and file structure
+4. Refinement — TDD and implementation
+5. Completion — integration and PR
+
+Each phase has a quality gate. The next phase receives FULL output of all previous phases.
+
+---
+
+## Advisor Agents
+
+Each of the 5 original plugins includes a background advisor agent that activates automatically:
+
+| Plugin | Advisor | What it does |
+|--------|---------|-------------|
+| dev-toolkit | `dev-advisor` | Suggests `/audit` after changes, test reminders, security warnings, SPARC for complex tasks, agent pack recommendations |
+| forgeplan-workflow | `forge-advisor` | Suggests `forgeplan route` before coding, evidence after implementation, SPARC for Deep tasks |
+| fpf | `fpf-advisor` | Suggests `/fpf decompose`, `evaluate`, `reason` for complex decisions |
+| laws-of-ux | `ux-reviewer` | Reviews frontend code against 30 Laws of UX when UI files are modified |
+| forgeplan-orchestra | `orchestra-advisor` | Suggests Orchestra sync after `forgeplan activate` or `forgeplan new` |
+
+You don't need to invoke advisors — they observe your work and offer suggestions when relevant.
+
+---
+
+## Agent Packs
+
+5 agent plugins provide 55 specialized agents you can install separately:
+
+| Pack | Install | Agents | Use case |
+|------|---------|:------:|---------|
+| **agents-core** | `/plugin install agents-core@ForgePlan-marketplace` | 11 | Core: debugger, code-reviewer, planner, tester, coder, researcher, reviewer |
+| **agents-domain** | `/plugin install agents-domain@ForgePlan-marketplace` | 11 | Language specialists: TypeScript, Go, React, Next.js, Electron, mobile |
+| **agents-pro** | `/plugin install agents-pro@ForgePlan-marketplace` | 21 | Security, architecture, DDD, creative, research, infrastructure |
+| **agents-github** | `/plugin install agents-github@ForgePlan-marketplace` | 7 | GitHub: PR, issues, releases, multi-repo, project boards, workflows |
+| **agents-sparc** | `/plugin install agents-sparc@ForgePlan-marketplace` | 5 | SPARC methodology: orchestrator + 4 phase specialists |
+
+---
+
+## How Agents Work
+
+Agents are invoked by Claude automatically when a task matches their expertise. You can also request a specific agent:
+
+```
+"Use the security-expert agent to review this auth code"
+"Spawn typescript-pro for this TypeScript refactoring"
+"Run the debugger agent on this error"
+```
+
+### SPARC Methodology
+
+When `/sprint` detects a **Deep** task and `agents-sparc` is installed, it uses SPARC phases:
+
+1. **Specification** → requirements and acceptance criteria
+2. **Pseudocode** → algorithms and data structures
+3. **Architecture** → system design and file structure
+4. **Refinement** → TDD and implementation
+5. **Completion** → integration and PR
+
+Each phase has a **quality gate**. The next phase receives full output of all previous phases — this prevents inconsistencies between phases.
+
+Three execution modes (auto-detected):
+- **Mode A** (Sequential): agents-sparc installed → phases run one by one
+- **Mode B** (Team-up): TeamCreate available → phases as team with dependencies
+- **Mode C** (Inline): no plugins → Claude executes phases itself
+
+---
+
 ## Troubleshooting
 
 ### Plugins not loading after install

--- a/plugins/agents-core/README-RU.md
+++ b/plugins/agents-core/README-RU.md
@@ -1,0 +1,31 @@
+[English](README.md) | [Русский](README-RU.md)
+
+# agents-core
+
+Основные агенты разработки: debugger, code reviewer, error detective, performance engineer, production validator + полная команда (coder, planner, researcher, reviewer, tester, TDD London School).
+
+## Установка
+
+```
+/plugin install agents-core@ForgePlan-marketplace
+```
+
+## Агенты
+
+| Агент | Описание |
+|-------|----------|
+| **debugger** | Отладка: диагностика, root cause analysis, систематическое решение проблем |
+| **code-reviewer** | Ревью кода: качество, безопасность, производительность |
+| **error-detective** | Расследование ошибок: RCA, каскадные сбои, корреляция логов |
+| **performance-engineer** | Производительность: профилирование, оптимизация, SLA |
+| **production-validator** | Валидация production: обнаружение моков, проверка интеграций |
+| **coder** | Реализация: чистый, production-quality код |
+| **planner** | Планирование: декомпозиция задач в исполнимые планы |
+| **researcher** | Исследование: анализ кодовой базы, поиск паттернов |
+| **reviewer** | QA: поиск багов и проблем дизайна |
+| **tester** | Тестирование: стратегии, написание тестов |
+| **tdd-london** | TDD London School: outside-in, mock-driven, behavior verification |
+
+## Лицензия
+
+MIT

--- a/plugins/agents-domain/README-RU.md
+++ b/plugins/agents-domain/README-RU.md
@@ -1,0 +1,31 @@
+[English](README.md) | [Русский](README-RU.md)
+
+# agents-domain
+
+Специалисты по языкам и фреймворкам для Claude Code.
+
+## Установка
+
+```
+/plugin install agents-domain@ForgePlan-marketplace
+```
+
+## Агенты
+
+| Агент | Стек |
+|-------|------|
+| **typescript-pro** | TypeScript 5+, type system, build tooling |
+| **typescript-type-auditor** | Аудит type safety, generics, conditional types |
+| **golang-pro** | Go 1.21+, concurrency, cloud-native |
+| **frontend-developer** | React, Vue, Angular, accessibility |
+| **nextjs-developer** | Next.js 14+ App Router, SSR/SSG |
+| **electron-pro** | Electron desktop apps, security, IPC |
+| **embedded-systems** | MCU firmware, RTOS, power optimization |
+| **fullstack-developer** | Database + API + frontend end-to-end |
+| **game-developer** | Game engines, graphics, multiplayer |
+| **mobile-app-developer** | iOS/Android native + cross-platform |
+| **websocket-engineer** | WebSocket, Socket.IO, real-time |
+
+## Лицензия
+
+MIT

--- a/plugins/agents-github/README-RU.md
+++ b/plugins/agents-github/README-RU.md
@@ -1,0 +1,29 @@
+[English](README.md) | [Русский](README-RU.md)
+
+# agents-github
+
+Агенты для операций с GitHub: PR, issues, releases, multi-repo, project boards, workflows.
+
+Требуется: `gh` CLI
+
+## Установка
+
+```
+/plugin install agents-github@ForgePlan-marketplace
+```
+
+## Агенты
+
+| Агент | Описание |
+|-------|----------|
+| **pr-manager** | PR lifecycle: create, review, merge, auto-merge |
+| **issue-manager** | Issues: создание, labeling, stale automation, декомпозиция |
+| **release-manager** | Релизы: changelog, `gh release`, multi-package |
+| **multi-repo-manager** | Multi-repo: org discovery, clone-update-PR loop |
+| **project-board-manager** | GitHub Projects V2: boards, fields, items |
+| **workflow-engineer** | GitHub Actions: YAML patterns, CI/CD, failure analysis |
+| **repo-architect** | Repo scaffolding: `.github/`, branch protection, templates |
+
+## Лицензия
+
+MIT

--- a/plugins/agents-pro/README-RU.md
+++ b/plugins/agents-pro/README-RU.md
@@ -1,0 +1,58 @@
+[English](README.md) | [Русский](README-RU.md)
+
+# agents-pro
+
+Профессиональные специалисты: security, архитектура, creative, research, инфраструктура.
+
+## Установка
+
+```
+/plugin install agents-pro@ForgePlan-marketplace
+```
+
+## Агенты
+
+### Security (4)
+| Агент | Описание |
+|-------|----------|
+| **security-expert** | OWASP Top 10, threat modeling, STRIDE/DREAD, zero-trust |
+| **injection-analyst** | Анализ prompt injection, jailbreak detection |
+| **pii-detector** | Поиск PII/secrets: API keys, credentials, compliance |
+| **claims-authorizer** | ABAC/RBAC авторизация, policy enforcement |
+
+### Architecture (6)
+| Агент | Описание |
+|-------|----------|
+| **architect-reviewer** | Ревью архитектуры: coupling, cohesion, scalability |
+| **microservices-architect** | Микросервисы: service mesh, event-driven, saga |
+| **ddd-domain-expert** | DDD: bounded contexts, aggregates, event storming |
+| **adr-architect** | ADR: MADR 3.0, decision records |
+| **distributed-systems-expert** | Raft, PBFT, CRDT, gossip protocols |
+| **goal-planner** | GOAP planning, A* search, OODA loop |
+
+### Creative (4)
+| Агент | Описание |
+|-------|----------|
+| **ui-designer** | UI/UX design, design systems |
+| **prompt-engineer** | Prompt engineering, LLM optimization |
+| **documentation-engineer** | Documentation as code |
+| **api-docs-engineer** | OpenAPI spec generation |
+
+### Research (5)
+| Агент | Описание |
+|-------|----------|
+| **research-analyst** | Информационный поиск, synthesis |
+| **search-specialist** | Advanced retrieval |
+| **ml-developer** | ML/AI: sklearn, training pipelines |
+| **code-analyzer** | Code quality metrics, 5-domain analysis |
+| **memory-specialist** | HNSW, vector quantization, hybrid search |
+
+### Infrastructure (2)
+| Агент | Описание |
+|-------|----------|
+| **mcp-developer** | MCP server/client разработка |
+| **platform-engineer** | IDP, GitOps, Backstage |
+
+## Лицензия
+
+MIT

--- a/plugins/agents-sparc/README-RU.md
+++ b/plugins/agents-sparc/README-RU.md
@@ -1,0 +1,39 @@
+[English](README.md) | [Русский](README-RU.md)
+
+# agents-sparc
+
+SPARC методология разработки: оркестратор с quality gates + 4 фазовых специалиста.
+
+## Установка
+
+```
+/plugin install agents-sparc@ForgePlan-marketplace
+```
+
+## SPARC Методология
+
+```
+S → Specification  — требования, критерии приёмки
+P → Pseudocode     — алгоритмы, структуры данных
+A → Architecture   — дизайн системы, компоненты
+R → Refinement     — TDD, рефакторинг, оптимизация
+C → Completion     — интеграция, документация
+```
+
+## Агенты
+
+| Агент | Фаза | Описание |
+|-------|------|----------|
+| **sparc-orchestrator** | Координатор | Управляет фазами, quality gates, делегирование |
+| **specification** | S | Анализ требований, constraints, acceptance criteria |
+| **pseudocode** | P | Дизайн алгоритмов, выбор структур данных, complexity |
+| **architecture** | A | Системный дизайн, компоненты, Mermaid диаграммы |
+| **refinement** | R | TDD red-green-refactor, оптимизация, error handling |
+
+## Интеграция
+
+`/sprint` Deep автоматически использует SPARC когда этот плагин установлен.
+
+## Лицензия
+
+MIT


### PR DESCRIPTION
## Summary

- USAGE-GUIDE (EN+RU): added Advisor Agents, Agent Packs, How Agents Work, SPARC sections
- 5 README-RU.md created for agent plugins (matching other plugins' bilingual pattern)

- [x] Validation PASS
- [x] Both EN and RU versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)