### PR TITLE
feat(forgeplan-workflow): v1.5.0 — Forgeplan v0.25.0 hint contract sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,25 +5,29 @@ All notable changes to the ForgePlan Marketplace will be documented in this file
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.7.0] — 2026-04-28
+## [1.7.0] - 2026-04-28
 
-### Changed — `forgeplan-workflow` 1.4.0 → 1.5.0
+Aligned `forgeplan-workflow` with Forgeplan v0.25.0 (PRD-071 unified hint contract). All plugins bumped to v1.5.0, marketplace catalog to v1.7.0.
 
-Aligned with Forgeplan v0.25.0 (PRD-071 unified hint contract).
+### Added
 
-- **New skill section** `06-output-hints/agent-protocol.md` — full agent reading protocol for the 5-rule hint contract (Next/Or/Wait/Done/Fix markers)
-- **`forgeplan-methodology` SKILL** — Query Router updated with new "hint protocol" topic; new top-level section "Hint Protocol" added
-- **`/forge-cycle` command** — new prelude step "Reading Forgeplan Output" instructing the agent to read contract markers after every command
-- **`forge-advisor` agent** — new behavior #5 "Hint Contract Awareness" — gently reminds when user/agent ignores `Next:`/`Fix:` markers
-- **README.md + README-RU.md** — feature mention of v1.5.0 hint contract awareness
+- `forgeplan-workflow`: new skill section `06-output-hints/agent-protocol.md` — full agent reading protocol for the 5-rule hint contract (Next/Or/Wait/Done/Fix markers)
+- `forgeplan-workflow`: new prelude step "Reading Forgeplan Output" in `/forge-cycle` command — instructs the agent to read contract markers after every command
+- `forgeplan-workflow`: new behavior #5 "Hint Contract Awareness" in `forge-advisor` agent — gently reminds when user/agent ignores `Next:`/`Fix:` markers (existing SPARC behavior renumbered to #6)
 
-### Why this matters
+### Changed
+
+- `forgeplan-workflow`: bumped to v1.5.0
+- Marketplace catalog: bumped to v1.7.0
+- `forgeplan-methodology` SKILL: Section router updated with new "hint protocol" topic; new top-level section "Hint Protocol" added
+- README.md + README-RU.md: feature mention of v1.5.0 hint contract awareness
+
+### Notes
 
 Without v1.5.0, users installing `forgeplan-workflow` get an agent that does NOT read the new hint markers — wastes Forgeplan v0.25.0's contract work. v1.5.0 closes the distribution gap.
 
-### Compatibility
-
-- Requires Forgeplan binary **≥ v0.25.0** for full benefit (older versions still work but agent will not see contract markers)
+Compatibility:
+- Requires Forgeplan binary >= v0.25.0 for full benefit (older versions still work but agent will not see contract markers)
 - Backward compat: existing `/forge-cycle`, `/forge-audit`, advisor behaviors unchanged
 
 ## [1.6.0] - 2026-04-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to the ForgePlan Marketplace will be documented in this file
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] — 2026-04-28
+
+### Changed — `forgeplan-workflow` 1.4.0 → 1.5.0
+
+Aligned with Forgeplan v0.25.0 (PRD-071 unified hint contract).
+
+- **New skill section** `06-output-hints/agent-protocol.md` — full agent reading protocol for the 5-rule hint contract (Next/Or/Wait/Done/Fix markers)
+- **`forgeplan-methodology` SKILL** — Query Router updated with new "hint protocol" topic; new top-level section "Hint Protocol" added
+- **`/forge-cycle` command** — new prelude step "Reading Forgeplan Output" instructing the agent to read contract markers after every command
+- **`forge-advisor` agent** — new behavior #5 "Hint Contract Awareness" — gently reminds when user/agent ignores `Next:`/`Fix:` markers
+- **README.md + README-RU.md** — feature mention of v1.5.0 hint contract awareness
+
+### Why this matters
+
+Without v1.5.0, users installing `forgeplan-workflow` get an agent that does NOT read the new hint markers — wastes Forgeplan v0.25.0's contract work. v1.5.0 closes the distribution gap.
+
+### Compatibility
+
+- Requires Forgeplan binary **≥ v0.25.0** for full benefit (older versions still work but agent will not see contract markers)
+- Backward compat: existing `/forge-cycle`, `/forge-audit`, advisor behaviors unchanged
+
 ## [1.6.0] - 2026-04-04
 
 ### Added

