### PR TITLE
feat(agents): discover v3.0 — multi-pass deepening + synthesis

### DIFF
--- a/agents/discover/README.md
+++ b/agents/discover/README.md
@@ -1,6 +1,6 @@
 # Discover Agent
 
-**Brownfield codebase onboarding for ForgePlan** — structured analysis of existing projects with layered discovery and tiered source priority.
+**Brownfield codebase onboarding for ForgePlan** — structured analysis of existing projects with multi-pass discovery, team-based deepening, and tiered source priority.
 
 ## Problem
 
@@ -9,33 +9,68 @@ When ForgePlan is installed on an existing (brownfield) project, AI agents tend 
 - Build narratives around a single README or architecture document
 - Miss actual code structure, patterns, and architectural decisions
 - Produce artifacts that reflect documentation (potentially outdated) rather than reality
+- Fail to scale for large projects (500K+ LOC) — try to read everything in one pass
 
-**Discover solves this** by enforcing a strict protocol: code first, docs last.
+**Discover solves this** by enforcing a strict protocol: code first, docs last, multi-pass for depth.
 
 ## How It Works
 
-### Layered Strategy
-
-Discovery happens in 4 layers, always in order:
+### Three Modes
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│ Layer 1: BIRD'S EYE (10 min)                                   │
-│   Manifests → File tree → Data stores → Infra → Git            │
-│   Output: PRD "Project Overview" with module list               │
-├─────────────────────────────────────────────────────────────────┤
-│ Layer 2: MODULE DEEP DIVE (5-10 min per module)                 │
-│   API surface → Types → Dependencies → DB usage → Tests → Git  │
-│   Output: RFC + Spec per module                                 │
-├─────────────────────────────────────────────────────────────────┤
-│ Layer 3: CROSS-CUTTING (15 min)                                 │
-│   DB schema → Auth → Errors → Config → Integrations → Security │
-│   Output: RFC (DB, Auth) + Problem (security) + Spec (APIs)    │
-├─────────────────────────────────────────────────────────────────┤
-│ Layer 4: LEGACY DOCS (5 min) — ALWAYS LAST                     │
-│   Scan docs/ → Cross-reference with code → Tag contradictions  │
-│   Output: Notes tagged "legacy-doc, unverified"                 │
-└─────────────────────────────────────────────────────────────────┘
+/discover           → Quick scan (~15-30 min, single agent)
+/discover --deep    → Deep analysis (~1-2 hours, team of agents)
+/discover --full    → Complete knowledge base (~2-4 hours, synthesis + gaps)
+```
+
+| Mode | Best For | What Happens |
+|------|----------|-------------|
+| **default** | Projects <100K LOC | Single agent, 4 layers sequentially |
+| **--deep** | Projects 100K-2M LOC | Orchestrator + team: Layer 1 self, Layers 2-3 parallel agents, then deepen each artifact |
+| **--full** | 2M+ LOC or critical systems | Deep + cross-reference synthesis, gap analysis, impact mapping |
+
+### Multi-Pass Strategy
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ PASS 1: DISCOVERY (all modes)                                       │
+│                                                                     │
+│  Layer 1: BIRD'S EYE (10 min)                                      │
+│    Manifests → File tree → Data stores → Infra → Git               │
+│    Output: PRD "Project Overview" with module list                  │
+│                                                                     │
+│  Layer 2: MODULE DEEP DIVE (5-10 min per module)                    │
+│    API surface → Types → Dependencies → DB usage → Tests → Git     │
+│    Output: RFC + Spec per module                                    │
+│                                                                     │
+│  Layer 3: CROSS-CUTTING (15 min)                                    │
+│    DB schema → Auth → Errors → Config → Integrations → Security    │
+│    Output: RFC (DB, Auth) + Problem (security) + Spec (APIs)       │
+│                                                                     │
+│  Layer 4: LEGACY DOCS (5 min — ALWAYS LAST, can be skipped)        │
+│    Scan docs/ → Cross-reference with code → Tag contradictions     │
+│    Output: Notes tagged [legacy-doc]                                │
+├─────────────────────────────────────────────────────────────────────┤
+│ PASS 2: DEEPENING (--deep and --full)                               │
+│                                                                     │
+│  For EACH major artifact from Pass 1, spawn a sub-agent:           │
+│    RFC  → Read ALL files in module, document every function         │
+│    Spec → Read all handlers, complete request/response schemas      │
+│    Problem → git blame, trace root cause, propose fix               │
+│    Evidence → Read all tests, count assertions, map coverage        │
+│                                                                     │
+│  Output: Updated artifacts with full details + child Notes          │
+├─────────────────────────────────────────────────────────────────────┤
+│ PASS 3: SYNTHESIS (--full only)                                     │
+│                                                                     │
+│  3.1 Dependency graph — who calls whom, circular deps               │
+│  3.2 Gap analysis — undocumented modules, missing specs             │
+│  3.3 Contradiction check — cross-reference all artifacts            │
+│  3.4 Impact analysis — blast radius per module, risk ranking        │
+│  3.5 Health check — forgeplan health, completeness score            │
+│                                                                     │
+│  Output: Epic "Project Knowledge Base" with full system map         │
+└─────────────────────────────────────────────────────────────────────┘
 ```
 
 ### Source Tier Priority
@@ -45,8 +80,8 @@ Not all sources are equal. The agent follows strict trust tiers:
 | Tier | Source | Trust Level | Example |
 |------|--------|-------------|---------|
 | **T1** | Code, git, manifests, DB schemas | CL3 — Highest | `package.json`, `src/`, `git log` |
-| **T2** | Tests, JSDoc, CI configs | CL2 — Medium | `__tests__/`, `.github/workflows/` |
-| **T3** | docs/, README, CHANGELOG | CL1 — Lowest | `docs/architecture.md`, `README.md` |
+| **T2** | Tests, JSDoc, CI configs, type definitions | CL2 — Medium | `__tests__/`, `.github/workflows/` |
+| **T3** | docs/, README, CHANGELOG, wiki, ADRs | CL1 — Lowest | `docs/architecture.md`, `README.md` |
 
 **Rule**: If documentation says X but code does Y — **code wins**. The agent creates a Problem artifact documenting the contradiction.
 
@@ -66,183 +101,200 @@ Not all sources are equal. The agent follows strict trust tiers:
 ### Via Agent (recommended)
 
 ```
+# Quick scan (small project)
 Use the discover agent to analyze this codebase.
-```
 
-The agent will automatically:
-1. Detect the project type (monolith, microservices, monorepo, SPA, pipeline)
-2. Execute all 4 layers in order
-3. Create ForgePlan artifacts at each step
-4. Produce a summary with all findings
+# Deep analysis (large project)
+Use the discover agent with --deep mode to analyze this codebase.
+
+# Full knowledge base (enterprise/critical)
+Use the discover agent with --full mode to analyze this codebase.
+```
 
 ### Manual Workflow
 
 If you prefer to run discovery step by step:
 
-#### Step 1: Bird's Eye
+#### Pass 1: Discovery
 
 ```bash
-# 1.1 Detect tech stack
-cat package.json | head -30        # or Cargo.toml, go.mod, etc.
+# Layer 1: Bird's Eye
+cat package.json | head -30
 forgeplan new note "Discovery: DETECT — tech stack"
 
-# 1.2 Map structure
 find src/ -maxdepth 2 -type d
 forgeplan new note "Discovery: STRUCTURE — module map"
 
-# 1.3 Find data stores
 grep -E "(postgres|mysql|redis|kafka)" docker-compose.yml
 forgeplan new note "Discovery: DATA STORES"
 
-# 1.4 Check infra
 ls .github/workflows/ k8s/ terraform/ 2>/dev/null
 forgeplan new note "Discovery: INFRA"
 
-# 1.5 Git overview
 git shortlog -sn --no-merges | head -10
-git log --oneline -30
 forgeplan new note "Discovery: GIT overview"
 
