### PR TITLE
feat(agents): discover v3.1 — 4-level progress tracking

### DIFF
--- a/agents/discover/README.md
+++ b/agents/discover/README.md
@@ -283,9 +283,74 @@ A: Phase 2.5 (TESTS) will create an Evidence artifact noting "no tests found" �
 **Q: How does Pass 2 avoid duplicating Pass 1 artifacts?**
 A: Pass 2 agents UPDATE existing artifacts (via `forgeplan update`), not create new ones. They add depth to what Pass 1 discovered. New child Notes are created only for sub-components discovered during deepening.
 
+## Progress Tracking
+
+The agent tracks progress at 4 levels to survive restarts, work in team mode, and give visibility:
+
+```
+┌─────────────────────────────────────────────────────┐
+│ Level 1: Todos (TaskCreate)                         │
+│   Real-time spinner in Claude Code UI               │
+│   Lost on restart — recreated from state file       │
+├─────────────────────────────────────────────────────┤
+│ Level 2: State File (.forgeplan/discovery-state.json)│
+│   Machine-readable JSON — source of truth           │
+│   Survives restarts, readable by team agents        │
+│   Deleted when discovery completes                  │
+├─────────────────────────────────────────────────────┤
+│ Level 3: Progress Artifact (ForgePlan Note)         │
+│   Human-readable checklist in forgeplan list        │
+│   Markdown: [ ] pending, [x] done → ARTIFACT-ID    │
+│   Permanent record of discovery                     │
+├─────────────────────────────────────────────────────┤
+│ Level 4: Hindsight (optional)                       │
+│   Long-term memory via Hindsight MCP                │
+│   Retains summary at end of each pass               │
+│   Enables cross-session recall                      │
+└─────────────────────────────────────────────────────┘
+```
+
+### Resume After Interruption
+
+If a discovery session is interrupted (crash, timeout, user stopped):
+
+```bash
+# State file persists — agent detects it on next start
+cat .forgeplan/discovery-state.json
+# → Shows exactly where it stopped
+
+# Agent automatically resumes:
+# "Resuming discovery from Layer 2, module: users (Phase 2.3 DEPENDENCIES)"
+```
+
+### What the Progress Artifact Looks Like
+
+```markdown
+## Discovery: MyProject
+Mode: deep | Started: 2026-04-07T10:00
+
+### Pass 1: Discovery
+- [x] Layer 1: Bird's Eye
+  - [x] 1.1 DETECT → NOTE-001
+  - [x] 1.2 STRUCTURE → NOTE-002
+  - [x] 1.3 DATA STORES → NOTE-003
+  - [x] 1.4 INFRA → NOTE-004
+  - [x] 1.5 GIT OVERVIEW → NOTE-005
+  - [x] PRD created → PRD-001
+- [ ] Layer 2: Module Deep Dive
+  - [x] orders → RFC-001, SPEC-001
+  - [ ] users ← IN PROGRESS (Phase 2.3)
+  - [ ] payments
+- [ ] Layer 3: Cross-Cutting
+- [ ] Layer 4: Legacy Docs
+
+### Pass 2: Deepening
+- [ ] Not started
+```
+
 ## Protocol Reference
 
-The machine-readable protocol is in `protocol.json` (v3.0.0). It contains:
+The machine-readable protocol is in `protocol.json` (v3.1.0). It contains:
 - Source tier definitions with trust levels
 - Three modes (default, deep, full) with pass configurations
 - All 4 layers with phase details and output specifications
@@ -294,7 +359,8 @@ The machine-readable protocol is in `protocol.json` (v3.0.0). It contains:
 - Project type detection hints
 - Sampling strategy rules
 - Relation types (informs, implements, summarizes, contradicts, deepens)
-- 13 enforcement rules
+- Progress tracking (4 levels: todos, state file, artifact, hindsight)
+- 16 enforcement rules
 
 ## Related
 

--- a/agents/discover/agent.md
+++ b/agents/discover/agent.md
@@ -21,6 +21,98 @@ Source Tier Priority (NEVER violate this order):
 
 **Pass 2 agents MUST update existing artifacts, not create duplicates.**
 