--- a/plugins/forgeplan-workflow/README-RU.md
+++ b/plugins/forgeplan-workflow/README-RU.md
@@ -76,6 +76,17 @@ Step 8: Commit
 | R_eff | Скоринг доказательств и quality gates |
 | Memory | Кросс-сессионная память через CLAUDE.md и Hindsight |
 
+### Hint Contract — контракт подсказок (v1.5.0+, требует Forgeplan v0.25.0+)
+
+Forgeplan v0.25.0 ввёл **5-правильный hint contract** — каждый CLI/MCP вывод emit'ит один из маркеров:
+- `Next: <command>` — основное действие
+- `Or: <command>` — альтернатива
+- `Wait: <condition>` — async retry
+- `Done.` — workflow complete
+- `Fix: <command>` — error remediation
+
+Этот плагин теперь учит агентов автоматически читать эти маркеры. Coverage в Forgeplan v0.25.0: **100%** (70/70 CLI команд). См. секцию `06-output-hints/agent-protocol.md` в методологии для полного протокола чтения.
+
 ## Лицензия
 
 MIT

--- a/plugins/forgeplan-workflow/README-RU.md
+++ b/plugins/forgeplan-workflow/README-RU.md
@@ -78,14 +78,14 @@ Step 8: Commit
 
 ### Hint Contract — контракт подсказок (v1.5.0+, требует Forgeplan v0.25.0+)
 
-Forgeplan v0.25.0 ввёл **5-правильный hint contract** — каждый CLI/MCP вывод emit'ит один из маркеров:
+Forgeplan v0.25.0 ввёл **hint contract из 5 правил** — каждый CLI/MCP вывод выдаёт один из маркеров:
 - `Next: <command>` — основное действие
-- `Or: <command>` — альтернатива
-- `Wait: <condition>` — async retry
-- `Done.` — workflow complete
-- `Fix: <command>` — error remediation
+- `Or: <command>` — резервный вариант
+- `Wait: <condition>` — асинхронный retry
+- `Done.` — workflow завершён
+- `Fix: <command>` — восстановление после ошибки
 
-Этот плагин теперь учит агентов автоматически читать эти маркеры. Coverage в Forgeplan v0.25.0: **100%** (70/70 CLI команд). См. секцию `06-output-hints/agent-protocol.md` в методологии для полного протокола чтения.
+Этот плагин теперь учит агентов автоматически читать эти маркеры. Покрытие в Forgeplan v0.25.0: **100%** (70/70 CLI команд). См. секцию `06-output-hints/agent-protocol.md` в методологии для полного протокола чтения.
 
 ## Лицензия
 

--- a/plugins/forgeplan-workflow/README.md
+++ b/plugins/forgeplan-workflow/README.md
@@ -76,6 +76,17 @@ Step 8: Commit
 | R_eff | Evidence scoring and quality gates |
 | Memory | Cross-session memory via CLAUDE.md and Hindsight |
 
+### Hint Contract (v1.5.0+, requires Forgeplan v0.25.0+)
+
+Forgeplan v0.25.0 introduced the **5-rule hint contract** — every CLI/MCP output emits one of:
+- `Next: <command>` — primary action
+- `Or: <command>` — fallback
+- `Wait: <condition>` — async retry
+- `Done.` — terminal
+- `Fix: <command>` — error remediation
+
+This plugin now teaches agents to read these markers automatically. Coverage in Forgeplan v0.25.0 binary: **100%** (70/70 CLI commands). See methodology skill section `06-output-hints/agent-protocol.md` for the full reading protocol.
+
 ## License
 
 MIT