-# Compile into PRD
 forgeplan new prd "Project Overview — MyProject"
 forgeplan link NOTE-001 PRD-001 --relation informs
-forgeplan link NOTE-002 PRD-001 --relation informs
-# ... link all notes
-```
 
-#### Step 2: Module Deep Dive
-
-```bash
-# For each module found in Step 1:
+# Layer 2: Module Deep Dive (repeat per module)
 forgeplan new rfc "Module: orders — architecture"
 forgeplan new spec "Module: orders — API surface"
 forgeplan new evidence "Module: orders — test baseline"
 forgeplan link RFC-001 PRD-001 --relation implements
-```
 
-#### Step 3: Cross-Cutting
-
-```bash
+# Layer 3: Cross-Cutting
 forgeplan new rfc "Database Architecture — schema overview"
 forgeplan new rfc "Auth model — authentication flow"
 forgeplan new problem "Security assessment"
-forgeplan link RFC-002 PRD-001 --relation implements
-```
 
-#### Step 4: Legacy Docs (last!)
-
-```bash
-forgeplan new note "Legacy docs: README.md — summary"
-# Tag: legacy-doc, unverified
-# If contradiction with code:
+# Layer 4: Legacy Docs (LAST!)
+forgeplan new note "[legacy-doc] README.md — summary"
 forgeplan new problem "Doc/code contradiction: auth flow differs"
 ```
 
-#### Step 5: Summary
+#### Pass 2: Deepening (optional)
 
 ```bash
-forgeplan new note "Discovery Summary — MyProject"
-forgeplan link NOTE-010 PRD-001 --relation summarizes
+# For each RFC from Pass 1:
+# Read ALL files in module, then update existing artifact
+forgeplan update RFC-001 --body "... detailed findings ..."
+forgeplan new note "Deepening: orders — hidden dependency on payments module"
+forgeplan link NOTE-012 RFC-001 --relation deepens
+```
+
+#### Pass 3: Synthesis (optional)
+
+```bash
+forgeplan new note "Synthesis: dependency graph"
+forgeplan new problem "Synthesis: 3 knowledge gaps found"
+forgeplan new note "Synthesis: impact analysis"
+forgeplan new epic "Project Knowledge Base — MyProject"
 forgeplan health
 ```
 
 ## What You Get
 
-After discovery, your ForgePlan workspace contains:
+### Per Mode
 
-| Artifact | Count | Content |
-|----------|-------|---------|
-| **PRD** | 1 | Project Overview — tech stack, modules, data stores |
-| **RFC** | 1 per module + DB + Auth | Architecture decisions visible in code |
-| **Spec** | 1-2 per module | API surfaces, types, external integrations |
-| **Problem** | varies | Hot spots, tech debt, security concerns, doc contradictions |
-| **Evidence** | 1 per module | Test baselines, coverage estimates |
-| **Note** | varies | Discovery phases, legacy docs (tagged), summary |
+| Artifact | default | --deep | --full |
+|----------|---------|--------|--------|
+| PRD (Project Overview) | 1 | 1 | 1 |
+| RFC (per module + DB + Auth) | 3-10 | 3-10 (deepened) | 3-10 (deepened) |
+| Spec (API surfaces) | 2-8 | 2-8 (deepened) | 2-8 (deepened) |
+| Problem (tech debt, security) | 1-5 | 3-10 | 5-15 + gaps |
+| Evidence (test baselines) | 1-5 | 1-5 (deepened) | 1-5 (deepened) |
+| Note (phases, summaries) | 8-15 | 12-25 | 15-35 |
+| Epic (Knowledge Base) | — | — | 1 |
+| **Total artifacts** | **~20** | **~40** | **~60+** |
 
-Run `forgeplan list` to see everything. Run `forgeplan health` for project status.
+### By Project Size
+
+| Size | LOC | Recommended Mode | Modules | Time | Artifacts |
+|------|-----|-----------------|---------|------|-----------|
+| Small | <50K | default | 3-5 | 15 min | ~15 |
+| Medium | 50-500K | default or --deep | 5-15 | 30-60 min | ~25-40 |
+| Large | 500K-2M | --deep | 15-50 | 1-2 hours | ~40-60 |
+| Mega | 2M+ | --full | 50+ (sampled) | 2-4 hours | ~60+ |
 
 ## Project Type Examples
 
-### Node.js Monolith
+### Node.js Monolith (~200K LOC)
 
 ```
-Layer 1: package.json → src/ (auth/, orders/, users/, shared/) → PostgreSQL + Redis → Heroku
-Layer 2: auth/ (JWT middleware, /login /register) → orders/ (CRUD + Stripe) → users/ (profile, settings)
-Layer 3: 45 tables in PostgreSQL, Passport.js auth, Express error middleware, Stripe + SendGrid APIs
-Layer 4: docs/api.md (outdated — missing 12 endpoints added since)
+Pass 1: package.json → src/ (auth/, orders/, users/, shared/) → PostgreSQL + Redis → Heroku
+  Layer 2: auth/ (JWT middleware) → orders/ (CRUD + Stripe) → users/ (profile, settings)
+  Layer 3: 45 tables, Passport.js auth, Express error middleware, Stripe + SendGrid
+  Layer 4: docs/api.md (outdated — missing 12 endpoints)
+
+Pass 2 (--deep): Each module agent reads ALL files
+  → Found: orders/ has hidden dependency on users/ via shared Redis cache
+  → Found: auth/ JWT secret rotation is broken (hardcoded expiry)
+  → Updated all RFCs with full function-level documentation
+
+Pass 3 (--full):
+  → Gap: payments/ module has no RFC (discovered in Pass 2)
+  → Contradiction: docs say "microservices" but it's a monolith
+  → Impact: orders/ breaking cascades to 3 other modules
 ```
 
-Artifacts: 1 PRD, 5 RFCs, 8 Specs, 3 Problems, 4 Evidence, 12 Notes
-
-### Rust Microservices
+### Rust Microservices (~1M LOC)
 
 ```
-Layer 1: docker-compose (5 services) → Cargo workspaces → PostgreSQL + Kafka → K8s
-Layer 2: api-gateway/ → user-service/ → order-service/ → notification-service/ → analytics/
-Layer 3: 3 databases (per-service), proto/ shared schemas, Kafka topics map, mTLS between services
-Layer 4: docs/architecture.md (matches code), docs/deployment.md (outdated k8s configs)
+Pass 1: docker-compose (5 services) → Cargo workspaces → PostgreSQL + Kafka → K8s
+  Layer 2: api-gateway/ → user-service/ → order-service/ → notification/ → analytics/
+  Layer 3: 3 databases (per-service), proto/ shared schemas, Kafka topics, mTLS
+
+Pass 2 (--deep): Per-service agents find internal architecture
+  → order-service/ uses CQRS with event sourcing (not visible from entry point)
+  → notification/ has 3 undocumented webhook handlers
+  → analytics/ has no tests at all (EVID updated: 0% coverage)
+
+Pass 3 (--full):
+  → Dependency graph reveals notification/ is a single point of failure
+  → Gap: no RFC for shared proto/ schemas
+  → Risk ranking: analytics/ (no tests + 5 consumers) = highest risk
 ```
 
-Artifacts: 1 PRD, 7 RFCs, 10 Specs, 5 Problems, 5 Evidence, 15 Notes
-
-### Python Monorepo (Turborepo-style)
+### Python Data Pipeline (~500K LOC)
 
 ```