+**ALWAYS check for existing state file before starting — resume if exists.**
+
+---
+
+# PROGRESS TRACKING — MANDATORY
+
+You MUST track progress at 4 levels. This ensures you never lose position across restarts, team mode, or long runs.
+
+## On Start: Check for Existing Discovery
+
+```bash
+# FIRST THING: check if a previous discovery was interrupted
+cat .forgeplan/discovery-state.json 2>/dev/null
+```
+
+**If state file EXISTS** → RESUME mode:
+1. Read state file — find last incomplete phase
+2. If Hindsight MCP available: `memory_recall("discovery {project}")`
+3. Report to user: "Resuming discovery from {last_phase}"
+4. Create todos (TaskCreate) for REMAINING phases only
+5. Continue from last incomplete phase
+
+**If state file DOES NOT EXIST** → FRESH mode:
+1. Create state file:
+```bash
+cat > .forgeplan/discovery-state.json << 'EOF'
+{
+  "discovery_id": "DISC-001",
+  "project": "{project_name}",
+  "mode": "{default|deep|full}",
+  "started_at": "{ISO 8601}",
+  "pass_1": {
+    "status": "in_progress",
+    "layers": {
+      "1_birds_eye": { "status": "pending", "phases_done": [], "artifacts": [] },
+      "2_modules": { "status": "pending", "modules": {} },
+      "3_cross_cutting": { "status": "pending", "artifacts": [] },
+      "4_legacy_docs": { "status": "pending", "artifacts": [] }
+    }
+  },
+  "pass_2": { "status": "pending", "deepened_artifacts": [] },
+  "pass_3": { "status": "not_applicable" },
+  "total_artifacts": 0,
+  "last_updated": "{ISO 8601}"
+}
+EOF
+```
+2. Create todos for ALL phases (TaskCreate with blockedBy):
+   - Task: "Layer 1: Bird's Eye" (no blockers)
+   - Task: "Layer 2: Module Deep Dive" (blockedBy: Layer 1)
+   - Task: "Layer 3: Cross-Cutting" (blockedBy: Layer 1)
+   - Task: "Layer 4: Legacy Docs" (blockedBy: Layer 2, Layer 3)
+   - If --deep: Task: "Pass 2: Deepening" (blockedBy: Layer 4)
+   - If --full: Task: "Pass 3: Synthesis" (blockedBy: Pass 2)
+3. Create progress artifact:
+```bash
+forgeplan new note "Discovery Progress — {project_name}"
+# Body: markdown checklist with all phases (see protocol.json tracking.progress_artifact)
+```
+4. If Hindsight MCP available: `memory_retain("Starting discovery on {project}, mode: {mode}")`
+5. Begin Layer 1 Phase 1.1
+
+## On Each Phase Completion
+
+Every time you finish a phase (e.g., Phase 1.2 STRUCTURE):
+
+1. **TaskUpdate** → mark phase task as completed
+2. **State file** → update: add phase to `phases_done`, add artifact IDs, update `last_updated`
+3. **Progress artifact** → update body: change `- [ ] 1.2 STRUCTURE` to `- [x] 1.2 STRUCTURE → NOTE-002`
+4. Log to user: `Phase 1.2 complete → NOTE-002`
+
+## On Each Pass Completion
+
+When an entire pass finishes:
+
+1. All of "On Each Phase Completion" +
+2. **State file** → mark pass as `completed`
+3. **Summary Note** → `forgeplan new note "Pass {N} Summary — {project}"`
+4. If Hindsight: `memory_retain("Pass {N} complete: {count} artifacts. Key findings: {top_3}")`
+5. Report: `Pass {N} complete. {count} artifacts created.`
+
+## On Discovery Complete
+
+1. **Delete state file** — discovery is done, no resume needed
+```bash
+rm .forgeplan/discovery-state.json
+```
+2. **Progress artifact** → final update: all `[x]`, add completion timestamp
+3. If Hindsight: `memory_retain("Discovery complete on {project}: {mode}, {total} artifacts")`
+4. Final summary (see FINAL SUMMARY section below)
+5. `forgeplan health`
+
 ---
 
 # Discover Agent — Brownfield Codebase Onboarding

--- a/agents/discover/protocol.json
+++ b/agents/discover/protocol.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0",
+  "version": "3.1.0",
   "name": "discover",
   "description": "Brownfield codebase onboarding with layered analysis, multi-pass deepening, and tiered source priority",
 