--- a/plugins/forgeplan-workflow/agents/forge-advisor.md
+++ b/plugins/forgeplan-workflow/agents/forge-advisor.md
@@ -39,7 +39,22 @@ Do this at most once per session. Do not nag.
 When the user makes a significant architectural choice (new pattern, technology selection, major refactor direction), suggest:
 > "That's an important architectural decision. Want me to capture it as an ADR with `forgeplan new adr`?"
 
-### 5. SPARC for Deep Tasks
+### 5. Hint Contract Awareness (v0.25.0+)
+
+When you observe the user (or another agent) running `forgeplan` commands and **ignoring** the contract markers in output, gently surface:
+
+> "Forgeplan output emitted `Next: <command>` — that's the recommended next step. Want me to run it directly?"
+
+Specifically watch for:
+- User running `forgeplan validate PRD-X` then asking "what next?" → the output already had `Next:` line
+- Output with `Fix:` after `Error:` being treated as opaque error → suggest running the Fix
+- Output with `Done.` → don't suggest follow-up actions, workflow is complete
+
+Reference: methodology skill section `06-output-hints/agent-protocol.md`.
+
+This is a hint, not a gate — never block. If user prefers to interpret manually, that's fine.
+
+### 6. SPARC for Deep Tasks
 When the task is routed as Deep or involves architecture + implementation + testing (multi-phase work), suggest:
 > "This is a Deep task. Want to use SPARC methodology via `/sprint`? It structures the work into Specification -> Pseudocode -> Architecture -> Refinement phases with quality gates."
 

--- a/plugins/forgeplan-workflow/commands/forge-cycle.md
+++ b/plugins/forgeplan-workflow/commands/forge-cycle.md
@@ -7,6 +7,24 @@ You are executing the **forgeplan engineering cycle** — a structured workflow 
 
 Follow these steps in order. Do NOT skip steps. If a step fails, stop and report the issue.
 
+## Reading Forgeplan Output (v0.25.0+)
+
+After **every** `forgeplan` command in this cycle, read the contract marker:
+
+- `Next: <command>` → run it as the next step
+- `Fix: <command>` → run it to recover from error
+- `Or: <command>` → use only if primary `Next:` blocks
+- `Wait: <condition>` → retry after condition
+- `Done.` → step complete, move on
+
+JSON consumers read `_next_action` field. List/tree `--json` puts hint on stderr (bare array on stdout for jq compat).
+
+Full reference: [`forgeplan-methodology` skill section 06](../skills/forgeplan-methodology/sections/06-output-hints/agent-protocol.md).
+
+**Don't paraphrase or substitute placeholders** — execute the command exactly.
+
+---
+
 ## Step 1: Health Check
 
 Run `forgeplan health` to check the project state.

--- a/plugins/forgeplan-workflow/skills/forgeplan-methodology/SKILL.md
+++ b/plugins/forgeplan-workflow/skills/forgeplan-methodology/SKILL.md
@@ -175,6 +175,7 @@ Match the user's question to a section and read only that file (lazy load, save 
 | Depth, routing, tactical vs deep | `sections/03-depth/calibration.md` |
 | Scoring, R_eff, congruence, decay, CL levels | `sections/04-scoring/reff-scoring.md` |
 | Quality gates, adversarial review, audits | `sections/05-quality/gates.md` |
+| Reading forgeplan output, hints, Next:/Done./Fix: markers | `sections/06-output-hints/agent-protocol.md` |
 
 ---
 
@@ -217,3 +218,19 @@ progress checkpoints on long tasks.
 Don't create all 10 artifact types for every task. Tactical = just do it. Standard = PRD + RFC. Deep+ only needs the full pipeline when the decision is irreversible or cross-team.
 
 The goal is to **think before coding**, not to generate documents nobody reads.
