### PR TITLE
fix(ci): ban prompt-type hooks to prevent false blocks

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -103,6 +103,42 @@ jobs:
           done
           echo "All hooks validated"
 
+      - name: Ban prompt-type hooks
+        run: |
+          python3 << 'SCRIPT'
+          import json, os, sys
+          violations = []
+          for root, _, files in os.walk('plugins'):
+              for f in files:
+                  if f != 'hooks.json':
+                      continue
+                  path = os.path.join(root, f)
+                  with open(path) as fh:
+                      try:
+                          d = json.load(fh)
+                      except json.JSONDecodeError:
+                          continue
+                  def scan(obj, trail):
+                      if isinstance(obj, dict):
+                          if obj.get('type') == 'prompt':
+                              violations.append(f"{path}: {trail} uses type=prompt (BANNED)")
+                          for k, v in obj.items():
+                              scan(v, f"{trail}.{k}")
+                      elif isinstance(obj, list):
+                          for i, v in enumerate(obj):
+                              scan(v, f"{trail}[{i}]")
+                  scan(d, 'root')
+          if violations:
+              print('FAIL: prompt-type hooks are banned (non-deterministic, cause false blocks).')
+              print('      Use type=command with a bash/python script that exits 0 silently when not matching.')
+              print('      See CONTRIBUTING.md for details.')
+              print()
+              for v in violations:
+                  print(f'  {v}')
+              sys.exit(1)
+          print('OK: No prompt-type hooks found')
+          SCRIPT
+
       - name: Check SKILL.md frontmatter
         run: |
           set -o pipefail

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,38 @@ Add your plugin to `.claude-plugin/marketplace.json`:
 |-------|--------|-------|
 | Event | `PreToolUse`, `PostToolUse` | Top-level key |
 | `matcher` | Tool name or `\|`-joined list | e.g. `"Bash"`, `"Write\|Edit"` |
-| `type` | `"command"` | Only supported type |
+| `type` | `"command"` | **Only supported type — `"prompt"` is BANNED (see below)** |
 | `command` | Shell command | Use `${CLAUDE_PLUGIN_ROOT}` for paths |
 | `timeout` | Integer (seconds) | Recommended: 3-5 |
+
+### Why `"type": "prompt"` is banned
+
+Prompt-type hooks inject an LLM instruction into the agent ("Check the command and respond if X, else respond with empty string"). This is **non-deterministic** and causes two critical problems:
+
+1. **False blocks**: The LLM sometimes "thinks out loud" before returning empty, and its reasoning is interpreted by the harness as a stop signal. Result: agent halts on unrelated commands.
+2. **Token cost**: Every single tool call pays for an LLM round-trip, even when the hook should be silent.
+
+**Correct pattern — command hook with silent exit:**
+
+```bash
+#!/usr/bin/env bash
+# Hint about /sync only when forgeplan activate runs. Silent otherwise.
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+
+[ -z "$CMD" ] && exit 0
+
+case "$CMD" in
+  *"forgeplan activate"*)
+    echo '{"message":"Consider /sync to keep Orchestra in sync."}'
+    exit 0
+    ;;
+  *)
+    exit 0  # silent for all other commands
+    ;;
+esac
+```
+
+The CI check `Ban prompt-type hooks` enforces this rule — any `"type": "prompt"` in `hooks.json` fails the build.
 - [ ] README.md included in plugin directory


### PR DESCRIPTION
## Summary
Add CI enforcement banning \`\"type\": \"prompt\"\` in hooks.json files.

## Problem
Prompt-type hooks inject LLM instructions like "respond with empty string unless command matches X". The LLM sometimes reasons before responding empty, and harness interprets that reasoning as a stop signal. Result: false blocks on unrelated commands.

This was observed with old cached forgeplan-orchestra v1.0.0 — a grep command containing the string 'forgeplan activate' (inside a file it was searching) triggered the hook to block continuation.

## Fix
- CI step \`Ban prompt-type hooks\` scans all \`hooks.json\` for \`type=prompt\`, fails build
- CONTRIBUTING.md documents ban with correct command hook pattern
- All current plugins pass (no violations)

## Verification
- ✅ Local test: \`python3 -c scan\` on current plugins → no violations
- ✅ CI will catch any future regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)