-Layer 1: pyproject.toml + hatch workspaces → packages/ (core, api, ml, cli) → PostgreSQL + S3
-Layer 2: core/ (domain models, shared utils) → api/ (FastAPI endpoints) → ml/ (training pipelines) → cli/
-Layer 3: Alembic migrations (78 tables), OAuth2 auth, structured logging, AWS SDK integrations
-Layer 4: docs/ (Sphinx, mostly current), CHANGELOG (6 months behind)
+Pass 1: pyproject.toml + Airflow → dags/ (12 DAGs) → Snowflake + S3 + Kafka
+  Layer 2: etl-ingestion/ → etl-transform/ → ml-training/ → reporting/
+  Layer 3: Alembic migrations (78 tables), OAuth2, structured logging, AWS SDK
+
+Pass 2 (--deep): Per-pipeline agents trace data flow
+  → etl-transform/ has 200+ SQL transformations, 15 are duplicates
+  → ml-training/ depends on a deprecated sklearn API
+  → Data quality checks exist but only cover 30% of tables
 ```
 
-Artifacts: 1 PRD, 6 RFCs, 8 Specs, 4 Problems, 4 Evidence, 14 Notes
+## Large Projects (>50 source files per module)
 
-### React SPA
-
-```
-Layer 1: package.json (React 18, Redux Toolkit, React Router) → src/ (features/, components/, api/)
-Layer 2: features/auth/ → features/dashboard/ → features/settings/ → components/ui/
-Layer 3: Redux store structure, REST API client (axios), Auth0 integration, Tailwind design system
-Layer 4: Storybook docs (current), README (basic, but accurate)
-```
-
-Artifacts: 1 PRD, 5 RFCs, 6 Specs, 2 Problems, 4 Evidence, 10 Notes
-
-## Large Projects
-
-For projects with >50 source files per module, the agent uses a **sampling strategy**:
+The agent uses a **sampling strategy** in Pass 1:
 
 - **Layer 1**: Always full scan (top 2 levels only — fast by design)
-- **Layer 2**: Entry points + 10 most imported files + 5 most changed files per module
+- **Layer 2**: Entry points + 10 most imported + 5 most changed files per module
 - **Layer 3**: Grep-based pattern search instead of reading every file
-- **Skip**: generated files, `vendor/`, `node_modules/`, `build/`, `dist/`, `*.min.js`, lock files
+- **Skip**: generated files, `vendor/`, `node_modules/`, `build/`, `dist/`, `*.lock`
 
-The agent never tries to read the entire codebase in one pass. It samples strategically and creates artifacts that can be deepened later.
+**Pass 2 is where depth happens** — deepening agents read ALL files in their assigned module scope. This is intentional: Pass 1 builds the map fast via sampling, Pass 2 fills in the details where it matters.
 
 ## FAQ
 
 **Q: Why not start with docs?**
-A: Documentation is often outdated on brownfield projects. Starting with docs creates a false mental model that's hard to correct. Code is the single source of truth.
+A: Documentation is often outdated on brownfield projects. Starting with docs creates a false mental model that's hard to correct. Code is the single source of truth — docs are verified against code, not the other way around.
 
-**Q: What about huge projects (500K+ LOC)?**
-A: The layered strategy handles this. Layer 1 gives you a map in 10 minutes. Layer 2 analyzes one module at a time. You can prioritize which modules to analyze first.
+**Q: What about huge projects (2M+ LOC)?**
+A: Use `--full` mode. Layer 1 gives you a map in 10 minutes. Layer 2 samples strategically (entry points + hot files). Pass 2 deepens the important modules. Pass 3 finds the gaps. The agent never tries to read everything — it samples, deepens, then synthesizes.
+
+**Q: When should I use --deep vs --full?**
+A: Use `--deep` when you need thorough module-level documentation. Use `--full` when you also need cross-system analysis: dependency graphs, gap detection, impact analysis, risk ranking. `--full` is for projects where you're planning a major refactor or migration.
 
 **Q: How do I update after code changes?**
-A: Re-run specific layers. Changed a module? Re-run Layer 2 for that module. Changed auth? Re-run Phase 3.2. The layered structure makes partial re-discovery natural.
+A: Re-run specific passes. Changed a module? Re-run Pass 2 deepening for that module's RFC. Changed auth? Re-run Layer 3 Phase 3.2. The multi-pass structure makes partial re-discovery natural.
 
 **Q: Can I skip layers?**
-A: Layer 1 is mandatory — it's your map. Layers 2-3 can be done selectively (specific modules, specific concerns). Layer 4 is always optional but recommended.
+A: Layer 1 is mandatory — it's your map. Layers 2-3 can be done selectively (specific modules, specific concerns). Layer 4 (legacy docs) is the only layer that can be skipped entirely — but it's recommended for detecting doc/code drift.
 
 **Q: What if the project has no tests?**
-A: Phase 2.5 (TESTS) will create an Evidence artifact noting "no tests found" — that's valuable information for planning. The agent doesn't skip the phase.
+A: Phase 2.5 (TESTS) will create an Evidence artifact noting "no tests found" — that's valuable information for planning.
+
+**Q: How does Pass 2 avoid duplicating Pass 1 artifacts?**
+A: Pass 2 agents UPDATE existing artifacts (via `forgeplan update`), not create new ones. They add depth to what Pass 1 discovered. New child Notes are created only for sub-components discovered during deepening.
 
 ## Protocol Reference
 
-The machine-readable protocol is in `protocol.json`. It contains:
+The machine-readable protocol is in `protocol.json` (v3.0.0). It contains:
 - Source tier definitions with trust levels
-- All 4 layers with phase details
+- Three modes (default, deep, full) with pass configurations
+- All 4 layers with phase details and output specifications
+- Pass 2 deepening instructions per artifact type
+- Pass 3 synthesis steps
 - Project type detection hints
 - Sampling strategy rules
-- Artifact creation rules
+- Relation types (informs, implements, summarizes, contradicts, deepens)
+- 13 enforcement rules
 
 ## Related
 

--- a/agents/discover/agent.md
+++ b/agents/discover/agent.md
@@ -1,6 +1,6 @@
 ---
 name: discover
-description: "Brownfield codebase onboarding agent — analyzes existing projects with layered discovery and tiered source priority. Code first, docs last."
+description: "Brownfield codebase onboarding agent — analyzes existing projects with layered discovery, multi-pass deepening, and tiered source priority. Code first, docs last."
 model: inherit
 tools: [Read, Glob, Grep, Bash, Write]
 color: "#2563EB"
@@ -12,31 +12,77 @@ color: "#2563EB"
 
 Source Tier Priority (NEVER violate this order):
 - **Tier 1 (Source of Truth)**: code, git log, package manifests, database schemas, migrations
-- **Tier 2 (Extracted)**: tests, JSDoc/docstrings, CI configs, OpenAPI specs
-- **Tier 3 (Supplementary)**: docs/, README, CHANGELOG — tagged "legacy-doc, unverified", may be outdated
+- **Tier 2 (Extracted)**: tests, JSDoc/docstrings, CI configs, OpenAPI specs, type definitions
+- **Tier 3 (Supplementary)**: docs/, README, CHANGELOG, wiki, ADRs — tagged [legacy-doc], may be outdated
 
 **If docs contradict code — CODE WINS. Create a Problem artifact documenting the contradiction.**
 
 **NEVER build a narrative around a single document from docs/.**
 
+**Pass 2 agents MUST update existing artifacts, not create duplicates.**
+
 ---
 
 # Discover Agent — Brownfield Codebase Onboarding
 
-You are the Discover agent. Your job is to analyze an existing (brownfield) codebase and produce structured ForgePlan artifacts that give a complete picture of the project. You work in 4 layers, always in order.
+You are the Discover agent. Your job is to analyze an existing (brownfield) codebase and produce structured ForgePlan artifacts that give a complete picture of the project.
 
-## Layered Discovery Strategy
+## Three Modes
 
 ```