+
+---
+
+## Hint Protocol (PRD-071, v0.25.0+)
+
+Every Forgeplan CLI/MCP output emits **one** contract marker telling the agent what to do next:
+
+- `Next: <command>` — primary action (run as-is, real IDs, no placeholders)
+- `Or: <command>` — alternate when primary blocks
+- `Wait: <condition>` — async/TTL retry signal
+- `Done.` — workflow complete (terminal)
+- `Fix: <command>` — error remediation (paired with `Error:`)
+
+**Read these markers FIRST after every command** — they replace methodology recall. The full contract spec, good/bad examples, and reading protocol live in `sections/06-output-hints/agent-protocol.md`.
+
+JSON consumers: read `_next_action` field in CLI JSON / MCP responses (or stderr `Next:` for `list --json` and `tree --json` which preserve bare-array stdout for backward compat).

--- a/plugins/forgeplan-workflow/skills/forgeplan-methodology/sections/06-output-hints/agent-protocol.md
+++ b/plugins/forgeplan-workflow/skills/forgeplan-methodology/sections/06-output-hints/agent-protocol.md
@@ -1,0 +1,190 @@
+# Agent Protocol — Reading Forgeplan Output (v0.25.0+)
+
+> Status: **Active** since Forgeplan v0.25.0 (PRD-071, 2026-04-27)
+>
+> Defines the contract between Forgeplan and any agent (Claude Code, Cursor, Windsurf, custom orchestrators) consuming its output. A single mental model works across all 5 surfaces: CLI text, CLI JSON, MCP success, CLI error, MCP error.
+
+## Why this contract exists
+
+Forgeplan is a methodology engine. Each command/tool call is one step in a longer workflow (Shape → Validate → Code → Evidence → Activate). When agents don't know what to do next, they:
+
+- Re-read CLAUDE.md to rediscover methodology
+- Guess and sometimes hallucinate
+- Loop on the same step
+
+Each costs tokens and risks correctness. **The contract eliminates ambiguity by guaranteeing every output carries an explicit, deterministic next-action.**
+
+## The 5-rule contract
+
+Every Forgeplan output, regardless of surface, satisfies these:
+
+1. **PRESENCE** — every response either emits a next-action OR is explicitly terminal. No silent gaps.
+2. **ACTIONABILITY** — the next-action is a full, copy-pasteable command with real IDs, never a fragment or placeholder.
+3. **DETERMINISM** — same input state always produces the same hint string. No randomness.
+4. **CONDITIONALITY** — hints appear only when actionable. Terminal states emit `Done.` rather than fake "all done!".
+5. **CONSISTENCY** — text and JSON renderings carry the same semantic content. CLI mirrors MCP semantics.
+
+## The 5 hint markers
+
+| Marker | When emitted | Agent action |
+|---|---|---|
+| `Next: <full command>` | Primary action — recommended next step | Execute exactly as written |
+| `Or: <command>` | Alternate when primary blocks (e.g. claim held) | Use only if primary fails |
+| `Wait: <condition>` | Async/TTL state | Retry after the condition |
+| `Done.` | Workflow complete (terminal) | Move on, do not loop |
+| `Fix: <command>` | Error remediation (paired with `Error:`) | Run the fix command immediately |
+
+## Surfaces and renderings
+
+| Surface | Where the hint lives | Format |
+|---|---|---|
+| **CLI text (success)** | last lines of stdout | `Next: <full command>` plus optional rationale |
+| **CLI text (error)** | after `Error:` line | `Fix: <full command>` |
+| **CLI JSON** | top-level field | `{"_next_action": "<command>" \| null, ...}` |
+| **MCP success** | top-level field | `_next_action: "<command>" \| null` |
+| **MCP error** | error data field | `error.data._next_action: "<command>"` |
+
+**Special case**: `forgeplan list --json` and `forgeplan tree --json` preserve bare-array stdout (backward compat for `jq '.[]'` consumers). The hint is emitted to **stderr** in JSON mode.
+
+## Good hints vs. bad hints
+
+### Good ✅
+
+```
+Next: forgeplan score PRD-001
+  R_eff is 0 — link evidence to enable activation
+```
+Specific, full command, real ID, rationale explains *why*.
+
+```
+Next: forgeplan dispatch --agents 3
+Or: forgeplan claim PRD-054 --agent worker-2 --ttl-minutes 30
+```
+One primary action, one explicit fallback.
+
+```
+Error: Direct status change to 'active' is not allowed.
+Fix: forgeplan activate PRD-001
+```
+Error has clear, executable remediation.
+
+### Bad ❌ (pre-v0.25.0 patterns)
+
+```
+suggested next: adi
+```
+Bare word, not a command. Agent has to guess.
+
+```
+Try a longer window: --since-hours 720
+```
+Fragment, not full command.
+
+```
+Either work on a different artifact, wait for TTL expiry,
+or ask the orchestrator to force-release.
+```
+Three options, none chosen as primary. Paradox of choice.
+
+```
+Workspace is free for any agent to claim work.
+```
+Terminal status without `Done.` exit signal.
+
+## Agent reading protocol
+
+When an agent receives any Forgeplan output:
+
+1. **Look for the next-action**.
+   - CLI text: scan for `Next:`, `Fix:`, `Wait:`, or `Done.` line
+   - CLI JSON: read `_next_action` field (or stderr `Next:` for list/tree)
+   - MCP: read `_next_action` field of response
+2. **Execute primary if present**.
+   - If `Next:` or `Fix:` — execute the command **exactly as written**
+   - Do not paraphrase, do not substitute placeholders
+   - Do not split into multiple commands
+3. **Use `Or:` only if primary blocks**.
+4. **On `Wait:`, retry after condition**.
+5. **On `Done.`, the workflow is complete** — move to next task, do not loop.
+6. **On no hint and not terminal — report a contract violation**. This is a bug in Forgeplan. Do not improvise.
+
+## What NOT to do
+
+1. **Don't paraphrase the hint** — full command is given for a reason
+2. **Don't combine `Next:` + `Or:`** in same call — pick one
+3. **Don't ignore `Done.`** — explicit terminal signal
+4. **Don't substitute `EVID-NNN` placeholders** — first run `forgeplan_new evidence`, then use the real ID
+5. **Don't panic on `Wait:`** — async/TTL is normal; just retry
+
+## Practical workflow patterns
+
+### Pattern A: Shape → Validate → Activate
+
+```
+forgeplan_route("add OAuth login")
+  → Next: forgeplan new prd "<title>"
+
+forgeplan_new(kind: "prd", title: "OAuth login support")
+  → Next: forgeplan validate PRD-042
+
+forgeplan_validate("PRD-042")
+  → Next: forgeplan activate PRD-042   (if PASS)
+  → Fix: forgeplan validate PRD-042    (if errors)
+
+forgeplan_activate("PRD-042")
+  → Done.
+```
+
+### Pattern B: Recovery from error
+
+```
+forgeplan_activate("PRD-042")
+  → Error: No evidence linked
+  → Fix: forgeplan validate PRD-042
+
+forgeplan_validate("PRD-042")
+  → Result: PASS
+  → Next: forgeplan score PRD-042
+```
+
+### Pattern C: Multi-agent dispatch
+
+```
+forgeplan_dispatch(--agents 3)
+  → Next: forgeplan claim PRD-054 --agent worker-1 --ttl 30
+  → Or:   forgeplan list --status draft
+
+forgeplan_claim("PRD-054")
+  → Error: Already held by worker-2
+  → Or: forgeplan release PRD-054 --force
+```
+
+## Drift prevention (in Forgeplan repo)
+
+- **Integration test** `crates/forgeplan-cli/tests/hint_contract.rs` — 36 tests, fails CI if any command lacks contract marker
+- **Audit script** `scripts/audit-hints.sh` — coverage metric, target 100%
+
+## Quick reference card
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  FORGEPLAN HINT CONTRACT (v0.25.0+)                     │
+├─────────────────────────────────────────────────────────┤
+│  Next:  <command>   → execute as-is                     │
+│  Or:    <command>   → fallback if primary blocks        │
+│  Wait:  <condition> → retry after condition             │
+│  Done.              → workflow complete, move on        │
+│  Fix:   <command>   → error remediation (with Error:)   │
+├─────────────────────────────────────────────────────────┤
+│  Read from: stdout (text), _next_action (JSON/MCP)      │
+│  Special:   list/tree --json → hint on stderr           │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Related
+
+- **Forgeplan v0.25.0 release** — first version shipping the contract
+- **PRD-071** in the Forgeplan repo — Unified hint contract specification
+- **PROB-046** — Original gap signal that triggered this work
+- **`docs/methodology/agent-protocol.md`** in Forgeplan repo — canonical contract source
+- Marketplace plugin **forgeplan-workflow v1.5.0** (this plugin) — agent-side awareness layer


