### PR TITLE
chore(ci): repo protection — rulesets, security, hooks

### DIFF
--- a/.claude/hooks/safety-hook.sh
+++ b/.claude/hooks/safety-hook.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# PreToolUse hook — blocks dangerous bash commands before execution
+# Exit 0 = allow, Exit 2 = block with message to stderr
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+[ -z "$COMMAND" ] && exit 0
+
+BLOCKED_PATTERNS=(
+  "git push --force"
+  "git push -f "
+  "git push origin main"
+  "git push origin dev"
+  "git reset --hard"
+  "git clean -fd"
+  "rm -rf /"
+  "rm -rf ~"
+  "rm -rf ."
+  "DROP TABLE"
+  "DROP DATABASE"
+  "git branch -D main"
+  "git branch -D dev"
+)
+
+for pattern in "${BLOCKED_PATTERNS[@]}"; do
+  if echo "$COMMAND" | grep -qi "$pattern"; then
+    echo "BLOCKED: '$pattern' is not allowed. Use feature branch + PR workflow instead." >&2
+    exit 2
+  fi
+done
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/safety-hook.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -2,14 +2,17 @@ name: Validate Plugins
 
 on:
   pull_request:
+    branches: [main, dev]
     paths:
       - 'plugins/**'
       - '.claude-plugin/marketplace.json'
+      - '.github/workflows/**'
   push:
-    branches: [main]
+    branches: [main, dev]
     paths:
       - 'plugins/**'
       - '.claude-plugin/marketplace.json'
+      - '.github/workflows/**'
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary
- CI workflow updated: `dev` branch added to push/PR triggers, `.github/workflows/**` added to path filters for self-validation
- Local safety hooks: `.claude/hooks/safety-hook.sh` blocks force-push, `rm -rf`, direct push to main/dev, `DROP TABLE`, branch deletion
- `.claude/settings.json` configures PreToolUse hook for Bash tool

## What was done outside this PR (GitHub API)
- **Rulesets created**: Main (PR + 1 review + CI strict), Dev (PR + CI), Tags (admin-only)
- **Security enabled**: Secret scanning, push protection, Dependabot alerts

## Verification
- ✅ All 3 rulesets active (verified via `gh api`)
- ✅ Secret scanning + push protection enabled
- ✅ Dependabot alerts enabled
- ✅ Hook blocks `git push --force` (exit 2)
- ✅ Hook allows safe commands like `git commit` (exit 0)
- ✅ `dev` branch created from main

## Test plan
- ✅ `echo '{"tool_input":{"command":"git push --force origin main"}}' | bash .claude/hooks/safety-hook.sh` → BLOCKED
- ✅ `echo '{"tool_input":{"command":"git add -A && git commit -m test"}}' | bash .claude/hooks/safety-hook.sh` → allowed
- ✅ `gh api repos/ForgePlan/marketplace/rulesets` → 3 rulesets active

🤖 Generated with [Claude Code](https://claude.com/claude-code)