### PR TITLE
docs: add discover agent + agent packs to all docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,22 @@ Hook bypass: временно убрать из `.claude/settings.json` (не р
 
 ---
 
+## Standalone Agents
+
+### Discover Agent (agents/discover/)
+
+Brownfield codebase onboarding — protocol v3.2.0.
+
+| Файл | Назначение |
+|------|-----------|
+| `agent.md` | Claude Code agent config — 3 modes, 3 passes, progress tracking |
+| `protocol.json` | Machine-readable protocol — layers, phases, rules, state schema |
+| `README.md` | Документация + примеры + manual workflow |
+
+**Не плагин** — standalone agent. Станет плагином после добавления MCP tools в ForgePlan CLI.
+
+---
+
 ## Quick Reference
 
 ```bash

--- a/README-RU.md
+++ b/README-RU.md
@@ -4,7 +4,7 @@
 
 Официальный маркетплейс плагинов Claude Code от [ForgePlan](https://github.com/ForgePlan) — UX, воркфлоу, инженерные и dev-инструменты.
 
-**5 плагинов** | **13 команд** | **5 агентов** | **4 хука** | **4 базы знаний** | [Руководство](docs/USAGE-GUIDE-RU.md)
+**10 плагинов** | **13 команд** | **60 агентов** | **1 standalone агент** | **4 хука** | **4 базы знаний** | [Руководство](docs/USAGE-GUIDE-RU.md)
 
 ## Быстрый старт
 
@@ -145,6 +145,74 @@ SKILL.md (роутер)
   → sections/02-cognitive/_index.md  → specific-law.md
   → sections/05-code-patterns/       → конкретные CSS/HTML/JS правила
 ```
+
+## Пакеты агентов
+
+Пять специализированных пакетов с 55 готовыми агентами для Claude Code.
+
+### [agents-core](plugins/agents-core/)
+
+> Базовые агенты разработки: debugger, code-reviewer, error-detective, performance-engineer, production-validator + полная dev-команда (coder, planner, researcher, reviewer, tester, TDD).
+
+```bash
+/plugin install agents-core@ForgePlan-marketplace
+```
+
+### [agents-domain](plugins/agents-domain/)
+
+> Специалисты по языкам и фреймворкам: TypeScript, Go, React, Next.js, Electron, embedded systems, mobile, WebSocket и др.
+
+```bash
+/plugin install agents-domain@ForgePlan-marketplace
+```
+
+### [agents-pro](plugins/agents-pro/)
+
+> Профессиональные специалисты: security, architecture, creative tools, research, infrastructure.
+
+```bash
+/plugin install agents-pro@ForgePlan-marketplace
+```
+
+### [agents-github](plugins/agents-github/)
+
+> GitHub-операции: PR, issues, releases, multi-repo, project boards, workflow engineering.
+
+```bash
+/plugin install agents-github@ForgePlan-marketplace
+```
+
+### [agents-sparc](plugins/agents-sparc/)
+
+> SPARC методология: оркестратор с quality gates + 4 фазовых специалиста (specification, pseudocode, architecture, refinement).
+
+```bash
+/plugin install agents-sparc@ForgePlan-marketplace
+```
+
+---
+
+## Standalone агенты
+
+### [discover](agents/discover/)
+
+> Онбординг brownfield-проектов — структурированный анализ с multi-pass discovery и приоритетом источников. Код первым, документация последней.
+
+Три режима для проектов любого размера:
+
+| Режим | Для | Что происходит |
+|-------|-----|----------------|
+| `default` | <100K LOC | Один агент, 4 слоя последовательно (~15-30 мин) |
+| `--deep` | 100K-2M LOC | Команда агентов, параллельные модули + углубление (~1-2 часа) |
+| `--full` | 2M+ LOC | Deep + синтез: анализ пробелов, карта влияния (~2-4 часа) |
+
+**3 прохода**: Discovery (слои 1-4) → Deepening (по артефактам) → Synthesis (перекрёстная проверка)
+**3 уровня доверия**: Код (T1, высший) > Тесты (T2) > Документация (T3, низший)
+**4 уровня отслеживания**: Todos + state file + артефакт прогресса + Hindsight (возобновляемый)
+
+Подробнее: [agents/discover/README.md](agents/discover/README.md)
+
+---
 
 ## Альтернатива: только Skill (через skills.sh)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Official plugin marketplace for Claude Code from [ForgePlan](https://github.com/ForgePlan) — UX, workflow, engineering, and developer tools.
 
-**10 plugins** | **13 commands** | **60 agents** | **4 hook configs** | **4 knowledge bases** | [Usage Guide](docs/USAGE-GUIDE.md) | [Architecture](docs/ARCHITECTURE.md)
+**10 plugins** | **13 commands** | **60 agents** | **1 standalone agent** | **4 hook configs** | **4 knowledge bases** | [Usage Guide](docs/USAGE-GUIDE.md) | [Architecture](docs/ARCHITECTURE.md)
 
 ## Quick Start
 
@@ -191,6 +191,28 @@ Five specialized agent packs providing 55 ready-to-use agents for Claude Code.
 ```bash
 /plugin install agents-sparc@ForgePlan-marketplace
 ```
+
+---
+
+## Standalone Agents
+
+### [discover](agents/discover/)
+
+> Brownfield codebase onboarding — structured analysis of existing projects with multi-pass discovery and tiered source priority. Code first, docs last.
+
+Three modes for any project size:
+
+| Mode | For | What happens |
+|------|-----|-------------|
+| `default` | <100K LOC | Single agent, 4 layers sequentially (~15-30 min) |
+| `--deep` | 100K-2M LOC | Team of agents, parallel modules + deepening (~1-2 hours) |
+| `--full` | 2M+ LOC | Deep + synthesis: gap analysis, impact mapping (~2-4 hours) |
+
+**3 passes**: Discovery (layers 1-4) → Deepening (per artifact) → Synthesis (cross-reference)
+**3 source tiers**: Code (T1, highest trust) > Tests (T2) > Docs (T3, lowest)
+**4-level tracking**: Todos + state file + progress artifact + Hindsight (resumable)
+
+See [agents/discover/README.md](agents/discover/README.md) for full documentation.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add discover agent to README.md (Standalone Agents section)
- Update README-RU.md: add all 5 agent packs + discover + fix stats (5→10 plugins, 60 agents)
- Add discover agent reference to CLAUDE.md

## Verification
- ✅ README.md has discover section with 3 modes table
- ✅ README-RU.md has agent packs + discover in Russian
- ✅ CLAUDE.md references agents/discover/

🤖 Generated with [Claude Code](https://claude.com/claude-code)