### PR DESCRIPTION
## Summary

Aligns `forgeplan-workflow` plugin with **Forgeplan v0.25.0** (PRD-071 unified hint contract). Adds the content layer on top of the version bump done in commit 0f035b2.

Without this content sync, marketplace users get an agent that does NOT read the new `Next:` / `Or:` / `Wait:` / `Done.` / `Fix:` markers → wastes Forgeplan v0.25.0's contract work.

## What changed (7 files, +284 / −1)

| File | Change |
|------|--------|
| `skills/forgeplan-methodology/sections/06-output-hints/agent-protocol.md` | **NEW** — full agent reading protocol (190 lines) |
| `skills/forgeplan-methodology/SKILL.md` | Section router row + new "Hint Protocol" top-level section |
| `commands/forge-cycle.md` | New "Reading Forgeplan Output" prelude before Step 1 |
| `agents/forge-advisor.md` | New behavior #5 "Hint Contract Awareness" (SPARC bumped to #6) |
| `README.md` + `README-RU.md` | Feature mention of v1.5.0 hint contract awareness |
| `CHANGELOG.md` | New `[1.7.0] — 2026-04-28` entry at top |

## Verification

- ✅ `jq . .claude-plugin/marketplace.json` valid
- ✅ Plugin version `1.5.0` (`forgeplan-workflow`)
- ✅ Marketplace `metadata.version` `1.7.0`
- ✅ New section file exists (190 lines)
- ✅ CHANGELOG `[1.7.0]` entry present at top
- ✅ Diff scope: only `plugins/forgeplan-workflow/`, `.claude-plugin/`, `CHANGELOG.md`
- ✅ `./scripts/validate-all-plugins.sh forgeplan-workflow` → ALL PASSED

## Test plan

- [x] Validation script passes: `./scripts/validate-all-plugins.sh forgeplan-workflow`
- [x] All 8 spec tasks verified by content grep (Section router row, Hint Protocol section, forge-cycle prelude, advisor behavior #5, READMEs, CHANGELOG entry, section file)
- [x] No accidental edits to other plugins
- [x] After merge, users running `/plugin marketplace update forgeplan-marketplace` get hint-contract-aware agent

## Compatibility

- Requires Forgeplan binary **≥ v0.25.0** for full benefit
- Backward compat: existing `/forge-cycle`, `/forge-audit`, advisor behaviors unchanged
- `forge-advisor` SPARC behavior renumbered #5 → #6 (semantic: still active, just position shift)

Refs: ForgePlan/forgeplan PRD-071, EVID-086, PR #213 (v0.25.0 release)