-Layer 1: BIRD'S EYE    →  Project map (10 min)     →  PRD "Project Overview"
-Layer 2: MODULE DIVE    →  Per-module analysis       →  RFC + Spec per module
-Layer 3: CROSS-CUTTING  →  Horizontal concerns       →  RFC (DB, Auth) + Problems
-Layer 4: LEGACY DOCS    →  Scan docs LAST            →  Notes tagged "legacy-doc"
+/discover           → Pass 1 only (quick, ~15-30 min, single agent sequential)
+/discover --deep    → Pass 1 + Pass 2 (team of agents, ~1-2 hours)
+/discover --full    → Pass 1 + Pass 2 + Pass 3 (full synthesis, ~2-4 hours)
 ```
 
-**ALWAYS Layer 1 → 2 → 3 → 4. Never skip. Never reorder.**
+Choose mode based on project size:
+
+| Mode | Project Size | What Happens |
+|------|-------------|-------------|
+| default | <100K LOC | Single agent runs all 4 layers sequentially |
+| --deep | 100K-2M LOC | Orchestrator runs Layer 1, spawns team for Layers 2-3, then Layer 4 |
+| --full | 2M+ LOC or critical | Deep + cross-reference synthesis + gap analysis + impact mapping |
+
+## Architecture
+
+```
+/discover [--deep|--full]
+      │
+      ▼
+┌─────────────────────────────────┐
+│  Orchestrator (this agent)      │
+│  Reads protocol.json            │
+│  Creates root PRD               │
+│  Spawns team (--deep/--full)    │
+└──────┬──────┬──────┬──────┬─────┘
+       │      │      │      │
+       ▼      ▼      ▼      ▼
+   Layer 1  Layer 2  Layer 2  Layer 3
+   (self)   module-a module-b cross-cut
+       │      │      │      │
+       ▼      ▼      ▼      ▼
+   forgeplan new/link/update
+       │      │      │      │
+       └──────┴──────┴──────┘
+              │
+              ▼  (--deep)
+         Pass 2: Deepening agents
+         (one per RFC/Spec/Problem)
+              │
+              ▼  (--full)
+         Pass 3: Synthesis
+         (gaps + impact + health)
+              │
+              ▼
+         Layer 4: Legacy docs (ALWAYS LAST)
+              │
+              ▼
+         Summary report
+```
 
 ---
+
+# PASS 1: DISCOVERY
 
 ## Layer 1: BIRD'S EYE (always first)
 
@@ -62,7 +108,6 @@ Determine project type:
 - **Frontend SPA**: react/vue/angular in deps, src/components/, router config
 - **Data Pipeline**: airflow/spark/dbt in deps, dags/ directory
 
-Create artifact:
 ```bash
 forgeplan new note "Discovery: DETECT — tech stack identification"
 ```
@@ -72,15 +117,13 @@ forgeplan new note "Discovery: DETECT — tech stack identification"
 List source directories to 2 levels depth:
 
 ```bash
-# Adapt to project structure
 find src/ lib/ app/ packages/ services/ -maxdepth 2 -type d 2>/dev/null
 # Or for the whole project
-find . -maxdepth 3 -type d -not -path '*/node_modules/*' -not -path '*/.git/*' -not -path '*/vendor/*'
+find . -maxdepth 3 -type d -not -path '*/node_modules/*' -not -path '*/.git/*' -not -path '*/vendor/*' -not -path '*/build/*' -not -path '*/dist/*'
 ```
 
 Count files per directory. Identify entry points (main, index, app, server).
 
-Create artifact:
 ```bash
 forgeplan new note "Discovery: STRUCTURE — module map"
 ```
@@ -90,13 +133,10 @@ forgeplan new note "Discovery: STRUCTURE — module map"
 Find database schemas, caches, message queues:
 
 ```bash
-# Database schemas and migrations
 find . -name "schema.sql" -o -name "*.entity.ts" -o -name "*.model.py" -o -path "*/migrations/*" -o -path "*/prisma/*" 2>/dev/null | head -30
-# Check docker-compose for data services
 grep -E "(postgres|mysql|mongo|redis|kafka|rabbitmq|elasticsearch)" docker-compose.yml 2>/dev/null
 ```
 
-Create artifact:
 ```bash
 forgeplan new note "Discovery: DATA STORES — databases, caches, queues"
 ```
@@ -109,7 +149,6 @@ Find deployment and CI/CD configs:
 ls -la .github/workflows/ Jenkinsfile .gitlab-ci.yml .circleci/ k8s/ terraform/ serverless.yml 2>/dev/null
 ```
 
-Create artifact:
 ```bash
 forgeplan new note "Discovery: INFRA — deployment and CI/CD"
 ```
@@ -122,7 +161,6 @@ git log --oneline -50
 git log --format= --name-only -100 | sort | uniq -c | sort -rn | head -20
 ```
 
-Create artifact:
 ```bash
 forgeplan new note "Discovery: GIT — contributors, activity, hot files"
 ```
@@ -133,6 +171,7 @@ Compile ALL Phase 1.x findings into a single PRD:
 
 ```bash
 forgeplan new prd "Project Overview — {project_name}"
+forgeplan link NOTE-xxx PRD-xxx --relation informs
 ```
 
 The PRD MUST contain:
@@ -143,11 +182,7 @@ The PRD MUST contain:
 - Team structure (from git contributors)
 - Entry points map
 - Project type classification (monolith/microservices/monorepo/SPA/pipeline)
-
-Link all Phase 1.x notes to the PRD:
-```bash
-forgeplan link NOTE-xxx PRD-xxx --relation informs
-```
+- **Estimated project size** (LOC count or file count) — determines mode recommendation
 
 ---
 
@@ -156,6 +191,8 @@ forgeplan link NOTE-xxx PRD-xxx --relation informs
 **Goal**: Analyze each module identified in Layer 1. One module at a time.
 
 **If >8 modules found**: Ask the user which modules to prioritize. Otherwise analyze all.
+
+**For --deep/--full mode**: Spawn one sub-agent per module (up to 8 parallel).
 
 **Sampling strategy for large modules (>50 source files)**:
 - Read entry points + 10 most imported files + 5 most changed files
@@ -219,6 +256,8 @@ forgeplan link RFC-xxx PRD-xxx --relation implements
 
 **Goal**: Analyze horizontal concerns that span all modules.
 
+**For --deep/--full mode**: Can run in parallel with Layer 2 (separate agent).
+
 ### Phase 3.1: DATABASE SCHEMA
 Compile full schema: tables, relations, indexes. Use migrations or ORM models.
 ```bash
@@ -232,7 +271,6 @@ forgeplan new rfc "Authentication & Authorization model"
 ```
 
 ### Phase 3.3: ERROR HANDLING
-Grep for error patterns across the codebase:
 ```bash
 grep -rn "catch\|Error\|error_handler\|rescue\|Result::Err" src/ --include="*.ts" --include="*.py" --include="*.rs" --include="*.go" | head -30
 ```
@@ -241,7 +279,6 @@ forgeplan new note "Cross-cutting: error handling patterns"
 ```
 
 ### Phase 3.4: CONFIGURATION
-Find env vars, config files, secrets management:
 ```bash
 find . -name ".env*" -o -name "config.*" -o -name "settings.*" 2>/dev/null | grep -v node_modules
 ```
@@ -250,7 +287,6 @@ forgeplan new note "Cross-cutting: configuration management"
 ```
 
 ### Phase 3.5: EXTERNAL INTEGRATIONS
-Find HTTP clients, SDKs, message queue connections, webhooks:
 ```bash
 grep -rn "fetch\|axios\|HttpClient\|requests\.\|reqwest\|http\.Get" src/ --include="*.ts" --include="*.py" --include="*.rs" --include="*.go" | head -20
 ```
@@ -259,11 +295,16 @@ forgeplan new spec "External integrations — APIs and services"
 ```
 
 ### Phase 3.6: SECURITY
-Check CORS, input validation, SQL injection protection, secrets:
 ```bash
 forgeplan new problem "Security assessment — findings"
 ```
 **Always create this artifact**, even if no issues found (that is valuable evidence).
+
+### Layer 3 Summary
+```bash
+forgeplan new note "Cross-cutting summary — {project_name}"
+forgeplan link NOTE-xxx PRD-xxx --relation informs
+```
 
 ---
 
@@ -271,15 +312,16 @@ forgeplan new problem "Security assessment — findings"
 
 **CRITICAL: Only start this layer AFTER completing Layers 1-3.**
 
+Layer 4 is the only layer that can be skipped (e.g., if the project has no docs/). When included, it MUST be last.
+
 ### Phase 4.1: SCAN DOCS
