### PR TITLE
feat(ci): auto-sync standalone skill mirrors (fpf, loux)

### DIFF
--- a/.github/workflows/sync-standalone-skills.yml
+++ b/.github/workflows/sync-standalone-skills.yml
@@ -1,0 +1,128 @@
+name: Sync Standalone Skill Mirrors
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'plugins/fpf/skills/fpf-knowledge/**'
+      - 'plugins/laws-of-ux/skills/ux-laws/**'
+      - '.github/workflows/sync-standalone-skills.yml'
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Which mirror(s) to sync'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - fpf
+          - loux
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - plugin: fpf
+            skill_path: plugins/fpf/skills/fpf-knowledge
+            target_repo: ForgePlan/fpf
+          - plugin: loux
+            skill_path: plugins/laws-of-ux/skills/ux-laws
+            target_repo: ForgePlan/loux
+
+    steps:
+      - name: Skip if not selected (manual run)
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TARGET: ${{ github.event.inputs.target }}
+          MATRIX_PLUGIN: ${{ matrix.plugin }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$INPUT_TARGET" != "all" ] && [ "$INPUT_TARGET" != "$MATRIX_PLUGIN" ]; then
+              echo "Skipping $MATRIX_PLUGIN (manual target=$INPUT_TARGET)"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout marketplace
+        if: steps.gate.outputs.skip != 'true'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: marketplace
+          fetch-depth: 1
+
+      - name: Checkout target standalone repo
+        if: steps.gate.outputs.skip != 'true'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ${{ matrix.target_repo }}
+          token: ${{ secrets.STANDALONE_SYNC_TOKEN }}
+          path: target
+          fetch-depth: 1
+
+      - name: Sync skill content
+        if: steps.gate.outputs.skip != 'true'
+        env:
+          SKILL_PATH: ${{ matrix.skill_path }}
+        run: |
+          set -euo pipefail
+          src="marketplace/$SKILL_PATH"
+          dst="target"
+
+          if [ ! -d "$src" ]; then
+            echo "::error::Source skill path not found: $src"
+            exit 1
+          fi
+
+          # Sync SKILL.md (overwrite — marketplace is source of truth)
+          cp "$src/SKILL.md" "$dst/SKILL.md"
+
+          # Sync sections/ — mirror exactly (deletes removed files)
+          rm -rf "$dst/sections"
+          cp -R "$src/sections" "$dst/sections"
+
+          # README.md and .gitignore are preserved (standalone-specific)
+
+          echo "Synced from $src to $dst"
+
+      - name: Commit and push if changed
+        if: steps.gate.outputs.skip != 'true'
+        working-directory: target
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+          SOURCE_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          TARGET_REPO: ${{ matrix.target_repo }}
+        run: |
+          set -euo pipefail
+          git config user.name "forgeplan-bot"
+          git config user.email "noreply@github.com"
+
+          git add -A SKILL.md sections
+
+          if git diff --cached --quiet; then
+            echo "No changes — skipping commit"
+            exit 0
+          fi
+
+          short_sha="${SOURCE_SHA:0:7}"
+
+          git commit -m "chore: sync from marketplace@${short_sha}
+
+          Auto-synced by .github/workflows/sync-standalone-skills.yml
+          Source: https://github.com/${SOURCE_REPO}/commit/${SOURCE_SHA}
+
+          Triggered by: ${EVENT_NAME}"
+
+          git push origin HEAD
+          echo "Pushed sync commit to ${TARGET_REPO}"

--- a/README-RU.md
+++ b/README-RU.md
@@ -208,16 +208,25 @@ SKILL.md (роутер)
 Если нужна только база знаний без команд, агентов и хуков:
 
 ```bash
-npx skills add ForgePlan/laws-of-ux-standalone -g
+# Laws of UX:
+npx skills add ForgePlan/loux -g
+
+# First Principles Framework:
+npx skills add ForgePlan/fpf -g
 ```
+
+Standalone-репо **автоматически зеркалируются** из маркетплейса — тот же контент, короткая команда установки. Issues и PR — в этот маркетплейс-репо.
+
+> Старый алиас `ForgePlan/laws-of-ux-standalone` всё ещё работает, но устарел — используйте `ForgePlan/loux`.
+
+### Плагин vs Skill — что включено
 
 | | Плагин (маркетплейс) | Skill (npx) |
 |---|:---:|:---:|
-| 30 UX-законов | Да | Да |
-| 9 файлов code patterns | Да | Да |
-| Команда `/ux-review` | Да | Нет |
-| Команда `/ux-law` | Да | Нет |
-| UX Reviewer агент | Да | Нет |
+| База знаний (законы / FPF spec) | Да | Да |
+| Файлы code patterns | Да | Да |
+| Slash-команды (`/ux-review`, `/fpf`, ...) | Да | Нет |
+| Reviewer / advisor агенты | Да | Нет |
 | Auto-hint хуки | Да | Нет |
 
 ## Обновление

--- a/README.md
+++ b/README.md
@@ -235,16 +235,25 @@ SKILL.md (router)
 If you only want the knowledge base without commands, agents, or hooks:
 
 ```bash
-npx skills add ForgePlan/laws-of-ux-standalone -g
+# Laws of UX:
+npx skills add ForgePlan/loux -g
+
+# First Principles Framework:
+npx skills add ForgePlan/fpf -g
 ```
+
+These standalone repos are **auto-mirrored** from the marketplace — same content, shorter install command. Issues and PRs go to this marketplace repo.
+
+> Legacy alias `ForgePlan/laws-of-ux-standalone` still works but is deprecated in favour of `ForgePlan/loux`.
+
+### Plugin vs Skill — what's included
 
 | | Plugin (marketplace) | Skill (npx) |
 |---|:---:|:---:|
-| 30 UX laws knowledge base | Yes | Yes |
-| 9 code pattern files | Yes | Yes |
-| `/ux-review` command | Yes | No |
-| `/ux-law` command | Yes | No |
-| UX Reviewer agent | Yes | No |
+| Knowledge base (laws / FPF spec) | Yes | Yes |
+| Code pattern files | Yes | Yes |
+| Slash commands (`/ux-review`, `/fpf`, ...) | Yes | No |
+| Reviewer / advisor agents | Yes | No |
 | Auto-hint hooks | Yes | No |
 
 ## Update


### PR DESCRIPTION
## Summary
- Add `.github/workflows/sync-standalone-skills.yml` — auto-mirrors FPF and Laws-of-UX skills to standalone repos on every push to `main`.
- Update `README.md` / `README-RU.md` with new short install commands: `npx skills add ForgePlan/fpf -g` and `npx skills add ForgePlan/loux -g`.

## What ships
| Mirror | Source path | Target repo |
|---|---|---|
| FPF | `plugins/fpf/skills/fpf-knowledge/` | [`ForgePlan/fpf`](https://github.com/ForgePlan/fpf) |
| LOUX | `plugins/laws-of-ux/skills/ux-laws/` | [`ForgePlan/loux`](https://github.com/ForgePlan/loux) |

Both standalone repos are already created and pre-populated with the initial content (manual first push). The workflow takes over from here.

## Verification
- `./scripts/validate-all-plugins.sh` — **ALL PASSED** (11 plugins, 13 commands, no collisions)
- YAML lint of new workflow file — pass
- Smoke test of standalone repos:
  - `npx skills add ForgePlan/fpf -l` → finds `fpf-knowledge` ✅
  - `npx skills add ForgePlan/loux -l` → finds `ux-laws` ✅
- Workflow uses **safe injection patterns** — all GitHub-context inputs go through `env:` blocks (per security_reminder hook).

## Required after merge
A maintainer must add a repo secret **before** the workflow can push:

1. Generate a fine-grained PAT with `contents:write` scope on `ForgePlan/fpf` AND `ForgePlan/loux` only.
2. Add it as `STANDALONE_SYNC_TOKEN` in repo Settings → Secrets and variables → Actions.
3. Manually trigger the workflow once via Actions UI to confirm green.

Until the secret is added, pushes to skill paths will fail the sync job (but won't affect plugin validation).

## Test plan
- [x] YAML syntax valid
- [x] No prompt-type hooks introduced
- [x] No command collisions
- [x] Standalone repos exist and serve content
- [x] README / README-RU updated bilingual
- [ ] Post-merge: add `STANDALONE_SYNC_TOKEN` secret
- [ ] Post-merge: trigger workflow_dispatch and verify both mirrors receive a no-op commit (or skip cleanly)

Refs: PRD-012