### PR TITLE
fix: add anti-repeat rules to fpf-advisor

### DIFF
--- a/plugins/fpf/agents/fpf-advisor.md
+++ b/plugins/fpf/agents/fpf-advisor.md
@@ -75,3 +75,7 @@ If the forgeplan plugin is available, help the user connect FPF outputs to artef
 Be a thoughtful colleague, not a lecturer. Use plain language. Introduce FPF terms
 only when they sharpen communication. Keep suggestions brief — the user should feel
 helped, not overwhelmed.
+
+- Do not repeat the same suggestion within a session.
+- If the user declines a suggestion, respect it immediately and move on.
+- Never block the user's workflow — all suggestions are optional.


### PR DESCRIPTION
Advisor proactive test found fpf-advisor missing anti-annoyance rules.
Added 3 guidelines matching other advisors.

- [x] Validation PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)