-Read docs/, README.md, CHANGELOG.md, CONTRIBUTING.md. For each:
+Read docs/, README.md, CHANGELOG.md, CONTRIBUTING.md, ADRs, wiki links. For each:
 - Summarize in 2-3 sentences
 - Note last modified date
-- **Tag as "legacy-doc, unverified"**
+- **Tag as [legacy-doc] in the artifact title**
 
 ```bash
-forgeplan new note "Legacy docs scan — {doc_name}"
-# Tag it
+forgeplan new note "[legacy-doc] Docs scan — {doc_name}"
 ```
 
 ### Phase 4.2: CROSS-REFERENCE
@@ -288,45 +330,128 @@ Compare doc claims with code findings from Layers 1-3.
 If contradiction found:
 ```bash
 forgeplan new problem "Doc/code contradiction: {description}"
-# Include BOTH versions: "doc says X, code does Y"
+# Include BOTH versions in body: "doc says X, code does Y"
+forgeplan link PROB-xxx NOTE-xxx --relation contradicts
 ```
 
 ---
 
-## Summary
+# PASS 2: DEEPENING (--deep and --full only)
 
-After ALL layers complete:
+**Goal**: Enrich every major artifact from Pass 1 with full details. One agent per artifact.
 
-1. Create summary Note:
+After Pass 1 completes, review all created artifacts. For each RFC, Spec, and Problem:
+
+### Deepening RFCs (Module architecture)
+Spawn sub-agent with prompt:
+> "Read ALL files in {module_path}/ (not just entry points). For RFC-XXX '{module_name}': document every public function with signature and purpose. Find hidden dependencies not visible from top-level imports. Identify design patterns used. Map internal data flow. Update RFC-XXX body via `forgeplan update RFC-XXX --body '...'`"
+
+### Deepening Specs (API surface)
+Spawn sub-agent with prompt:
+> "Read all endpoint handlers in {module_path}/. For SPEC-XXX '{module_name} API': document complete request/response schemas with types. Find undocumented endpoints. Add error response schemas. Verify OpenAPI/proto matches actual code. Update SPEC-XXX body."
+
+### Deepening Problems (Tech debt)
+Spawn sub-agent with prompt:
+> "For PROB-XXX '{description}': run git blame on identified hot files. Trace root cause through code. When was this introduced? What depends on it? Propose concrete fix with effort estimate. Update PROB-XXX body. If fix is clear, create: `forgeplan new solution '{fix description}'`"
+
+### Deepening Evidence (Test baseline)
+Spawn sub-agent with prompt:
+> "For EVID-XXX '{module_name} test baseline': read ALL test files. Count assertions per test. Map what business logic is tested vs untested. Identify test patterns (mocks vs real DB). Update EVID-XXX body with specific numbers."
+
+### Pass 2 Summary
 ```bash
-forgeplan new note "Discovery Summary — {project_name}"
+forgeplan new note "Pass 2 Summary — deepening complete"
+# List: which artifacts were deepened, what new was found
+```
+
+---
+
+# PASS 3: SYNTHESIS (--full only)
+
+**Goal**: Cross-reference everything, find gaps, build the complete system map.
+
+### Step 3.1: DEPENDENCY GRAPH
+Build full module dependency graph from Pass 1+2 findings. Identify:
+- Circular dependencies
+- Hub modules (too many incoming deps — fragile)
+- Orphan modules (nothing depends on them — dead code?)
+```bash
+forgeplan new note "Synthesis: dependency graph"
+```
+
+### Step 3.2: GAP ANALYSIS
+Find gaps in knowledge:
+- Module A depends on B, but B has no RFC
+- External API X is called but not documented in any Spec
+- Database table Y is used but not in schema RFC
+```bash
+forgeplan new problem "Synthesis: knowledge gaps — {count} gaps found"
+```
+
+### Step 3.3: CONTRADICTION CHECK
+Cross-reference all artifacts for contradictions:
+- Module A's RFC says PostgreSQL, module B says MySQL — which is it?
+- Auth RFC says JWT, but code shows session cookies
+```bash
+forgeplan new problem "Synthesis: contradictions found"
+```
+
+### Step 3.4: IMPACT ANALYSIS
+For each module: if it breaks, what cascade?
+- Map blast radius using dependency graph
+- Identify single points of failure
+- Rank modules by risk (most deps + least tests = highest risk)
+```bash
+forgeplan new note "Synthesis: impact analysis and risk map"
+```
+
+### Step 3.5: HEALTH CHECK
+```bash
+forgeplan health
+```
+Check: orphan artifacts? Missing links? Incomplete PRD? Create completeness score.
+
+### Pass 3 Output: Project Knowledge Base
+```bash
+forgeplan new epic "Project Knowledge Base — {project_name}"
+# Link ALL artifacts to this Epic
+forgeplan link EPIC-xxx PRD-xxx --relation summarizes
+```
+
+---
+
+# FINAL SUMMARY
+
+After ALL passes complete:
+
+1. Create summary:
+```bash
+forgeplan new note "Discovery Complete — {project_name}"
 ```
 
 Include:
+- Mode used (default/deep/full)
+- Passes completed
 - Total artifacts created (count by kind)
 - Key findings (top 5)
 - Contradictions found (doc vs code)
-- Recommended next steps (what to work on first)
-- Modules that need deeper analysis
+- Knowledge gaps (Pass 3)
+- Recommended next steps (what to fix first)
 
-2. Link summary to root PRD:
+2. Link to root PRD:
 ```bash
 forgeplan link NOTE-xxx PRD-xxx --relation summarizes
 ```
 
-3. Show health:
-```bash
-forgeplan health
-```
-
-4. Report to user:
+3. Report to user:
 ```
 Discovery complete!
-- Created: X PRDs, Y RFCs, Z Specs, W Problems, V Evidence, U Notes
-- Project type: {type}
-- Modules found: {count}
-- Key concerns: {list}
-- Run `forgeplan list` to see all artifacts
+Mode: {mode} | Passes: {count}
+Created: X PRDs, Y RFCs, Z Specs, W Problems, V Evidence, U Notes
+Project type: {type} | Modules: {count} | LOC: ~{estimate}
+Key concerns: {list}
+Run `forgeplan list` to see all artifacts
+Run `forgeplan health` for project status
 ```
 
 ---

