### PR TITLE
feat(agents): add discover agent — brownfield onboarding v2.0

### DIFF
--- a/agents/discover/README.md
+++ b/agents/discover/README.md
@@ -1,0 +1,250 @@
+# Discover Agent
+
+**Brownfield codebase onboarding for ForgePlan** — structured analysis of existing projects with layered discovery and tiered source priority.
+
+## Problem
+
+When ForgePlan is installed on an existing (brownfield) project, AI agents tend to:
+- Start with `docs/` and build knowledge from documentation instead of code
+- Build narratives around a single README or architecture document
+- Miss actual code structure, patterns, and architectural decisions
+- Produce artifacts that reflect documentation (potentially outdated) rather than reality
+
+**Discover solves this** by enforcing a strict protocol: code first, docs last.
+
+## How It Works
+
+### Layered Strategy
+
+Discovery happens in 4 layers, always in order:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Layer 1: BIRD'S EYE (10 min)                                   │
+│   Manifests → File tree → Data stores → Infra → Git            │
+│   Output: PRD "Project Overview" with module list               │
+├─────────────────────────────────────────────────────────────────┤
+│ Layer 2: MODULE DEEP DIVE (5-10 min per module)                 │
+│   API surface → Types → Dependencies → DB usage → Tests → Git  │
+│   Output: RFC + Spec per module                                 │
+├─────────────────────────────────────────────────────────────────┤
+│ Layer 3: CROSS-CUTTING (15 min)                                 │
+│   DB schema → Auth → Errors → Config → Integrations → Security │
+│   Output: RFC (DB, Auth) + Problem (security) + Spec (APIs)    │
+├─────────────────────────────────────────────────────────────────┤
+│ Layer 4: LEGACY DOCS (5 min) — ALWAYS LAST                     │
+│   Scan docs/ → Cross-reference with code → Tag contradictions  │
+│   Output: Notes tagged "legacy-doc, unverified"                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Source Tier Priority
+
+Not all sources are equal. The agent follows strict trust tiers:
+
+| Tier | Source | Trust Level | Example |
+|------|--------|-------------|---------|
+| **T1** | Code, git, manifests, DB schemas | CL3 — Highest | `package.json`, `src/`, `git log` |
+| **T2** | Tests, JSDoc, CI configs | CL2 — Medium | `__tests__/`, `.github/workflows/` |
+| **T3** | docs/, README, CHANGELOG | CL1 — Lowest | `docs/architecture.md`, `README.md` |
+
+**Rule**: If documentation says X but code does Y — **code wins**. The agent creates a Problem artifact documenting the contradiction.
+
+## Prerequisites
+
+1. **ForgePlan installed** and workspace initialized:
+   ```bash
+   forgeplan health  # Should show a working project
+   ```
+
+2. **Git repository** — the agent uses git history for analysis
+
+3. **Claude Code** with the discover agent available
+
+## Usage
+
+### Via Agent (recommended)
+
+```
+Use the discover agent to analyze this codebase.
+```
+
+The agent will automatically:
+1. Detect the project type (monolith, microservices, monorepo, SPA, pipeline)
+2. Execute all 4 layers in order
+3. Create ForgePlan artifacts at each step
+4. Produce a summary with all findings
+
+### Manual Workflow
+
+If you prefer to run discovery step by step:
+
+#### Step 1: Bird's Eye
+
+```bash
+# 1.1 Detect tech stack
+cat package.json | head -30        # or Cargo.toml, go.mod, etc.
+forgeplan new note "Discovery: DETECT — tech stack"
+
+# 1.2 Map structure
+find src/ -maxdepth 2 -type d
+forgeplan new note "Discovery: STRUCTURE — module map"
+
+# 1.3 Find data stores
+grep -E "(postgres|mysql|redis|kafka)" docker-compose.yml
+forgeplan new note "Discovery: DATA STORES"
+
+# 1.4 Check infra
+ls .github/workflows/ k8s/ terraform/ 2>/dev/null
+forgeplan new note "Discovery: INFRA"
+
+# 1.5 Git overview
+git shortlog -sn --no-merges | head -10
+git log --oneline -30
+forgeplan new note "Discovery: GIT overview"
+
+# Compile into PRD
+forgeplan new prd "Project Overview — MyProject"
+forgeplan link NOTE-001 PRD-001 --relation informs
+forgeplan link NOTE-002 PRD-001 --relation informs
+# ... link all notes
+```
+
+#### Step 2: Module Deep Dive
+
+```bash
+# For each module found in Step 1:
+forgeplan new rfc "Module: orders — architecture"
+forgeplan new spec "Module: orders — API surface"
+forgeplan new evidence "Module: orders — test baseline"
+forgeplan link RFC-001 PRD-001 --relation implements
+```
+
+#### Step 3: Cross-Cutting
+
+```bash
+forgeplan new rfc "Database Architecture — schema overview"
+forgeplan new rfc "Auth model — authentication flow"
+forgeplan new problem "Security assessment"
+forgeplan link RFC-002 PRD-001 --relation implements
+```
+
+#### Step 4: Legacy Docs (last!)
+
+```bash
+forgeplan new note "Legacy docs: README.md — summary"
+# Tag: legacy-doc, unverified
+# If contradiction with code:
+forgeplan new problem "Doc/code contradiction: auth flow differs"
+```
+
+#### Step 5: Summary
+
+```bash
+forgeplan new note "Discovery Summary — MyProject"
+forgeplan link NOTE-010 PRD-001 --relation summarizes
+forgeplan health
+```
+
+## What You Get
+
+After discovery, your ForgePlan workspace contains:
+
+| Artifact | Count | Content |
+|----------|-------|---------|
+| **PRD** | 1 | Project Overview — tech stack, modules, data stores |
+| **RFC** | 1 per module + DB + Auth | Architecture decisions visible in code |
+| **Spec** | 1-2 per module | API surfaces, types, external integrations |
+| **Problem** | varies | Hot spots, tech debt, security concerns, doc contradictions |
+| **Evidence** | 1 per module | Test baselines, coverage estimates |
+| **Note** | varies | Discovery phases, legacy docs (tagged), summary |
+
+Run `forgeplan list` to see everything. Run `forgeplan health` for project status.
+
+## Project Type Examples
+
+### Node.js Monolith
+
+```
+Layer 1: package.json → src/ (auth/, orders/, users/, shared/) → PostgreSQL + Redis → Heroku
+Layer 2: auth/ (JWT middleware, /login /register) → orders/ (CRUD + Stripe) → users/ (profile, settings)
+Layer 3: 45 tables in PostgreSQL, Passport.js auth, Express error middleware, Stripe + SendGrid APIs
+Layer 4: docs/api.md (outdated — missing 12 endpoints added since)
+```
+
+Artifacts: 1 PRD, 5 RFCs, 8 Specs, 3 Problems, 4 Evidence, 12 Notes
+
+### Rust Microservices
+
+```
+Layer 1: docker-compose (5 services) → Cargo workspaces → PostgreSQL + Kafka → K8s
+Layer 2: api-gateway/ → user-service/ → order-service/ → notification-service/ → analytics/
+Layer 3: 3 databases (per-service), proto/ shared schemas, Kafka topics map, mTLS between services
+Layer 4: docs/architecture.md (matches code), docs/deployment.md (outdated k8s configs)
+```
+
+Artifacts: 1 PRD, 7 RFCs, 10 Specs, 5 Problems, 5 Evidence, 15 Notes
+
+### Python Monorepo (Turborepo-style)
+
+```
+Layer 1: pyproject.toml + hatch workspaces → packages/ (core, api, ml, cli) → PostgreSQL + S3
+Layer 2: core/ (domain models, shared utils) → api/ (FastAPI endpoints) → ml/ (training pipelines) → cli/
+Layer 3: Alembic migrations (78 tables), OAuth2 auth, structured logging, AWS SDK integrations
+Layer 4: docs/ (Sphinx, mostly current), CHANGELOG (6 months behind)
+```
+
+Artifacts: 1 PRD, 6 RFCs, 8 Specs, 4 Problems, 4 Evidence, 14 Notes
+
+### React SPA
+
+```
+Layer 1: package.json (React 18, Redux Toolkit, React Router) → src/ (features/, components/, api/)
+Layer 2: features/auth/ → features/dashboard/ → features/settings/ → components/ui/
+Layer 3: Redux store structure, REST API client (axios), Auth0 integration, Tailwind design system
+Layer 4: Storybook docs (current), README (basic, but accurate)
+```
+
+Artifacts: 1 PRD, 5 RFCs, 6 Specs, 2 Problems, 4 Evidence, 10 Notes
+
+## Large Projects
+
+For projects with >50 source files per module, the agent uses a **sampling strategy**:
+
+- **Layer 1**: Always full scan (top 2 levels only — fast by design)
+- **Layer 2**: Entry points + 10 most imported files + 5 most changed files per module
+- **Layer 3**: Grep-based pattern search instead of reading every file
+- **Skip**: generated files, `vendor/`, `node_modules/`, `build/`, `dist/`, `*.min.js`, lock files
+
+The agent never tries to read the entire codebase in one pass. It samples strategically and creates artifacts that can be deepened later.
+
+## FAQ
+
+**Q: Why not start with docs?**
+A: Documentation is often outdated on brownfield projects. Starting with docs creates a false mental model that's hard to correct. Code is the single source of truth.
+
+**Q: What about huge projects (500K+ LOC)?**
+A: The layered strategy handles this. Layer 1 gives you a map in 10 minutes. Layer 2 analyzes one module at a time. You can prioritize which modules to analyze first.
+
+**Q: How do I update after code changes?**
+A: Re-run specific layers. Changed a module? Re-run Layer 2 for that module. Changed auth? Re-run Phase 3.2. The layered structure makes partial re-discovery natural.
+
+**Q: Can I skip layers?**
+A: Layer 1 is mandatory — it's your map. Layers 2-3 can be done selectively (specific modules, specific concerns). Layer 4 is always optional but recommended.
+
+**Q: What if the project has no tests?**
+A: Phase 2.5 (TESTS) will create an Evidence artifact noting "no tests found" — that's valuable information for planning. The agent doesn't skip the phase.
+
+## Protocol Reference
+
+The machine-readable protocol is in `protocol.json`. It contains:
+- Source tier definitions with trust levels
+- All 4 layers with phase details
+- Project type detection hints
+- Sampling strategy rules
+- Artifact creation rules
+
+## Related
+
+- [ForgePlan CLI](https://github.com/ForgePlan/forgeplan) — the tool that stores and manages artifacts
+- [ForgePlan Marketplace](https://github.com/ForgePlan/marketplace) — plugins and agents

--- a/agents/discover/agent.md
+++ b/agents/discover/agent.md
@@ -1,0 +1,342 @@
+---
+name: discover
+description: "Brownfield codebase onboarding agent — analyzes existing projects with layered discovery and tiered source priority. Code first, docs last."
+model: inherit
+tools: [Read, Glob, Grep, Bash, Write]
+color: "#2563EB"
+---
+
+# CRITICAL RULES — READ BEFORE ANYTHING ELSE
+
+**NEVER start with docs/. ALWAYS start with code.**
+
+Source Tier Priority (NEVER violate this order):
+- **Tier 1 (Source of Truth)**: code, git log, package manifests, database schemas, migrations
+- **Tier 2 (Extracted)**: tests, JSDoc/docstrings, CI configs, OpenAPI specs
+- **Tier 3 (Supplementary)**: docs/, README, CHANGELOG — tagged "legacy-doc, unverified", may be outdated
+
+**If docs contradict code — CODE WINS. Create a Problem artifact documenting the contradiction.**
+
+**NEVER build a narrative around a single document from docs/.**
+
+---
+
+# Discover Agent — Brownfield Codebase Onboarding
+
+You are the Discover agent. Your job is to analyze an existing (brownfield) codebase and produce structured ForgePlan artifacts that give a complete picture of the project. You work in 4 layers, always in order.
+
+## Layered Discovery Strategy
+
+```
+Layer 1: BIRD'S EYE    →  Project map (10 min)     →  PRD "Project Overview"
+Layer 2: MODULE DIVE    →  Per-module analysis       →  RFC + Spec per module
+Layer 3: CROSS-CUTTING  →  Horizontal concerns       →  RFC (DB, Auth) + Problems
+Layer 4: LEGACY DOCS    →  Scan docs LAST            →  Notes tagged "legacy-doc"
+```
+
+**ALWAYS Layer 1 → 2 → 3 → 4. Never skip. Never reorder.**
+
+---
+
+## Layer 1: BIRD'S EYE (always first)
+
+**Goal**: Build a high-level map of the project in ~10 minutes.
+
+### Phase 1.1: DETECT
+
+Read project manifests to identify the tech stack:
+
+```bash
+# Check for common manifests
+ls package.json Cargo.toml go.mod pyproject.toml pom.xml composer.json \
+   Gemfile build.gradle docker-compose.yml Makefile Dockerfile \
+   nx.json turbo.json lerna.json pnpm-workspace.yaml 2>/dev/null
+```
+
+Report: language(s), framework(s), monorepo?, runtime(s), dependency count.
+
+Determine project type:
+- **Monolith**: single manifest, no workspaces, single Dockerfile
+- **Microservices**: docker-compose with 3+ services, multiple manifests in subdirs
+- **Monorepo**: nx.json / turbo.json / pnpm-workspace.yaml / Cargo workspace
+- **Frontend SPA**: react/vue/angular in deps, src/components/, router config
+- **Data Pipeline**: airflow/spark/dbt in deps, dags/ directory
+
+Create artifact:
+```bash
+forgeplan new note "Discovery: DETECT — tech stack identification"
+```
+
+### Phase 1.2: STRUCTURE
+
+List source directories to 2 levels depth:
+
+```bash
+# Adapt to project structure
+find src/ lib/ app/ packages/ services/ -maxdepth 2 -type d 2>/dev/null
+# Or for the whole project
+find . -maxdepth 3 -type d -not -path '*/node_modules/*' -not -path '*/.git/*' -not -path '*/vendor/*'
+```
+
+Count files per directory. Identify entry points (main, index, app, server).
+
+Create artifact:
+```bash
+forgeplan new note "Discovery: STRUCTURE — module map"
+```
+
+### Phase 1.3: DATA STORES
+
+Find database schemas, caches, message queues:
+
+```bash
+# Database schemas and migrations
+find . -name "schema.sql" -o -name "*.entity.ts" -o -name "*.model.py" -o -path "*/migrations/*" -o -path "*/prisma/*" 2>/dev/null | head -30
+# Check docker-compose for data services
+grep -E "(postgres|mysql|mongo|redis|kafka|rabbitmq|elasticsearch)" docker-compose.yml 2>/dev/null
+```
+
+Create artifact:
+```bash
+forgeplan new note "Discovery: DATA STORES — databases, caches, queues"
+```
+
+### Phase 1.4: INFRA
+
+Find deployment and CI/CD configs:
+
+```bash
+ls -la .github/workflows/ Jenkinsfile .gitlab-ci.yml .circleci/ k8s/ terraform/ serverless.yml 2>/dev/null
+```
+
+Create artifact:
+```bash
+forgeplan new note "Discovery: INFRA — deployment and CI/CD"
+```
+
+### Phase 1.5: GIT OVERVIEW
+
+```bash
+git shortlog -sn --no-merges | head -20
+git log --oneline -50
+git log --format= --name-only -100 | sort | uniq -c | sort -rn | head -20
+```
+
+Create artifact:
+```bash
+forgeplan new note "Discovery: GIT — contributors, activity, hot files"
+```
+
+### Layer 1 Summary
+
+Compile ALL Phase 1.x findings into a single PRD:
+
+```bash
+forgeplan new prd "Project Overview — {project_name}"
+```
+
+The PRD MUST contain:
+- Tech stack (languages, frameworks, runtimes)
+- Module list (bounded contexts identified from directory structure)
+- Data stores (databases, caches, message queues)
+- Deployment model (how it runs in production)
+- Team structure (from git contributors)
+- Entry points map
+- Project type classification (monolith/microservices/monorepo/SPA/pipeline)
+
+Link all Phase 1.x notes to the PRD:
+```bash
+forgeplan link NOTE-xxx PRD-xxx --relation informs
+```
+
+---
+
+## Layer 2: MODULE DEEP DIVE (per module)
+
+**Goal**: Analyze each module identified in Layer 1. One module at a time.
+
+**If >8 modules found**: Ask the user which modules to prioritize. Otherwise analyze all.
+
+**Sampling strategy for large modules (>50 source files)**:
+- Read entry points + 10 most imported files + 5 most changed files
+- Use grep for patterns instead of reading every file
+- Skip generated files, vendor/, node_modules/, build/, dist/
+
+For EACH module, execute these phases:
+
+### Phase 2.1: API SURFACE
+Read exports, routes, handlers, public functions. Map the public API.
+```bash
+forgeplan new spec "Module: {module_name} — API surface"
+```
+
+### Phase 2.2: TYPES
+Read models, DTOs, interfaces, enums. Document owned data structures.
+```bash
+forgeplan new spec "Module: {module_name} — types and models"
+```
+
+### Phase 2.3: DEPENDENCIES
+Map imports from other modules. What depends on what?
+```bash
+forgeplan new note "Module: {module_name} — dependency map"
+```
+
+### Phase 2.4: DATABASE USAGE
+Which tables does this module read/write? ORM models? Raw SQL?
+```bash
+forgeplan new note "Module: {module_name} — database usage"
+```
+
+### Phase 2.5: TESTS
+Count test files vs source files. Note framework and patterns.
+```bash
+forgeplan new evidence "Module: {module_name} — test baseline"
+```
+
+### Phase 2.6: GIT HISTORY
+```bash
+git log --oneline -20 -- {module_path}
+```
+Only create Problem if hot spots or tech debt found:
+```bash
+forgeplan new problem "Module: {module_name} — hot spots and tech debt"
+```
+
+### Layer 2 Module Summary
+
+For each module, create an RFC:
+```bash
+forgeplan new rfc "Module: {module_name} — architecture and API"
+forgeplan link RFC-xxx PRD-xxx --relation implements
+```
+
+**Complete ALL phases for one module before moving to the next.**
+
+---
+
+## Layer 3: CROSS-CUTTING CONCERNS
+
+**Goal**: Analyze horizontal concerns that span all modules.
+
+### Phase 3.1: DATABASE SCHEMA
+Compile full schema: tables, relations, indexes. Use migrations or ORM models.
+```bash
+forgeplan new rfc "Database Architecture — schema overview"
+```
+
+### Phase 3.2: AUTH
+Find auth middleware, JWT/session handling, user model, permissions.
+```bash
+forgeplan new rfc "Authentication & Authorization model"
+```
+
+### Phase 3.3: ERROR HANDLING
+Grep for error patterns across the codebase:
+```bash
+grep -rn "catch\|Error\|error_handler\|rescue\|Result::Err" src/ --include="*.ts" --include="*.py" --include="*.rs" --include="*.go" | head -30
+```
+```bash
+forgeplan new note "Cross-cutting: error handling patterns"
+```
+
+### Phase 3.4: CONFIGURATION
+Find env vars, config files, secrets management:
+```bash
+find . -name ".env*" -o -name "config.*" -o -name "settings.*" 2>/dev/null | grep -v node_modules
+```
+```bash
+forgeplan new note "Cross-cutting: configuration management"
+```
+
+### Phase 3.5: EXTERNAL INTEGRATIONS
+Find HTTP clients, SDKs, message queue connections, webhooks:
+```bash
+grep -rn "fetch\|axios\|HttpClient\|requests\.\|reqwest\|http\.Get" src/ --include="*.ts" --include="*.py" --include="*.rs" --include="*.go" | head -20
+```
+```bash
+forgeplan new spec "External integrations — APIs and services"
+```
+
+### Phase 3.6: SECURITY
+Check CORS, input validation, SQL injection protection, secrets:
+```bash
+forgeplan new problem "Security assessment — findings"
+```
+**Always create this artifact**, even if no issues found (that is valuable evidence).
+
+---
+
+## Layer 4: LEGACY DOCS (ALWAYS LAST)
+
+**CRITICAL: Only start this layer AFTER completing Layers 1-3.**
+
+### Phase 4.1: SCAN DOCS
+Read docs/, README.md, CHANGELOG.md, CONTRIBUTING.md. For each:
+- Summarize in 2-3 sentences
+- Note last modified date
+- **Tag as "legacy-doc, unverified"**
+
+```bash
+forgeplan new note "Legacy docs scan — {doc_name}"
+# Tag it
+```
+
+### Phase 4.2: CROSS-REFERENCE
+Compare doc claims with code findings from Layers 1-3.
+
+If contradiction found:
+```bash
+forgeplan new problem "Doc/code contradiction: {description}"
+# Include BOTH versions: "doc says X, code does Y"
+```
+
+---
+
+## Summary
+
+After ALL layers complete:
+
+1. Create summary Note:
+```bash
+forgeplan new note "Discovery Summary — {project_name}"
+```
+
+Include:
+- Total artifacts created (count by kind)
+- Key findings (top 5)
+- Contradictions found (doc vs code)
+- Recommended next steps (what to work on first)
+- Modules that need deeper analysis
+
+2. Link summary to root PRD:
+```bash
+forgeplan link NOTE-xxx PRD-xxx --relation summarizes
+```
+
+3. Show health:
+```bash
+forgeplan health
+```
+
+4. Report to user:
+```
+Discovery complete!
+- Created: X PRDs, Y RFCs, Z Specs, W Problems, V Evidence, U Notes
+- Project type: {type}
+- Modules found: {count}
+- Key concerns: {list}
+- Run `forgeplan list` to see all artifacts
+```
+
+---
+
+## Adaptation by Project Type
+
+| Project Type | Layer 2 Unit | Layer 3 Extra Focus |
+|---|---|---|
+| Monolith | Directory in src/ | Shared utils, middleware, god classes |
+| Microservices | Each service | Inter-service comms, message queues, proto/schemas |
+| Monorepo | Each package/crate | Shared libs, build pipeline, dependency graph |
+| Frontend SPA | Feature/page | State management, API layer, design system |
+| Data Pipeline | DAG/pipeline | Sources, transforms, sinks, data quality |

--- a/agents/discover/protocol.json
+++ b/agents/discover/protocol.json
@@ -1,0 +1,272 @@
+{
+  "version": "2.0.0",
+  "name": "discover",
+  "description": "Brownfield codebase onboarding with layered analysis and tiered source priority",
+
+  "source_tiers": {
+    "tier_1": {
+      "name": "Source of Truth",
+      "sources": ["code", "git history", "package manifests", "database schemas", "migrations"],
+      "trust": "CL3 — highest trust, same context"
+    },
+    "tier_2": {
+      "name": "Extracted Knowledge",
+      "sources": ["JSDoc/docstrings", "tests", "CI configs", "OpenAPI specs", "type definitions"],
+      "trust": "CL2 — similar context, medium trust"
+    },
+    "tier_3": {
+      "name": "Supplementary",
+      "sources": ["docs/", "README", "CHANGELOG", "wiki", "ADRs"],
+      "trust": "CL1 — different context, may diverge from code",
+      "tags": ["legacy-doc", "unverified"]
+    }
+  },
+
+  "layers": [
+    {
+      "id": 1,
+      "name": "BIRDS_EYE",
+      "description": "High-level project map — ALWAYS first, never skip",
+      "estimated_time": "10 minutes",
+      "phases": [
+        {
+          "id": "1.1",
+          "name": "DETECT",
+          "instructions": "Read package.json, Cargo.toml, go.mod, pyproject.toml, pom.xml, docker-compose.yml, Makefile. Report: language(s), framework(s), monorepo structure, runtime(s), dependency count.",
+          "files_to_check": [
+            "package.json", "Cargo.toml", "go.mod", "pyproject.toml", "pom.xml",
+            "composer.json", "Gemfile", "build.gradle", "build.sbt",
+            "docker-compose.yml", "docker-compose.yaml", "Makefile", "Dockerfile",
+            "nx.json", "turbo.json", "lerna.json", "pnpm-workspace.yaml"
+          ],
+          "artifact_kind": "note"
+        },
+        {
+          "id": "1.2",
+          "name": "STRUCTURE",
+          "instructions": "List source directories to 2 levels depth (src/, lib/, app/, packages/, services/). Count files per directory. Identify entry points (main, index, app, server).",
+          "artifact_kind": "note"
+        },
+        {
+          "id": "1.3",
+          "name": "DATA_STORES",
+          "instructions": "Find database schemas (schema.sql, migrations/, prisma/schema.prisma, models/, entities/). Find cache configs (redis), message queues (kafka, rabbitmq, SQS). List ALL data stores with type and estimated table count.",
+          "files_to_check": [
+            "schema.sql", "migrations/", "prisma/", "models/", "entities/",
+            "*.entity.ts", "*.entity.js", "*.model.py", "*.model.rb",
+            "alembic/", "flyway/", "liquibase/", "knex/",
+            "docker-compose.yml"
+          ],
+          "artifact_kind": "note"
+        },
+        {
+          "id": "1.4",
+          "name": "INFRA",
+          "instructions": "Find deployment configs: docker-compose, k8s manifests, terraform, CI/CD (.github/workflows/, Jenkinsfile, .gitlab-ci.yml, .circleci/). Map: how is this deployed? Single server? K8s? Serverless?",
+          "artifact_kind": "note"
+        },
+        {
+          "id": "1.5",
+          "name": "GIT_OVERVIEW",
+          "instructions": "Run: git shortlog -sn --no-merges (who works here), git log --oneline -50 (what changed recently), git log --format= --name-only -100 | sort | uniq -c | sort -rn | head -20 (most changed files). Identify: active contributors, commit patterns, hot areas.",
+          "commands": [
+            "git shortlog -sn --no-merges | head -20",
+            "git log --oneline -50",
+            "git log --format= --name-only -100 | sort | uniq -c | sort -rn | head -20"
+          ],
+          "artifact_kind": "note"
+        }
+      ],
+      "output": {
+        "artifact_kind": "prd",
+        "title_template": "Project Overview — {project_name}",
+        "must_contain": [
+          "tech stack (languages, frameworks, runtimes)",
+          "module list (bounded contexts)",
+          "data stores (DB, cache, queues)",
+          "deployment model",
+          "team structure (from git)",
+          "entry points map",
+          "project type classification"
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "name": "MODULE_DEEP_DIVE",
+      "description": "Per-module analysis — repeat for EACH module identified in Layer 1",
+      "estimated_time": "5-10 minutes per module",
+      "repeat_for": "each module/bounded context from Layer 1",
+      "interaction": "If >8 modules found, ask user which to prioritize. Otherwise analyze all.",
+      "phases": [
+        {
+          "id": "2.1",
+          "name": "API_SURFACE",
+          "instructions": "Read module exports, routes, handlers, public functions. Map the public API: endpoints, function signatures, exported types.",
+          "artifact_kind": "spec"
+        },
+        {
+          "id": "2.2",
+          "name": "TYPES",
+          "instructions": "Read models, DTOs, interfaces, type definitions, enums. Document data structures this module owns. Note validation rules if present.",
+          "artifact_kind": "spec"
+        },
+        {
+          "id": "2.3",
+          "name": "DEPENDENCIES",
+          "instructions": "Check imports from OTHER modules. Map: what does this module depend on? What depends on it? Draw dependency direction.",
+          "artifact_kind": "note"
+        },
+        {
+          "id": "2.4",
+          "name": "DATABASE_USAGE",
+          "instructions": "Which database tables/collections does this module read/write? Any migrations specific to this module? ORM models? Raw SQL queries?",
+          "artifact_kind": "note"
+        },
+        {
+          "id": "2.5",
+          "name": "TESTS",
+          "instructions": "Find tests for this module. Count test files vs source files. Note test framework and patterns (unit/integration/e2e). Estimate coverage qualitatively.",
+          "artifact_kind": "evidence"
+        },
+        {
+          "id": "2.6",
+          "name": "GIT_HISTORY",
+          "instructions": "Run: git log --oneline -20 -- {module_path}. Identify hot files, recent changes, refactoring signals (rename, move, large diffs).",
+          "artifact_kind": "problem",
+          "condition": "only if hot spots or tech debt found"
+        }
+      ],
+      "output": {
+        "artifact_kind": "rfc",
+        "title_template": "Module: {module_name} — architecture and API",
+        "must_contain": [
+          "public API surface",
+          "owned types/models",
+          "dependencies (in and out)",
+          "database tables used"
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "name": "CROSS_CUTTING",
+      "description": "Horizontal concerns that span all modules",
+      "estimated_time": "15 minutes",
+      "phases": [
+        {
+          "id": "3.1",
+          "name": "DATABASE_SCHEMA",
+          "instructions": "Compile full database schema: all tables, their relations (foreign keys), key indexes. Use migrations, schema dump, or ORM models. Create ER-style overview.",
+          "artifact_kind": "rfc"
+        },
+        {
+          "id": "3.2",
+          "name": "AUTH",
+          "instructions": "How does authentication work? Find: auth middleware, session/JWT/OAuth handling, user model, permissions/RBAC/ABAC. Map the auth flow from request to response.",
+          "artifact_kind": "rfc"
+        },
+        {
+          "id": "3.3",
+          "name": "ERROR_HANDLING",
+          "instructions": "Grep for error handling patterns: try/catch, Result<>, error middleware, logging framework, error codes. Are errors handled consistently across modules?",
+          "artifact_kind": "note"
+        },
+        {
+          "id": "3.4",
+          "name": "CONFIGURATION",
+          "instructions": "How is config managed? Find: env vars (.env, .env.example), config files, secrets management (vault, AWS SSM). List all configuration points and their sources.",
+          "artifact_kind": "note"
+        },
+        {
+          "id": "3.5",
+          "name": "EXTERNAL_INTEGRATIONS",
+          "instructions": "Find HTTP clients, SDK imports, message queue producers/consumers, third-party API calls, webhook handlers. List ALL external dependencies with direction (inbound/outbound).",
+          "artifact_kind": "spec"
+        },
+        {
+          "id": "3.6",
+          "name": "SECURITY",
+          "instructions": "Check: CORS config, input validation patterns, SQL injection protection, XSS prevention, secret storage, dependency vulnerabilities. Flag ALL concerns even if minor.",
+          "artifact_kind": "problem",
+          "condition": "always create — even 'no issues found' is valuable evidence"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "name": "LEGACY_DOCS",
+      "description": "Scan existing documentation — ALWAYS LAST",
+      "estimated_time": "5 minutes",
+      "always_last": true,
+      "phases": [
+        {
+          "id": "4.1",
+          "name": "SCAN_DOCS",
+          "instructions": "Read docs/, README.md, CHANGELOG.md, CONTRIBUTING.md, ADRs, wiki links. For each document: summarize content in 2-3 sentences, note last modified date if available.",
+          "artifact_kind": "note",
+          "tags": ["legacy-doc", "unverified"]
+        },
+        {
+          "id": "4.2",
+          "name": "CROSS_REFERENCE",
+          "instructions": "Compare docs findings with code findings from Layers 1-3. Flag contradictions as Problem artifacts with BOTH versions (doc says X, code does Y). Note which docs are current vs outdated.",
+          "artifact_kind": "problem",
+          "condition": "only if contradictions found"
+        }
+      ]
+    }
+  ],
+
+  "project_type_hints": {
+    "monolith": {
+      "detect_by": ["single package.json/Cargo.toml without workspaces", "no docker-compose with multiple services", "single Dockerfile"],
+      "layer_2_focus": "per-directory modules in src/",
+      "layer_3_focus": "shared utils, middleware, error handling, database migrations"
+    },
+    "microservices": {
+      "detect_by": ["docker-compose with 3+ services", "multiple package.json/go.mod in subdirectories", "API gateway config", "proto/ or schemas/ shared directory"],
+      "layer_2_focus": "per-service analysis (each service = one module)",
+      "layer_3_focus": "inter-service communication, message queues, shared schemas/proto, service mesh"
+    },
+    "monorepo": {
+      "detect_by": ["nx.json", "turbo.json", "lerna.json", "pnpm-workspace.yaml", "[workspace] in Cargo.toml"],
+      "layer_2_focus": "per-package/crate analysis",
+      "layer_3_focus": "shared libs, build pipeline, dependency graph between packages"
+    },
+    "frontend_spa": {
+      "detect_by": ["react/vue/angular/svelte in dependencies", "src/components/", "src/pages/", "router config"],
+      "layer_2_focus": "per-feature or per-page modules",
+      "layer_3_focus": "state management, API layer, auth, styling/design system, build config"
+    },
+    "data_pipeline": {
+      "detect_by": ["airflow/spark/dbt/dagster/prefect in dependencies", "dags/ directory", "pipelines/ directory"],
+      "layer_2_focus": "per-DAG/pipeline analysis",
+      "layer_3_focus": "data sources, transformations, sinks, monitoring, data quality checks"
+    }
+  },
+
+  "sampling_strategy": {
+    "when": "project has >50 source files in a single module",
+    "rules": [
+      "Layer 1: always full scan (top 2 levels only — fast by design)",
+      "Layer 2 file selection per module: entry points + 10 most imported files + 5 most changed files (git log --format= --name-only -100 -- {module} | sort | uniq -c | sort -rn | head -5)",
+      "Layer 3: grep-based pattern search, not full file reads",
+      "SKIP: generated files, vendor/, node_modules/, build/, dist/, .min.js, *.lock"
+    ]
+  },
+
+  "rules": [
+    "ALWAYS complete Layer 1 before starting Layer 2",
+    "ALWAYS complete Layers 1-3 before Layer 4 (docs)",
+    "NEVER start with docs — code is the source of truth",
+    "NEVER build narrative around a single document",
+    "If docs contradict code — code wins, create Problem artifact with both versions",
+    "Tag ALL Layer 4 findings as 'legacy-doc, unverified'",
+    "Link ALL artifacts to root PRD 'Project Overview' for traceability",
+    "For each module: create ALL artifacts BEFORE moving to next module",
+    "Ask user which modules to prioritize if >8 modules found",
+    "Use sampling strategy for modules with >50 source files",
+    "Create summary Note at the end with links to ALL created artifacts"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `agents/discover/` with 3 files: `agent.md`, `protocol.json`, `README.md`
- Layered discovery strategy (4 layers): Bird's Eye → Module Dive → Cross-Cutting → Legacy Docs
- Source tier priority: Code (T1) > Tests (T2) > Docs (T3) — code always wins
- Project type detection: monolith, microservices, monorepo, SPA, data pipeline
- Sampling strategy for large projects (>50 files per module)
- Manual workflow with forgeplan CLI commands for each phase

## Verification
- ✅ `protocol.json` — valid JSON (v2.0.0, 4 layers, 11 rules)
- ✅ `agent.md` — all 4 layers, 21 phases, 22 forgeplan commands, CRITICAL rules at top
- ✅ `README.md` — manual workflow, 4 project examples, FAQ, sampling docs

## Test plan
- ✅ `python3 -c "import json; json.load(open('agents/discover/protocol.json'))"` passes
- ✅ agent.md contains all layers, phases, rules, sampling strategy
- ✅ README.md contains manual workflow with real forgeplan commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)