### PR TITLE
docs: hotfix — apply lost fixes from PR #9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to the ForgePlan Marketplace will be documented in this file
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-04-04
+
+### Added
+- Agent Army: 55 agents across 5 packs (agents-core, agents-domain, agents-pro, agents-github, agents-sparc)
+- SPARC development methodology integration with /sprint Deep tasks
+- ARCHITECTURE.md and ARCHITECTURE-RU.md documentation (4 Systems, 4 Layers)
+- Bilingual architecture docs with cross-links
+
+### Fixed
+- Duplicate sections in USAGE-GUIDE.md (Advisor Agents, Agent Packs, How Agents Work appeared twice)
+- README.md Quick Start updated with step-by-step flow
+- Added "Where to Start?" role-based guide to README.md
+- Architecture link added to README header stats
+
+## [1.4.0] - 2026-04-04
+
+### Added
+- plugin.json v2 schema support
+- Collision detection for overlapping plugin commands
+
+### Changed
+- Marketplace catalog updated with v2 schema fields
+
+## [1.3.1] - 2026-04-04
+
+### Changed
+- USAGE-GUIDE.md expanded with Advisor Agents, Agent Packs, How Agents Work, SPARC Methodology sections
+- USAGE-GUIDE-RU.md expanded with matching Russian translations
+
+### Fixed
+- Small formatting fixes in usage guides
+
 ## [1.3.0] - 2026-04-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,20 +4,33 @@
 
 Official plugin marketplace for Claude Code from [ForgePlan](https://github.com/ForgePlan) — UX, workflow, engineering, and developer tools.
 
-**10 plugins** | **13 commands** | **60 agents** | **4 hook configs** | **4 knowledge bases** | [Usage Guide](docs/USAGE-GUIDE.md)
+**10 plugins** | **13 commands** | **60 agents** | **4 hook configs** | **4 knowledge bases** | [Usage Guide](docs/USAGE-GUIDE.md) | [Architecture](docs/ARCHITECTURE.md)
 
 ## Quick Start
 
 ```bash
-# Add the ForgePlan marketplace
+# 1. Add the ForgePlan marketplace
 /plugin marketplace add ForgePlan/marketplace
 
-# Browse available plugins
-/plugin
+# 2. Install your first plugin (works with any project, no dependencies)
+/plugin install dev-toolkit@ForgePlan-marketplace
 
-# Install a specific plugin
-/plugin install laws-of-ux@ForgePlan-marketplace
+# 3. Reload to activate
+/reload-plugins
+
+# 4. Try it — run a code audit
+/audit
 ```
+
+## Where to Start?
+
+| Your role | Install these | Why |
+|-----------|--------------|-----|
+| Any developer | dev-toolkit + agents-core | Universal tools |
+| Frontend | + laws-of-ux + agents-domain | UX + framework agents |
+| Architect | + fpf + agents-pro + agents-sparc | Thinking + SPARC |
+| Forgeplan user | + forgeplan-workflow + forgeplan-orchestra | Full lifecycle |
+| Everything | All 10 plugins | Complete ecosystem |
 
 ## Available Plugins
 

--- a/docs/ARCHITECTURE-RU.md
+++ b/docs/ARCHITECTURE-RU.md
@@ -1,0 +1,180 @@
+[English](ARCHITECTURE.md) | [Русский](ARCHITECTURE-RU.md)
+
+# Архитектура ForgePlan: 4 системы, 4 уровня
+
+## Обзор
+
+Экосистема ForgePlan состоит из 4 взаимодополняющих систем, каждая из которых работает на своём уровне:
+
+```
+Orchestra    — ГДЕ задача?         (tracking, sync, inbox)
+Forgeplan    — ЧТО делать?         (PRD, evidence, lifecycle)
+FPF          — КАК думать?         (decompose, evaluate, reason)
+SPARC        — КАК кодить?         (spec -> pseudo -> arch -> refine -> complete)
+```
+
+Никаких пересечений. Каждая система делает одно дело хорошо.
+
+---
+
+## Уровень 1: Orchestra (Отслеживание задач)
+
+**Назначение**: Отслеживать ГДЕ задачи находятся в pipeline.
+
+| Поле | Значения |
+|------|----------|
+| Status | Backlog -> To Do -> Doing -> Review -> Done |
+| Phase | Shape -> Validate -> Code -> Evidence -> Done |
+
+**Инструменты**: `/sync`, `/session`, Orchestra MCP server
+
+---
+
+## Уровень 2: Forgeplan (Жизненный цикл проекта)
+
+**Назначение**: Определить ЧТО строить и отслеживать прогресс через методологию.
+
+**Цикл**: Route -> Shape -> Build -> Audit -> Evidence -> Activate
+
+| Этап | Что происходит | Артефакт |
+|------|---------------|----------|
+| Route | Определить глубину задачи (Tactical/Standard/Deep) | - |
+| Shape | Описать что строим | PRD |
+| Build | Реализовать код | Code |
+| Audit | Проверить качество | Findings |
+| Evidence | Задокументировать что построено/проверено | Evidence |
+| Activate | Отметить PRD как завершённый | - |
+
+**Инструменты**: `forgeplan health`, `forgeplan route`, `forgeplan new prd`, `/forge-cycle`, `/forge-audit`
+
+---
+
+## Уровень 3: FPF (Структурированное мышление)
+
+**Назначение**: КАК думать над сложными проблемами.
+
+| Режим | Когда использовать | Результат |
+|-------|--------------------|-----------|
+| `/fpf decompose` | Разбить систему на ограниченные части | Context table + Mermaid diagram |
+| `/fpf evaluate` | Сравнить альтернативы с доказательствами | F-G-R scores + decision matrix |
+| `/fpf reason` | Отладить или проанализировать проблему | 3+ гипотезы -> проверка -> заключение |
+| `/fpf lookup` | Найти концепцию FPF | Определение + примеры |
+
+**База знаний**: 224 секции спецификации FPF + 4 applied patterns
+
+---
+
+## Уровень 4: SPARC (Структурированное кодирование)
+
+**Назначение**: КАК кодить фичу через 5 последовательных фаз.
+
+### Фазы SPARC
+
+```
+S — Specification    -> Что строить? Требования, ограничения, критерии приёмки
+P — Pseudocode       -> Как строить? Алгоритмы, структуры данных, сложность
+A — Architecture     -> Где строить? Дизайн системы, компоненты, Mermaid диаграммы
+R — Refinement       -> Как улучшить? TDD red-green-refactor, оптимизация
+C — Completion       -> Готово? Интеграция, деплой, документация
+```
+
+### Quality Gates
+
+| Фаза | Агент | Quality Gate |
+|------|-------|-------------|
+| S | specification | Требования полные, критерии приёмки определены |
+| P | pseudocode | Алгоритм выбран, сложность оценена |
+| A | architecture | Компоненты определены, границы чёткие |
+| R | refinement | Тесты зелёные, покрытие > 80% |
+| C | (orchestrator) | Всё интегрировано, документация готова |
+
+### Агенты
+
+Плагин `agents-sparc` предоставляет 5 агентов:
+- `sparc-orchestrator` — координирует все фазы, обеспечивает quality gates
+- `specification` — специалист по анализу требований
+- `pseudocode` — специалист по проектированию алгоритмов
+- `architecture` — специалист по дизайну систем
+- `refinement` — специалист по TDD и оптимизации кода
+
+---
+
+## Как они работают вместе
+
+### SPARC vs Forgeplan
+
+Нет конфликтов. Разные уровни:
+
+| | Forgeplan | SPARC |
+|--|----------|-------|
+| Уровень | Управление проектом (ЧТО) | Разработка кода (КАК) |
+| Цикл | Route->Shape->Build->Audit->Evidence | Spec->Pseudo->Arch->Refine->Complete |
+| Артефакты | PRD, RFC, ADR, Evidence | Code, tests, diagrams |
+| Скоуп | Весь жизненный цикл проекта | Один спринт/фича |
+
+### Поток интеграции
+
+```
+Forgeplan:  Route -> Shape (PRD) -> BUILD <- SPARC живёт здесь -> Audit -> Evidence
+                                      |
+SPARC:                    Spec -> Pseudo -> Arch -> Refine -> Complete
+                                      |
+Agents:              specification  pseudocode  architecture  refinement
+                       agent         agent        agent        agent
+```
+
+### Конкретный пример
+
+```
+1. forgeplan route "add OAuth"           -> Standard depth
+2. forgeplan new prd "OAuth Integration" -> PRD-010
+3. /sprint "implement OAuth"
+     | Sprint запускает цикл SPARC (Deep scale):
+     Wave 1: specification agent -> требования, потоки, edge cases
+     Wave 2: pseudocode agent    -> алгоритм валидации токенов
+             architecture agent  -> компоненты, Mermaid диаграмма
+     Wave 3: refinement agent    -> TDD, тесты, рефакторинг
+4. /audit -> ревьюеры проверяют результат
+5. forgeplan new evidence "OAuth implemented, tests pass"
+6. Commit -> PR -> Merge
+```
+
+### SPARC + Orchestra
+
+Orchestra отслеживает задачи. SPARC — это КАК задача выполняется:
+
+```
+Orchestra: Task "OAuth" Status=Doing, Phase=Code
+                |
+Forgeplan: PRD-010 active, Build phase
+                |
+SPARC:     Specification -> Pseudocode -> Architecture -> Refinement
+                |
+Orchestra: Task "OAuth" Status=Review, Phase=Evidence
+```
+
+---
+
+## Карта плагинов
+
+| Система | Плагин(ы) | Установка |
+|---------|----------|-----------|
+| Orchestra | forgeplan-orchestra | `/plugin install forgeplan-orchestra@ForgePlan-marketplace` |
+| Forgeplan | forgeplan-workflow | `/plugin install forgeplan-workflow@ForgePlan-marketplace` |
+| FPF | fpf | `/plugin install fpf@ForgePlan-marketplace` |
+| SPARC | agents-sparc | `/plugin install agents-sparc@ForgePlan-marketplace` |
+| Универсальные инструменты | dev-toolkit | `/plugin install dev-toolkit@ForgePlan-marketplace` |
+| UX | laws-of-ux | `/plugin install laws-of-ux@ForgePlan-marketplace` |
+| Агенты | agents-core, agents-domain, agents-pro, agents-github | `/plugin install agents-core@ForgePlan-marketplace` |
+
+---
+
+## Рекомендуемые стеки
+
+| Роль | Плагины |
+|------|---------|
+| Любой разработчик | dev-toolkit + agents-core |
+| Фронтенд | dev-toolkit + laws-of-ux + agents-domain |
+| Архитектор | fpf + agents-pro + agents-sparc |
+| Пользователь Forgeplan | forgeplan-workflow + fpf + agents-core + agents-sparc |
+| Полный стек (все системы) | все 10 плагинов |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,180 @@
+[English](ARCHITECTURE.md) | [Русский](ARCHITECTURE-RU.md)
+
+# ForgePlan Architecture: 4 Systems, 4 Layers
+
+## Overview
+
+ForgePlan ecosystem consists of 4 complementary systems, each operating at its own level:
+
+```
+Orchestra    — WHERE is the task?  (tracking, sync, inbox)
+Forgeplan    — WHAT to do?         (PRD, evidence, lifecycle)
+FPF          — HOW to think?       (decompose, evaluate, reason)
+SPARC        — HOW to code?        (spec -> pseudo -> arch -> refine -> complete)
+```
+
+No overlaps. Each system does one thing well.
+
+---
+
+## Layer 1: Orchestra (Task Tracking)
+
+**Purpose**: Track WHERE tasks are in the pipeline.
+
+| Field | Values |
+|-------|--------|
+| Status | Backlog -> To Do -> Doing -> Review -> Done |
+| Phase | Shape -> Validate -> Code -> Evidence -> Done |
+
+**Tools**: `/sync`, `/session`, Orchestra MCP server
+
+---
+
+## Layer 2: Forgeplan (Project Lifecycle)
+
+**Purpose**: Define WHAT to build and track progress through the methodology.
+
+**Cycle**: Route -> Shape -> Build -> Audit -> Evidence -> Activate
+
+| Stage | What happens | Artifact |
+|-------|-------------|----------|
+| Route | Determine task depth (Tactical/Standard/Deep) | - |
+| Shape | Describe what we're building | PRD |
+| Build | Implement the code | Code |
+| Audit | Review quality | Findings |
+| Evidence | Document what was built/verified | Evidence |
+| Activate | Mark PRD as complete | - |
+
+**Tools**: `forgeplan health`, `forgeplan route`, `forgeplan new prd`, `/forge-cycle`, `/forge-audit`
+
+---
+
+## Layer 3: FPF (Structured Thinking)
+
+**Purpose**: HOW to think through complex problems.
+
+| Mode | When to use | Output |
+|------|------------|--------|
+| `/fpf decompose` | Break system into bounded parts | Context table + Mermaid diagram |
+| `/fpf evaluate` | Compare alternatives with evidence | F-G-R scores + decision matrix |
+| `/fpf reason` | Debug or analyze a problem | 3+ hypotheses -> test -> conclude |
+| `/fpf lookup` | Find an FPF concept | Definition + examples |
+
+**Knowledge base**: 224 FPF specification sections + 4 applied patterns
+
+---
+
+## Layer 4: SPARC (Structured Coding)
+
+**Purpose**: HOW to code a feature through 5 sequential phases.
+
+### SPARC Phases
+
+```
+S — Specification    -> What to build? Requirements, constraints, acceptance criteria
+P — Pseudocode       -> How to build? Algorithms, data structures, complexity
+A — Architecture     -> Where to build? System design, components, Mermaid diagrams
+R — Refinement       -> How to improve? TDD red-green-refactor, performance tuning
+C — Completion       -> Ready? Integration, deployment, documentation
+```
+
+### Quality Gates
+
+| Phase | Agent | Quality Gate |
+|-------|-------|-------------|
+| S | specification | Requirements complete, acceptance criteria defined |
+| P | pseudocode | Algorithm chosen, complexity evaluated |
+| A | architecture | Components defined, boundaries clear |
+| R | refinement | Tests green, coverage > 80% |
+| C | (orchestrator) | Everything integrated, docs ready |
+
+### Agents
+
+The `agents-sparc` plugin provides 5 agents:
+- `sparc-orchestrator` — coordinates all phases, enforces quality gates
+- `specification` — requirements analysis specialist
+- `pseudocode` — algorithm design specialist
+- `architecture` — system design specialist
+- `refinement` — TDD and code optimization specialist
+
+---
+
+## How They Work Together
+
+### SPARC vs Forgeplan
+
+No conflict. Different levels:
+
+| | Forgeplan | SPARC |
+|--|----------|-------|
+| Level | Project management (WHAT) | Code development (HOW) |
+| Cycle | Route->Shape->Build->Audit->Evidence | Spec->Pseudo->Arch->Refine->Complete |
+| Artifacts | PRD, RFC, ADR, Evidence | Code, tests, diagrams |
+| Scope | Entire project lifecycle | One sprint/feature |
+
+### Integration Flow
+
+```
+Forgeplan:  Route -> Shape (PRD) -> BUILD <- SPARC lives here -> Audit -> Evidence
+                                      |
+SPARC:                    Spec -> Pseudo -> Arch -> Refine -> Complete
+                                      |
+Agents:              specification  pseudocode  architecture  refinement
+                       agent         agent        agent        agent
+```
+
+### Concrete Example
+
+```
+1. forgeplan route "add OAuth"           -> Standard depth
+2. forgeplan new prd "OAuth Integration" -> PRD-010
+3. /sprint "implement OAuth"
+     | Sprint triggers SPARC cycle (Deep scale):
+     Wave 1: specification agent -> requirements, flows, edge cases
+     Wave 2: pseudocode agent    -> token validation algorithm
+             architecture agent  -> components, Mermaid diagram
+     Wave 3: refinement agent    -> TDD, tests, refactoring
+4. /audit -> reviewers check the result
+5. forgeplan new evidence "OAuth implemented, tests pass"
+6. Commit -> PR -> Merge
+```
+
+### SPARC + Orchestra
+
+Orchestra tracks tasks. SPARC is HOW the task gets done:
+
+```
+Orchestra: Task "OAuth" Status=Doing, Phase=Code
+                |
+Forgeplan: PRD-010 active, Build phase
+                |
+SPARC:     Specification -> Pseudocode -> Architecture -> Refinement
+                |
+Orchestra: Task "OAuth" Status=Review, Phase=Evidence
+```
+
+---
+
+## Plugin Map
+
+| System | Plugin(s) | Install |
+|--------|----------|---------|
+| Orchestra | forgeplan-orchestra | `/plugin install forgeplan-orchestra@ForgePlan-marketplace` |
+| Forgeplan | forgeplan-workflow | `/plugin install forgeplan-workflow@ForgePlan-marketplace` |
+| FPF | fpf | `/plugin install fpf@ForgePlan-marketplace` |
+| SPARC | agents-sparc | `/plugin install agents-sparc@ForgePlan-marketplace` |
+| Universal tools | dev-toolkit | `/plugin install dev-toolkit@ForgePlan-marketplace` |
+| UX | laws-of-ux | `/plugin install laws-of-ux@ForgePlan-marketplace` |
+| Agents | agents-core, agents-domain, agents-pro, agents-github | `/plugin install agents-core@ForgePlan-marketplace` |
+
+---
+
+## Recommended Stacks
+
+| Role | Plugins |
+|------|---------|
+| Any developer | dev-toolkit + agents-core |
+| Frontend | dev-toolkit + laws-of-ux + agents-domain |
+| Architect | fpf + agents-pro + agents-sparc |
+| Forgeplan user | forgeplan-workflow + fpf + agents-core + agents-sparc |
+| Full stack (all systems) | all 10 plugins |

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -241,60 +241,6 @@ Hooks cannot be disabled per-session. To disable a plugin's hooks, uninstall the
 
 ## Advisor Agents
 
-Each of the 5 original plugins includes a background advisor agent:
-
-| Plugin | Advisor | What it does |
-|--------|---------|-------------|
-| dev-toolkit | dev-advisor | Suggests /audit after changes, test reminders, security warnings, SPARC for complex tasks |
-| forgeplan-workflow | forge-advisor | Suggests forgeplan route before coding, evidence after implementation, SPARC for Deep tasks |
-| fpf | fpf-advisor | Suggests /fpf decompose, evaluate, reason for complex decisions |
-| laws-of-ux | ux-reviewer | Reviews frontend code against 30 Laws of UX |
-| forgeplan-orchestra | orchestra-advisor | Suggests Orchestra sync after forgeplan actions |
-
-Advisors activate automatically — you don't need to invoke them. They observe your work and offer suggestions when relevant.
-
----
-
-## Agent Packs
-
-5 agent plugins provide 55 specialized agents:
-
-| Pack | Agents | Use case |
-|------|:------:|---------|
-| agents-core (11) | debugger, code-reviewer, error-detective, performance-engineer, production-validator, coder, planner, researcher, reviewer, tester, tdd-london | Core development workflow |
-| agents-domain (11) | typescript-pro, type-auditor, golang-pro, frontend-dev, nextjs-dev, electron-pro, embedded-systems, fullstack-dev, game-dev, mobile-dev, websocket-engineer | Language/framework specialists |
-| agents-pro (21) | security-expert, injection-analyst, pii-detector, claims-authorizer, architect-reviewer, microservices-architect, ddd-domain-expert, adr-architect, distributed-systems-expert, goal-planner, ui-designer, prompt-engineer, documentation-engineer, api-docs-engineer, research-analyst, search-specialist, ml-developer, code-analyzer, memory-specialist, mcp-developer, platform-engineer | Professional specialists |
-| agents-github (7) | pr-manager, issue-manager, release-manager, multi-repo-manager, project-board-manager, workflow-engineer, repo-architect | GitHub operations |
-| agents-sparc (5) | sparc-orchestrator, specification, pseudocode, architecture, refinement | SPARC development methodology |
-
-Install: `/plugin install agents-core@ForgePlan-marketplace`
-
----
-
-## How Agents Work
-
-Agents are invoked automatically by Claude when a task matches their expertise. You can also request a specific agent:
-
-```
-"Use the security-expert agent to review this code"
-"Spawn the typescript-pro agent for this TypeScript refactoring"
-```
-
-### SPARC Methodology
-
-When /sprint detects a Deep task and agents-sparc is installed, it uses SPARC phases:
-1. Specification — requirements and acceptance criteria
-2. Pseudocode — algorithms and data structures
-3. Architecture — system design and file structure
-4. Refinement — TDD and implementation
-5. Completion — integration and PR
-
-Each phase has a quality gate. The next phase receives FULL output of all previous phases.
-
----
-
-## Advisor Agents
-
 Each of the 5 original plugins includes a background advisor agent that activates automatically:
 
 | Plugin | Advisor | What it does |


### PR DESCRIPTION
Fixes lost during squash merge of PR #9:
- [x] USAGE-GUIDE duplicate sections removed (was 2x Advisors, 2x Agents, 2x How Agents Work)
- [x] ARCHITECTURE.md + ARCHITECTURE-RU.md created
- [x] CHANGELOG updated (v1.3.1, v1.4.0, v1.6.0)
- [x] README: /reload-plugins + "Where to Start?" + Architecture link
- [x] Validation PASS 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)