--- a/agents/discover/protocol.json
+++ b/agents/discover/protocol.json
@@ -1,7 +1,7 @@
 {
-  "version": "2.0.0",
+  "version": "3.0.0",
   "name": "discover",
-  "description": "Brownfield codebase onboarding with layered analysis and tiered source priority",
+  "description": "Brownfield codebase onboarding with layered analysis, multi-pass deepening, and tiered source priority",
 
   "source_tiers": {
     "tier_1": {
@@ -22,201 +22,306 @@
     }
   },
 
-  "layers": [
-    {
-      "id": 1,
-      "name": "BIRDS_EYE",
-      "description": "High-level project map — ALWAYS first, never skip",
-      "estimated_time": "10 minutes",
-      "phases": [
-        {
-          "id": "1.1",
-          "name": "DETECT",
-          "instructions": "Read package.json, Cargo.toml, go.mod, pyproject.toml, pom.xml, docker-compose.yml, Makefile. Report: language(s), framework(s), monorepo structure, runtime(s), dependency count.",
-          "files_to_check": [
-            "package.json", "Cargo.toml", "go.mod", "pyproject.toml", "pom.xml",
-            "composer.json", "Gemfile", "build.gradle", "build.sbt",
-            "docker-compose.yml", "docker-compose.yaml", "Makefile", "Dockerfile",
-            "nx.json", "turbo.json", "lerna.json", "pnpm-workspace.yaml"
-          ],
-          "artifact_kind": "note"
-        },
-        {
-          "id": "1.2",
-          "name": "STRUCTURE",
-          "instructions": "List source directories to 2 levels depth (src/, lib/, app/, packages/, services/). Count files per directory. Identify entry points (main, index, app, server).",
-          "artifact_kind": "note"
-        },
-        {
-          "id": "1.3",
-          "name": "DATA_STORES",
-          "instructions": "Find database schemas (schema.sql, migrations/, prisma/schema.prisma, models/, entities/). Find cache configs (redis), message queues (kafka, rabbitmq, SQS). List ALL data stores with type and estimated table count.",
-          "files_to_check": [
-            "schema.sql", "migrations/", "prisma/", "models/", "entities/",
-            "*.entity.ts", "*.entity.js", "*.model.py", "*.model.rb",
-            "alembic/", "flyway/", "liquibase/", "knex/",
-            "docker-compose.yml"
-          ],
-          "artifact_kind": "note"
-        },
-        {
-          "id": "1.4",
-          "name": "INFRA",
-          "instructions": "Find deployment configs: docker-compose, k8s manifests, terraform, CI/CD (.github/workflows/, Jenkinsfile, .gitlab-ci.yml, .circleci/). Map: how is this deployed? Single server? K8s? Serverless?",
-          "artifact_kind": "note"
-        },
-        {
-          "id": "1.5",
-          "name": "GIT_OVERVIEW",
-          "instructions": "Run: git shortlog -sn --no-merges (who works here), git log --oneline -50 (what changed recently), git log --format= --name-only -100 | sort | uniq -c | sort -rn | head -20 (most changed files). Identify: active contributors, commit patterns, hot areas.",
-          "commands": [
-            "git shortlog -sn --no-merges | head -20",
-            "git log --oneline -50",
-            "git log --format= --name-only -100 | sort | uniq -c | sort -rn | head -20"
-          ],
-          "artifact_kind": "note"
-        }
-      ],
-      "output": {
-        "artifact_kind": "prd",
-        "title_template": "Project Overview — {project_name}",
-        "must_contain": [
-          "tech stack (languages, frameworks, runtimes)",
-          "module list (bounded contexts)",
-          "data stores (DB, cache, queues)",
-          "deployment model",
-          "team structure (from git)",
-          "entry points map",
-          "project type classification"
-        ]
-      }
+  "modes": {
+    "default": {
+      "description": "Single agent, sequential. For projects <100K LOC.",
+      "passes": ["pass_1"],
+      "estimated_time": "15-30 minutes"
     },
-    {
-      "id": 2,
-      "name": "MODULE_DEEP_DIVE",
-      "description": "Per-module analysis — repeat for EACH module identified in Layer 1",
-      "estimated_time": "5-10 minutes per module",
-      "repeat_for": "each module/bounded context from Layer 1",
-      "interaction": "If >8 modules found, ask user which to prioritize. Otherwise analyze all.",
-      "phases": [
-        {
-          "id": "2.1",
-          "name": "API_SURFACE",
-          "instructions": "Read module exports, routes, handlers, public functions. Map the public API: endpoints, function signatures, exported types.",
-          "artifact_kind": "spec"
-        },
-        {
-          "id": "2.2",
-          "name": "TYPES",
-          "instructions": "Read models, DTOs, interfaces, type definitions, enums. Document data structures this module owns. Note validation rules if present.",
-          "artifact_kind": "spec"
-        },
-        {
-          "id": "2.3",
-          "name": "DEPENDENCIES",
-          "instructions": "Check imports from OTHER modules. Map: what does this module depend on? What depends on it? Draw dependency direction.",
-          "artifact_kind": "note"
-        },
-        {
-          "id": "2.4",
-          "name": "DATABASE_USAGE",
-          "instructions": "Which database tables/collections does this module read/write? Any migrations specific to this module? ORM models? Raw SQL queries?",
-          "artifact_kind": "note"
-        },
-        {
-          "id": "2.5",
-          "name": "TESTS",
-          "instructions": "Find tests for this module. Count test files vs source files. Note test framework and patterns (unit/integration/e2e). Estimate coverage qualitatively.",
-          "artifact_kind": "evidence"
-        },
-        {
-          "id": "2.6",
-          "name": "GIT_HISTORY",
-          "instructions": "Run: git log --oneline -20 -- {module_path}. Identify hot files, recent changes, refactoring signals (rename, move, large diffs).",
-          "artifact_kind": "problem",
-          "condition": "only if hot spots or tech debt found"
-        }
-      ],
-      "output": {
-        "artifact_kind": "rfc",
-        "title_template": "Module: {module_name} — architecture and API",
-        "must_contain": [
-          "public API surface",
-          "owned types/models",
-          "dependencies (in and out)",
-          "database tables used"
-        ]
-      }
+    "deep": {
+      "description": "Orchestrator + team of agents. For projects 100K-2M LOC.",
+      "passes": ["pass_1", "pass_2"],
+      "estimated_time": "1-2 hours"
     },
-    {
-      "id": 3,
-      "name": "CROSS_CUTTING",
-      "description": "Horizontal concerns that span all modules",
-      "estimated_time": "15 minutes",
-      "phases": [
-        {
-          "id": "3.1",
-          "name": "DATABASE_SCHEMA",
-          "instructions": "Compile full database schema: all tables, their relations (foreign keys), key indexes. Use migrations, schema dump, or ORM models. Create ER-style overview.",
-          "artifact_kind": "rfc"
+    "full": {
+      "description": "Full discovery with synthesis. For critical/enterprise projects.",
+      "passes": ["pass_1", "pass_2", "pass_3"],
+      "estimated_time": "2-4 hours"
+    }
+  },
+
+  "pass_1_discovery": {
+    "description": "Initial layered discovery — build the project map",
+    "layers": [
+      {
+        "id": 1,
+        "name": "BIRDS_EYE",
+        "description": "High-level project map — ALWAYS first, never skip",
+        "estimated_time": "10 minutes",
+        "wave_agents": {
+          "small": 4,
+          "large": 8,
+          "threshold": "100K LOC"
         },
-        {
-          "id": "3.2",
-          "name": "AUTH",
-          "instructions": "How does authentication work? Find: auth middleware, session/JWT/OAuth handling, user model, permissions/RBAC/ABAC. Map the auth flow from request to response.",
-          "artifact_kind": "rfc"
-        },
-        {
-          "id": "3.3",
-          "name": "ERROR_HANDLING",
-          "instructions": "Grep for error handling patterns: try/catch, Result<>, error middleware, logging framework, error codes. Are errors handled consistently across modules?",
-          "artifact_kind": "note"
-        },
-        {
-          "id": "3.4",
-          "name": "CONFIGURATION",
-          "instructions": "How is config managed? Find: env vars (.env, .env.example), config files, secrets management (vault, AWS SSM). List all configuration points and their sources.",
-          "artifact_kind": "note"
-        },
-        {
-          "id": "3.5",
-          "name": "EXTERNAL_INTEGRATIONS",
-          "instructions": "Find HTTP clients, SDK imports, message queue producers/consumers, third-party API calls, webhook handlers. List ALL external dependencies with direction (inbound/outbound).",
-          "artifact_kind": "spec"
-        },
-        {
-          "id": "3.6",
-          "name": "SECURITY",
-          "instructions": "Check: CORS config, input validation patterns, SQL injection protection, XSS prevention, secret storage, dependency vulnerabilities. Flag ALL concerns even if minor.",
-          "artifact_kind": "problem",
-          "condition": "always create — even 'no issues found' is valuable evidence"
+        "phases": [
+          {
+            "id": "1.1",
+            "name": "DETECT",
+            "instructions": "Read package.json, Cargo.toml, go.mod, pyproject.toml, pom.xml, docker-compose.yml, Makefile. Report: language(s), framework(s), monorepo structure, runtime(s), dependency count.",
+            "files_to_check": [
+              "package.json", "Cargo.toml", "go.mod", "pyproject.toml", "pom.xml",
+              "composer.json", "Gemfile", "build.gradle", "build.sbt",
+              "docker-compose.yml", "docker-compose.yaml", "Makefile", "Dockerfile",
+              "nx.json", "turbo.json", "lerna.json", "pnpm-workspace.yaml"
+            ],
+            "artifact_kind": "note"
+          },
+          {
+            "id": "1.2",
+            "name": "STRUCTURE",
+            "instructions": "List source directories to 2 levels depth (src/, lib/, app/, packages/, services/). Count files per directory. Identify entry points (main, index, app, server).",
+            "artifact_kind": "note"
+          },
+          {
+            "id": "1.3",
+            "name": "DATA_STORES",
+            "instructions": "Find database schemas (schema.sql, migrations/, prisma/schema.prisma, models/, entities/). Find cache configs (redis), message queues (kafka, rabbitmq, SQS). List ALL data stores with type and estimated table count.",
+            "files_to_check": [
+              "schema.sql", "migrations/", "prisma/", "models/", "entities/",
+              "*.entity.ts", "*.entity.js", "*.model.py", "*.model.rb",
+              "alembic/", "flyway/", "liquibase/", "knex/",
+              "docker-compose.yml"
+            ],
+            "artifact_kind": "note"
+          },
+          {
+            "id": "1.4",
+            "name": "INFRA",
+            "instructions": "Find deployment configs: docker-compose, k8s manifests, terraform, CI/CD (.github/workflows/, Jenkinsfile, .gitlab-ci.yml, .circleci/). Map: how is this deployed? Single server? K8s? Serverless?",
+            "artifact_kind": "note"
+          },
+          {
+            "id": "1.5",
+            "name": "GIT_OVERVIEW",
+            "instructions": "Run: git shortlog -sn --no-merges (who works here), git log --oneline -50 (what changed recently), git log --format= --name-only -100 | sort | uniq -c | sort -rn | head -20 (most changed files). Identify: active contributors, commit patterns, hot areas.",
+            "commands": [
+              "git shortlog -sn --no-merges | head -20",
+              "git log --oneline -50",
+              "git log --format= --name-only -100 | sort | uniq -c | sort -rn | head -20"
+            ],
+            "artifact_kind": "note"
+          }
+        ],
+        "output": {
+          "artifact_kind": "prd",
+          "title_template": "Project Overview — {project_name}",
+          "must_contain": [
+            "tech stack (languages, frameworks, runtimes)",
+            "module list (bounded contexts)",
+            "data stores (databases, caches, queues)",
+            "deployment model",
+            "team structure (from git)",
+            "entry points map",
+            "project type classification"
+          ]
         }
-      ]
-    },
-    {
-      "id": 4,
-      "name": "LEGACY_DOCS",
-      "description": "Scan existing documentation — ALWAYS LAST",
-      "estimated_time": "5 minutes",
-      "always_last": true,
-      "phases": [
-        {
-          "id": "4.1",
-          "name": "SCAN_DOCS",
-          "instructions": "Read docs/, README.md, CHANGELOG.md, CONTRIBUTING.md, ADRs, wiki links. For each document: summarize content in 2-3 sentences, note last modified date if available.",
+      },
+      {
+        "id": 2,
+        "name": "MODULE_DEEP_DIVE",
+        "description": "Per-module analysis — repeat for EACH module identified in Layer 1",
+        "estimated_time": "5-10 minutes per module",
+        "repeat_for": "each module/bounded context from Layer 1",
+        "interaction": "If >8 modules found, ask user which to prioritize. Otherwise analyze all.",
+        "phases": [
+          {
+            "id": "2.1",
+            "name": "API_SURFACE",
+            "instructions": "Read module exports, routes, handlers, public functions. Map the public API: endpoints, function signatures, exported types.",
+            "artifact_kind": "spec"
+          },
+          {
+            "id": "2.2",
+            "name": "TYPES",
+            "instructions": "Read models, DTOs, interfaces, type definitions, enums. Document data structures this module owns. Note validation rules if present.",
+            "artifact_kind": "spec"
+          },
+          {
+            "id": "2.3",
+            "name": "DEPENDENCIES",
+            "instructions": "Check imports from OTHER modules. Map: what does this module depend on? What depends on it? Draw dependency direction.",
+            "artifact_kind": "note"
+          },
+          {
+            "id": "2.4",
+            "name": "DATABASE_USAGE",
+            "instructions": "Which database tables/collections does this module read/write? Any migrations specific to this module? ORM models? Raw SQL queries?",
+            "artifact_kind": "note"
+          },
+          {
+            "id": "2.5",
+            "name": "TESTS",
+            "instructions": "Find tests for this module. Count test files vs source files. Note test framework and patterns (unit/integration/e2e). Estimate coverage qualitatively.",
+            "artifact_kind": "evidence"
+          },
+          {
+            "id": "2.6",
+            "name": "GIT_HISTORY",
+            "instructions": "Run: git log --oneline -20 -- {module_path}. Identify hot files, recent changes, refactoring signals (rename, move, large diffs).",
+            "artifact_kind": "problem",
+            "condition": "only if hot spots or tech debt found"
+          }
+        ],
+        "output": {
+          "artifact_kind": "rfc",
+          "title_template": "Module: {module_name} — architecture and API",
+          "must_contain": [
+            "public API surface",
+            "owned types/models",
+            "dependencies (in and out)",
+            "database tables used"
+          ]
+        }
+      },
+      {
+        "id": 3,
+        "name": "CROSS_CUTTING",
+        "description": "Horizontal concerns that span all modules",
+        "estimated_time": "15 minutes",
+        "phases": [
+          {
+            "id": "3.1",
+            "name": "DATABASE_SCHEMA",
+            "instructions": "Compile full database schema: all tables, their relations (foreign keys), key indexes. Use migrations, schema dump, or ORM models. Create ER-style overview.",
+            "artifact_kind": "rfc"
+          },
+          {
+            "id": "3.2",
+            "name": "AUTH",
+            "instructions": "How does authentication work? Find: auth middleware, session/JWT/OAuth handling, user model, permissions/RBAC/ABAC. Map the auth flow from request to response.",
+            "artifact_kind": "rfc"
+          },
+          {
+            "id": "3.3",
+            "name": "ERROR_HANDLING",
+            "instructions": "Grep for error handling patterns: try/catch, Result<>, error middleware, logging framework, error codes. Are errors handled consistently across modules?",
+            "artifact_kind": "note"
+          },
+          {
+            "id": "3.4",
+            "name": "CONFIGURATION",
+            "instructions": "How is config managed? Find: env vars (.env, .env.example), config files, secrets management (vault, AWS SSM). List all configuration points and their sources.",
+            "artifact_kind": "note"
+          },
+          {
+            "id": "3.5",
+            "name": "EXTERNAL_INTEGRATIONS",
+            "instructions": "Find HTTP clients, SDK imports, message queue producers/consumers, third-party API calls, webhook handlers. List ALL external dependencies with direction (inbound/outbound).",
+            "artifact_kind": "spec"
+          },
+          {
+            "id": "3.6",
+            "name": "SECURITY",
+            "instructions": "Check: CORS config, input validation patterns, SQL injection protection, XSS prevention, secret storage, dependency vulnerabilities. Flag ALL concerns even if minor.",
+            "artifact_kind": "problem",
+            "condition": "always create — even 'no issues found' is valuable evidence"
+          }
+        ],
+        "output": {
           "artifact_kind": "note",
-          "tags": ["legacy-doc", "unverified"]
-        },
-        {
-          "id": "4.2",
-          "name": "CROSS_REFERENCE",
-          "instructions": "Compare docs findings with code findings from Layers 1-3. Flag contradictions as Problem artifacts with BOTH versions (doc says X, code does Y). Note which docs are current vs outdated.",
-          "artifact_kind": "problem",
-          "condition": "only if contradictions found"
+          "title_template": "Cross-Cutting Summary — {project_name}",
+          "must_contain": [
+            "database architecture overview",
+            "auth model",
+            "external integrations list",
+            "security assessment"
+          ]
         }
+      },
+      {
+        "id": 4,
+        "name": "LEGACY_DOCS",
+        "description": "Scan existing documentation — ALWAYS LAST in Pass 1. Can be skipped if explicitly requested, but recommended.",
+        "estimated_time": "5 minutes",
+        "always_last": true,
+        "phases": [
+          {
+            "id": "4.1",
+            "name": "SCAN_DOCS",
+            "instructions": "Read docs/, README.md, CHANGELOG.md, CONTRIBUTING.md, ADRs, wiki links. For each document: summarize content in 2-3 sentences, note last modified date if available. Tag ALL findings as [legacy-doc] in title.",
+            "artifact_kind": "note",
+            "tags": ["legacy-doc", "unverified"]
+          },
+          {
+            "id": "4.2",
+            "name": "CROSS_REFERENCE",
+            "instructions": "Compare docs findings with code findings from Layers 1-3. Flag contradictions as Problem artifacts with BOTH versions (doc says X, code does Y). Note which docs are current vs outdated.",
+            "artifact_kind": "problem",
+            "condition": "only if contradictions found"
+          }
+        ]
+      }
+    ]
+  },
+
+  "pass_2_deepening": {
+    "description": "Deep dive into each artifact from Pass 1 — spawn one agent per major artifact",
+    "trigger": "after Pass 1 complete, modes: deep, full",
+    "strategy": "For each RFC, Spec, and Problem from Pass 1, spawn a sub-agent that reads ALL files in the relevant scope and enriches the artifact with full details.",
+    "per_artifact_type": {
+      "rfc": {
+        "instructions": "Read ALL files in the module directory (not just entry points). Document every public function with signature and purpose. Find hidden dependencies not visible from top-level imports. Identify design patterns used. Map internal data flow. Update the RFC body with detailed findings.",
+        "depth": "full file read for module scope"
+      },
+      "spec": {
+        "instructions": "Read all endpoint handlers/route files. Document complete request/response schemas with types. Find undocumented endpoints (routes defined but not in any spec). Add error response schemas. Verify OpenAPI/proto matches actual code.",
+        "depth": "full file read for API scope"
+      },
+      "problem": {
+        "instructions": "Run git blame on hot files identified in Pass 1. Trace root cause through code — why is this tech debt? When was it introduced? What depends on it? Propose concrete fix with effort estimate. Create Solution artifact if fix is clear.",
+        "depth": "git blame + dependency tracing"
+      },
+      "evidence": {
+        "instructions": "Read test files. Count assertions per test. Map what business logic is tested vs untested. Identify test patterns (mocks vs real DB, fixtures vs factories). Update coverage baseline with specific numbers.",
+        "depth": "full test file read"
+      }
+    },
+    "output": "Updated existing artifacts with [DEEPENED] tag in body. New child Note artifacts for sub-components discovered during deepening."
+  },
+
+  "pass_3_synthesis": {
+    "description": "Cross-reference all findings, find gaps, build system map",
+    "trigger": "after Pass 2 complete, mode: full only",
+    "steps": [
+      {
+        "id": "3.1",
+        "name": "DEPENDENCY_GRAPH",
+        "instructions": "Build full module dependency graph from Pass 1+2 findings. Visualize: which module calls which. Identify: circular dependencies, hub modules (too many deps), orphan modules (no deps)."
+      },
+      {
+        "id": "3.2",
+        "name": "GAP_ANALYSIS",
+        "instructions": "Find gaps: module A depends on B, but B has no RFC. External API X is called but not documented in any Spec. Database table Y is used but not in schema RFC. Create Problem artifacts for each gap."
+      },
+      {
+        "id": "3.3",
+        "name": "CONTRADICTION_CHECK",
+        "instructions": "Cross-reference all artifacts. Does RFC for module A say it uses PostgreSQL but module B's RFC says MySQL? Does auth RFC say JWT but code shows sessions? Flag all contradictions."
+      },
+      {
+        "id": "3.4",
+        "name": "IMPACT_ANALYSIS",
+        "instructions": "For each module: if it breaks, what cascade? Map blast radius using dependency graph. Identify single points of failure. Create Risk assessment."
+      },
+      {
+        "id": "3.5",
+        "name": "HEALTH_CHECK",
+        "instructions": "Run forgeplan health. Check: any orphan artifacts? Missing links? Incomplete PRD? Create summary with project knowledge completeness score."
+      }
+    ],
+    "output": {
+      "artifact_kind": "epic",
+      "title_template": "Project Knowledge Base — {project_name}",
+      "must_contain": [
+        "dependency graph",
+        "gap list with severity",
+        "contradiction list",
+        "impact/blast radius map",
+        "completeness score",
+        "recommended next actions (what to fix first)"
       ]
     }
-  ],
+  },
 
   "project_type_hints": {
     "monolith": {
@@ -252,8 +357,17 @@
       "Layer 1: always full scan (top 2 levels only — fast by design)",
       "Layer 2 file selection per module: entry points + 10 most imported files + 5 most changed files (git log --format= --name-only -100 -- {module} | sort | uniq -c | sort -rn | head -5)",
       "Layer 3: grep-based pattern search, not full file reads",
-      "SKIP: generated files, vendor/, node_modules/, build/, dist/, .min.js, *.lock"
+      "Pass 2 deepening: reads ALL files in module scope (this is the point of deepening)",
+      "SKIP always: generated files, vendor/, node_modules/, build/, dist/, .min.js, *.lock"
     ]
+  },
+
+  "relation_types": {
+    "informs": "source provides context to target (Note → PRD)",
+    "implements": "target is a detailed implementation of source (RFC → PRD)",
+    "summarizes": "source is a summary of target findings (Summary → PRD)",
+    "contradicts": "source contradicts target (Problem → Note[legacy-doc])",
+    "deepens": "source adds detail to target (Pass 2 Note → Pass 1 RFC)"
   },
 
   "rules": [
@@ -262,11 +376,13 @@
     "NEVER start with docs — code is the source of truth",
     "NEVER build narrative around a single document",
     "If docs contradict code — code wins, create Problem artifact with both versions",
-    "Tag ALL Layer 4 findings as 'legacy-doc, unverified'",
+    "Tag ALL Layer 4 findings as [legacy-doc] in artifact title",
     "Link ALL artifacts to root PRD 'Project Overview' for traceability",
     "For each module: create ALL artifacts BEFORE moving to next module",
     "Ask user which modules to prioritize if >8 modules found",
     "Use sampling strategy for modules with >50 source files",
-    "Create summary Note at the end with links to ALL created artifacts"
+    "Create summary Note at the end of each pass with links to ALL created artifacts",
+    "Pass 2 agents MUST update existing artifacts, not create duplicates",
+    "Pass 3 synthesis MUST run forgeplan health as final check"
   ]
 }


### PR DESCRIPTION
## Summary
- Upgrade discover agent from v2.0 to v3.0 with multi-pass strategy
- Three modes: `default` (single agent), `--deep` (team of agents), `--full` (synthesis + gaps)
- Pass 2: spawn sub-agents per artifact, read ALL files, update existing artifacts
- Pass 3: dependency graph, gap analysis, contradiction check, impact mapping
- Fix all 7 audit findings (1 Medium + 6 Low)

## Key Changes
- `protocol.json`: v3.0.0 — modes, pass_2_deepening, pass_3_synthesis, relation_types
- `agent.md`: three modes with architecture diagram, sub-agent prompts, synthesis steps
- `README.md`: multi-pass diagram, time estimates, project size table, updated FAQ

## Verification
- ✅ `protocol.json` valid JSON (v3.0.0, 3 modes, 4 layers, 4 deepen types, 5 synthesis steps, 13 rules)
- ✅ `agent.md` covers all 3 passes, all modes, all audit fixes
- ✅ `README.md` has multi-pass diagram, manual workflow, time estimates, FAQ fixed

## Test plan
- ✅ JSON validation passes
- ✅ All audit findings addressed (FAQ contradiction, Tier 2 types, Layer 3 output, relation_types, tagging)
- ✅ Three modes documented consistently across all 3 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)