@@ -370,6 +370,116 @@
     "deepens": "source adds detail to target (Pass 2 Note → Pass 1 RFC)"
   },
 
+  "tracking": {
+    "description": "Multi-level progress tracking — ensures agent never loses position across restarts, team mode, and long runs",
+
+    "state_file": {
+      "path": ".forgeplan/discovery-state.json",
+      "description": "Machine-readable state. Source of truth for agent position. Survives session restarts. Readable by team agents.",
+      "schema": {
+        "discovery_id": "string — unique ID (e.g., DISC-001)",
+        "project": "string — project name",
+        "mode": "string — default|deep|full",
+        "started_at": "ISO 8601 timestamp",
+        "pass_1": {
+          "status": "pending|in_progress|completed",
+          "layers": {
+            "1_birds_eye": {
+              "status": "pending|in_progress|completed",
+              "phases_done": ["1.1", "1.2"],
+              "artifacts": ["NOTE-001", "NOTE-002"]
+            },
+            "2_modules": {
+              "status": "pending|in_progress|completed",
+              "modules": {
+                "{module_name}": {
+                  "status": "pending|in_progress|completed",
+                  "current_phase": "2.3_DEPENDENCIES or null",
+                  "artifacts": ["RFC-001", "SPEC-001"]
+                }
+              }
+            },
+            "3_cross_cutting": { "status": "pending|in_progress|completed", "artifacts": [] },
+            "4_legacy_docs": { "status": "pending|in_progress|completed|skipped", "artifacts": [] }
+          }
+        },
+        "pass_2": { "status": "pending|in_progress|completed", "deepened_artifacts": [] },
+        "pass_3": { "status": "pending|in_progress|completed|not_applicable" },
+        "total_artifacts": "number",
+        "last_updated": "ISO 8601 timestamp"
+      }
+    },
+
+    "todos": {
+      "description": "Claude Code TaskCreate/TaskUpdate — runtime UX with spinner. Ephemeral (lost on restart), but provides real-time progress to user.",
+      "strategy": "Create all phase tasks upfront with blockedBy dependencies. Mark in_progress when starting, completed when done.",
+      "on_restart": "Recreate todos only for remaining phases (read state file first)."
+    },
+
+    "progress_artifact": {
+      "description": "ForgePlan Note with markdown checklist — human-readable progress visible in forgeplan list / forgeplan health.",
+      "artifact_kind": "note",
+      "title_template": "Discovery Progress — {project_name}",
+      "body_template": "## Discovery: {project_name}\nMode: {mode}\nStarted: {timestamp}\n\n### Pass 1: Discovery\n- [ ] Layer 1: Bird's Eye\n  - [ ] 1.1 DETECT\n  - [ ] 1.2 STRUCTURE\n  - [ ] 1.3 DATA STORES\n  - [ ] 1.4 INFRA\n  - [ ] 1.5 GIT OVERVIEW\n  - [ ] PRD created\n- [ ] Layer 2: Module Deep Dive\n  - [ ] {module_1}\n  - [ ] {module_2}\n  - [ ] ...\n- [ ] Layer 3: Cross-Cutting\n  - [ ] 3.1 DB Schema\n  - [ ] 3.2 Auth\n  - [ ] 3.3 Errors\n  - [ ] 3.4 Config\n  - [ ] 3.5 Integrations\n  - [ ] 3.6 Security\n- [ ] Layer 4: Legacy Docs\n\n### Pass 2: Deepening\n- [ ] Not started\n\n### Pass 3: Synthesis\n- [ ] Not started",
+      "update_rule": "Replace [ ] with [x] as phases complete. Add artifact IDs after each line."
+    },
+
+    "hindsight": {
+      "description": "Optional long-term memory via Hindsight MCP. Useful for multi-session discoveries.",
+      "when_available": "Check if mcp__hindsight__memory_retain is callable",
+      "retain_at": [
+        "discovery start (project name, mode, estimated size)",
+        "end of each pass (pass number, artifact count, key findings)",
+        "discovery complete (full summary, all artifact IDs)"
+      ],
+      "recall_at": [
+        "session start when state file exists",
+        "user says 'continue discovery' or 'resume'"
+      ],
+      "not_available_fallback": "State file + progress artifact are sufficient. Hindsight is bonus, not required."
+    },
+
+    "lifecycle": {
+      "on_fresh_start": [
+        "1. Check: does .forgeplan/discovery-state.json exist? If yes → go to on_resume",
+        "2. Create state file with status=pending for all passes/layers",
+        "3. Create todos (TaskCreate) for all phases with blockedBy dependencies",
+        "4. Create progress artifact: forgeplan new note 'Discovery Progress — {project}'",
+        "5. If Hindsight available: memory_retain('Starting discovery on {project}, mode: {mode}')",
+        "6. Begin Layer 1 Phase 1.1"
+      ],
+      "on_resume": [
+        "1. Read .forgeplan/discovery-state.json",
+        "2. If Hindsight available: memory_recall('discovery {project}')",
+        "3. Report to user: 'Resuming discovery from {last_incomplete_phase}'",
+        "4. Recreate todos (TaskCreate) for REMAINING phases only",
+        "5. Read progress artifact to verify alignment with state file",
+        "6. Continue from last incomplete phase"
+      ],
+      "on_phase_complete": [
+        "1. TaskUpdate → completed for this phase",
+        "2. Update state file: mark phase completed, add artifact IDs",
+        "3. Update progress artifact: [ ] → [x] for this phase",
+        "4. Log: 'Phase {id} complete → {artifact_id}'"
+      ],
+      "on_pass_complete": [
+        "1. All of on_phase_complete +",
+        "2. Update state file: mark pass as completed",
+        "3. If Hindsight available: memory_retain('Pass {N} complete: {artifact_count} artifacts, key findings: {top_3}')",
+        "4. Create pass summary Note: forgeplan new note 'Pass {N} Summary — {project}'",
+        "5. Report to user: 'Pass {N} complete. {artifact_count} artifacts created.'"
+      ],
+      "on_discovery_complete": [
+        "1. Delete state file (discovery is done, no resume needed)",
+        "2. Final update to progress artifact: all [x], add completion timestamp",
+        "3. If Hindsight available: memory_retain('Discovery complete: {mode}, {total_artifacts} artifacts, key: {summary}')",
+        "4. Create final summary Note with all artifact links",
+        "5. Run forgeplan health",
+        "6. Report to user with full summary"
+      ]
+    }
+  },
+
   "rules": [
     "ALWAYS complete Layer 1 before starting Layer 2",
     "ALWAYS complete Layers 1-3 before Layer 4 (docs)",
@@ -383,6 +493,9 @@
     "Use sampling strategy for modules with >50 source files",
     "Create summary Note at the end of each pass with links to ALL created artifacts",
     "Pass 2 agents MUST update existing artifacts, not create duplicates",
-    "Pass 3 synthesis MUST run forgeplan health as final check"
+    "Pass 3 synthesis MUST run forgeplan health as final check",
+    "ALWAYS check for .forgeplan/discovery-state.json before starting — resume if exists",
+    "ALWAYS update state file after each phase completion",
+    "ALWAYS maintain progress artifact checklist in sync with state file"
   ]
 }


### PR DESCRIPTION
## Summary
- Add 4-level progress tracking to discover agent for resilient, resumable discovery
- Level 1: TaskCreate/TaskUpdate — runtime UX spinner
- Level 2: `.forgeplan/discovery-state.json` — machine state, survives restarts, team-readable
- Level 3: ForgePlan Note checklist — human-readable progress in `forgeplan list`
- Level 4: Hindsight MCP — optional cross-session memory (retain/recall)

## Key Design Decisions
- State file is source of truth — always exists during discovery, deleted on completion
- Todos are ephemeral UX — recreated from state file on restart
- Progress artifact is permanent record — survives even after state file deleted
- Hindsight is optional bonus — graceful fallback if not connected

## Verification
- ✅ `protocol.json` valid JSON (v3.1.0, 16 rules, tracking lifecycle with 5 events)
- ✅ `agent.md` has PROGRESS TRACKING section with init/resume/update/complete flows
- ✅ `README.md` has tracking docs, resume example, progress artifact preview

## Test plan
- ✅ JSON validation passes with tracking section
- ✅ State file schema covers all phases/modules/passes
- ✅ Lifecycle covers: fresh start, resume, phase complete, pass complete, discovery complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)