### PR TITLE
feat(dev-toolkit): forge-report skill + /report command (v1.5.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.7.0"
+    "version": "1.8.0"
   },
   "plugins": [
     {
@@ -53,8 +53,8 @@
     {
       "name": "dev-toolkit",
       "source": "./plugins/dev-toolkit",
-      "description": "Universal engineering toolkit: multi-expert audit, wave-based sprints, session context recall, and safety hooks. Works with any project and language.",
-      "version": "1.4.0",
+      "description": "Universal engineering toolkit: multi-expert audit, wave-based sprints, session context recall, structured reports, and safety hooks. Works with any project and language.",
+      "version": "1.5.0",
       "author": {
         "name": "ForgePlan"
       },
@@ -67,6 +67,7 @@
         "code-review",
         "workflow",
         "quality",
+        "structured-reports",
         "universal"
       ]
     },

--- a/plugins/dev-toolkit/.claude-plugin/plugin.json
+++ b/plugins/dev-toolkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-toolkit",
-  "version": "1.4.0",
-  "description": "Universal engineering toolkit: multi-expert audit, wave-based sprints, session context recall, and safety hooks. Works with any project and language.",
+  "version": "1.5.0",
+  "description": "Universal engineering toolkit: multi-expert audit, wave-based sprints, session context recall, structured reports, and safety hooks. Works with any project and language.",
   "author": {
     "name": "ForgePlan"
   },
@@ -25,9 +25,9 @@
   },
   "supersedes": {},
   "components": {
-    "commands": ["audit", "sprint", "recall"],
+    "commands": ["audit", "sprint", "recall", "report"],
     "agents": ["dev-advisor"],
-    "skills": [],
+    "skills": ["forge-report"],
     "hooks": ["PreToolUse:Bash", "PostToolUse:Write|Edit|MultiEdit"]
   }
 }

--- a/plugins/dev-toolkit/commands/report.md
+++ b/plugins/dev-toolkit/commands/report.md
@@ -1,0 +1,63 @@
+---
+name: report
+description: "Generate a structured report for the recent work — pick template (build/audit/decision/incident/migration), apply forge-report skill conventions, output scannable summary with TL;DR, what's done, not-done, reversibility, drift risks, and next steps."
+---
+
+# /report — Structured Summary of Recent Work
+
+You are generating a **structured report** for the user about recent multi-step work in this conversation.
+
+## Step 1 — Load the forge-report skill
+
+Read the skill router: `plugins/dev-toolkit/skills/forge-report/SKILL.md`
+
+If the skill is not found at that path (e.g. user installed dev-toolkit globally), it should be auto-loaded from the installation. Don't fabricate format — always pull from the skill.
+
+## Step 2 — Pick the right template
+
+Scan the conversation for the dominant task type. Use this decision tree:
+
+1. **Created/built something new** (PR, files, feature, plugin) → `build-summary`
+2. **Reviewed/audited existing code** (security, architecture, quality) → `audit-summary`
+3. **Made a product/architecture decision** (chose between alternatives, recorded ADR) → `decision-summary`
+4. **Debugged or fixed an incident** (broken pipeline, prod issue, mysterious bug) → `incident-summary`
+5. **Refactored or migrated** (framework upgrade, restructure, schema change) → `migration-summary`
+
+If multiple apply, pick the one whose **next step** is most actionable for the user.
+
+If none apply (just Q&A, explanation, single edit) — say so:
+> "Recent work doesn't meet structured-report criteria. Here's a brief summary instead: ..."
+
+## Step 3 — Read the template + required sections
+
+For the chosen template:
+- `sections/01-templates/<template>.md` — type-specific structure
+- `sections/02-required-sections/` — TL;DR, not-done, reversibility, drift-risks, next-steps (all mandatory)
+- `sections/00-anchors/` — status icons, TL;DR rules, confidence labels
+
+## Step 4 — Generate the report
+
+Apply the template **strictly**:
+
+- TL;DR at the very top, 1-3 lines, ≤80 chars per line
+- Use single-legend status icons (✅⏳⚠️❌🔵⚪➡️) consistently
+- All 5 required sections present (use "—" if literally nothing applies)
+- Confidence labels (✅High/🟡Medium/⚠️Assumed) on uncertain claims
+- Cycle metadata at bottom (tool calls, files, time)
+
+## Step 5 — Self-check against anti-patterns
+
+Before sending, scan the report against:
+- `sections/03-anti-patterns/wall-of-text.md` — break prose into structure
+- `sections/03-anti-patterns/over-reporting.md` — if task was tiny, downscale to inline summary
+- `sections/03-anti-patterns/duplicate-info.md` — collapse repeated facts
+
+## Step 6 — Output
+
+Send the report. Don't add "Here's your report:" preamble — the structure is self-evident.
+
+## Notes
+
+- This command is **explicit** — user invoked `/report`, so always generate (don't skip even if task was small; user asked).
+- For automatic generation (without explicit `/report`), the global CLAUDE.md rule decides — see `~/.claude/CLAUDE.md` "Structured Reports" section.
+- If the conversation has no multi-step work to report on, say so honestly — do not fabricate content.

--- a/plugins/dev-toolkit/skills/forge-report/SKILL.md
+++ b/plugins/dev-toolkit/skills/forge-report/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: forge-report
+description: "Structured report formats for Claude. Use when finishing a multi-step task (≥5 tool calls, ≥3 files modified, multi-task TaskList, or cross-system effects like git push/PR/deploy). Triggers on: report, summary, summarise, отчёт, итоги, завершение задачи, build complete, audit complete, deployment complete, decision recorded, incident resolved, migration done. Provides 5 templates (build/audit/decision/incident/migration), anchor conventions (status icons, TL;DR, confidence), required sections (not-done, reversibility, drift-risks, next-steps), and anti-patterns. Not for simple Q&A or single-file edits."
+license: MIT
+---
+
+# forge-report — Structured Report Formats
+
+A library of templates and conventions for producing **clear, scannable, actionable** finishing reports after multi-step tasks. Designed for Claude Code agents.
+
+## When to use this skill
+
+Use when you finish a task that meets **≥2 of 4** criteria:
+
+1. ≥5 tool calls in this turn
+2. ≥3 files created or modified
+3. TaskList with ≥3 items
+4. Cross-system effect (git push, PR, deploy, external API call, secret added)
+
+For smaller tasks → use plain prose. Don't over-report.
+
+## How to use this skill (agentic RAG)
+
+This skill is a **router**. Follow these steps:
+
+### Step 1 — Pick the right template
+
+| Task type | Template | Section file |
+|---|---|---|
+| Built/created something new | `build-summary` | `01-templates/build-summary.md` |
+| Reviewed/audited code | `audit-summary` | `01-templates/audit-summary.md` |
+| Made + recorded a product decision | `decision-summary` | `01-templates/decision-summary.md` |
+| Debugged / resolved incident | `incident-summary` | `01-templates/incident-summary.md` |
+| Refactored / migrated something | `migration-summary` | `01-templates/migration-summary.md` |
+
+Don't see exact match? Pick the closest and adapt.
+
+### Step 2 — Load the anchor conventions
+
+Read these once per session (compact, ~30 lines each):
+
+- `00-anchors/status-icons.md` — single legend for ✅⏳⚠️❌🔵⚪➡️
+- `00-anchors/tldr-format.md` — TL;DR rules (1-3 lines, ≤80 chars)
+- `00-anchors/confidence-levels.md` — when to mark High/Medium/Assumed
+
+### Step 3 — Include required sections
+
+Every report must include (load from `02-required-sections/`):
+
+| Section | When | Why |
+|---|---|---|
+| TL;DR | Always, very top | Reader decides if they read further |
+| Not done | Always, even if obvious | Confirms boundaries respected |
+| Reversibility | When changes touch git/files/external | Trust + safety |
+| Drift risks | When artefacts cross-reference each other | Prevents future bit-rot |
+| Next steps | Always | Future-self / future-session pickup |
+
+### Step 4 — Avoid anti-patterns
+
+Before sending, scan against `03-anti-patterns/`:
+
+- `wall-of-text.md` — break into bullets/tables
+- `over-reporting.md` — small tasks don't need reports
+- `duplicate-info.md` — say it once, link the rest
+
+## Quick template skeleton
+
+```
+TL;DR: <1-3 lines, ≤80 chars per line>
+
+═══ ✅ <What was done> ═══════════════════════════════════════════
+  <items with What/Where/Status>
+
+═══ ⚪ Not done (intentional) ════════════════════════════════════
+  <items>
+
+═══ 🔄 Reversibility ════════════════════════════════════════════
+  Reversible: <items>
+  Irreversible: <items or "none">
+
+═══ ⚠️ Drift risks ═════════════════════════════════════════════
+  <items with mitigation>
+
+═══ ➡️ Next steps ══════════════════════════════════════════════
+  1. <action>
+  2. <action>
+
+💰 Cycle: <tool calls / files / time>
+```
+
+## Cross-references
+
+- Inside dev-toolkit: `/audit`, `/sprint`, `/recall` — sister utilities
+- Marketplace: `forge-report` is the format that other dev-toolkit commands should output to
+
+## Versioning
+
+This skill is shipped with `dev-toolkit` plugin. Version moves together.

--- a/plugins/dev-toolkit/skills/forge-report/sections/00-anchors/_index.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/00-anchors/_index.md
@@ -1,0 +1,22 @@
+# 00-anchors — Visual & semantic conventions
+
+Single source of truth for icons, TL;DR format, and confidence labels.
+**Read once per session**, then apply consistently across all reports.
+
+## Files
+
+| File | What it defines |
+|------|-----------------|
+| `status-icons.md` | The 7 status icons + when to use each |
+| `tldr-format.md` | TL;DR rules: length, position, content |
+| `confidence-levels.md` | Marking facts vs assumptions |
+
+## Why anchors matter
+
+A report scans easily only when **icons mean the same thing every time**.
+If ✅ sometimes means "done" and sometimes "verified", the reader stops trusting them.
+
+## When to update
+
+- New icon or convention → add a file here, then update SKILL.md examples.
+- Don't add icons "just to look pretty". Each must answer one question.

--- a/plugins/dev-toolkit/skills/forge-report/sections/00-anchors/confidence-levels.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/00-anchors/confidence-levels.md
@@ -1,0 +1,57 @@
+# Confidence Levels — Mark facts vs assumptions
+
+**Most bugs from Claude come from confidently stating assumptions.** Confidence labels separate verified facts from inference.
+
+## Three levels — traffic-light icons
+
+| Label | When to use | Example |
+|-------|-------------|---------|
+| 🟢 **High** | Verified by tool output (Read/Bash/test result) | `🟢 High: PR #24 merged (gh pr view returned state=MERGED)` |
+| 🟡 **Medium** | Inferred from context, not directly tested | `🟡 Medium: workflow likely green (last 3 runs were green)` |
+| 🔴 **Assumed** | Estimate, opinion, or unverified prediction | `🔴 Assumed: 4-6 hours to build (based on similar past tasks)` |
+
+**Important**: confidence icons (🟢🟡🔴) are a **separate namespace** from status icons (✅📝⏳⚠️❌🔵⚪➡️). Never mix them in the same column or sentence.
+
+## When to label
+
+Apply confidence when:
+- Stating **time estimates** ("X hours")
+- Making **predictions** ("this will work / fail")
+- Reporting **status** of things you didn't directly check
+- Claiming **causation** ("X happened because Y")
+
+Don't label when:
+- Direct quote from tool output (already verified)
+- Self-evident facts ("the file exists")
+- Obvious inferences ("PR is green because all 3 checks pass")
+
+## Format inline
+
+```
+🟢 High confidence — Workflow green (verified via gh run view 25020766130)
+🟡 Medium — Likely takes 2 minutes (not measured, similar to last sync)
+🔴 Assumed — Users will adopt by Q3 (no metrics yet)
+```
+
+## Format in tables
+
+```
+| Item | Status | Confidence |
+|------|--------|------------|
+| Repo created | ✅ | High |
+| CI will work | 🟡 | Medium (untested with secret) |
+| Adoption next month | ⚠️ | Assumed |
+```
+
+## Why this matters
+
+Without labels, the reader can't tell:
+- "It works" = verified or hoped?
+- "Takes 5 min" = measured or guessed?
+- "Safe to deploy" = tested in staging or based on dry-run?
+
+A 5-line report with confidence labels is more useful than a 50-line report without.
+
+## Anti-pattern
+
+Don't sprinkle "I think" / "probably" / "maybe" everywhere — that's noise. Use the 3-label system instead. 1 explicit label > 5 hedged sentences.

--- a/plugins/dev-toolkit/skills/forge-report/sections/00-anchors/status-icons.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/00-anchors/status-icons.md
@@ -1,0 +1,58 @@
+# Status Icons — Single Legend
+
+**Use these icons consistently across all reports. Don't invent new ones.**
+
+| Icon | Meaning | Example |
+|------|---------|---------|
+| ✅ | Done — verified successful | `✅ PR #24 merged, CI green` |
+| 📝 | Modified — files edited (vs created) | `📝 README.md (line 42, 1 char)` |
+| ⏳ | Pending — in progress or queued | `⏳ Deploy starting, ETA 5m` |
+| ⚠️ | Risk / warning — works but watch out | `⚠️ Rate limit at 80% capacity` |
+| ❌ | Failed — explicit failure to record | `❌ Migration rollback required` |
+| 🔵 | Info — context, no action needed | `🔵 Total tokens used: 6078` |
+| ⚪ | Not done — intentional, not forgotten | `⚪ Skipped UI tests (no display in CI)` |
+| ➡️ | Next step — action user should take | `➡️ Run gh secret set TOKEN ...` |
+
+## Confidence labels (separate system)
+
+Confidence uses a **distinct traffic-light set** to avoid colliding with status icons:
+
+| Icon | Meaning | Example |
+|------|---------|---------|
+| 🟢 | High — directly verified | `🟢 PR merged (gh pr view confirmed)` |
+| 🟡 | Medium — inferred, not tested | `🟡 Likely takes 2 min (similar to last sync)` |
+| 🔴 | Assumed — estimate or prediction | `🔴 4-6 hours to build (gut estimate)` |
+
+See `confidence-levels.md` for when to use each.
+
+## Rules
+
+1. **One icon per row** — don't combine like `✅⚠️`.
+2. **Icon goes first** — `✅ Item` not `Item ✅`.
+3. **Don't redecorate** — no 🎉🚀🔥 unless there's a real reason.
+4. **No icon = neutral statement** — that's also fine.
+
+## Anti-patterns
+
+- ❌ Using `✅` for "I tried" — only for verified.
+- ❌ Using `⚠️` for everything mildly uncertain — reserve for real risk.
+- ❌ Mixing emojis for the same concept (`✓` vs `✅`).
+
+## Why these 8 status + 3 confidence
+
+Status icons cover state:
+- Result: ✅ ❌
+- Change: 📝
+- In motion: ⏳
+- Caution: ⚠️
+- Context: 🔵
+- Boundaries: ⚪
+- Action: ➡️
+
+Confidence icons (🟢🟡🔴) live in a parallel "traffic-light" namespace — never mix them with status icons in the same column.
+
+Adding more icons makes the legend forgettable. If you feel the urge to invent one — try harder with the existing 11.
+
+## Section-header convention
+
+Some templates use icons as section markers, e.g. `═══ ✅ Created ═════`. In that context the icon **groups** items by category (here: completed items), it does NOT mean "this heading is verified". Treat the icon as a label, not a status.

--- a/plugins/dev-toolkit/skills/forge-report/sections/00-anchors/tldr-format.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/00-anchors/tldr-format.md
@@ -1,0 +1,59 @@
+# TL;DR Format
+
+**TL;DR is the first thing the reader sees. It decides whether they read further.**
+
+## Rules
+
+1. **Position**: very top, before any heading.
+2. **Length**: 1-3 lines, ≤80 characters per line. Exception: `incident-summary` may extend to 4 lines.
+3. **Content**: what changed + what user must do (if anything) + 1 risk if any.
+4. **Tense**: past for completed, present for state, imperative for actions.
+
+## Format
+
+```
+TL;DR: <what changed in 1 line>. <action user needs OR "no action needed">.
+       <one risk if applicable, omit otherwise>.
+```
+
+## Good examples
+
+```
+TL;DR: 3 PRD draft + NOTE-003 + Hindsight bank сохранены. Никаких действий не
+       требуется. Готово к активации по триггеру (см. NOTE-003).
+```
+
+```
+TL;DR: PR #24 merged, sync workflow зелёный. Установка ForgePlan/fpf и /loux
+       работает через npx. Дрейф: NOTE-002 — обновить actions/checkout до сент.
+```
+
+```
+TL;DR: Auth middleware добавлен, 12 тестов pass. Требуется secret JWT_SECRET
+       в .env перед деплоем.
+```
+
+## Bad examples
+
+```
+❌ TL;DR: Я выполнил задачу, всё хорошо.
+   (no specifics, no action, no risk)
+
+❌ TL;DR: Создал файл src/auth/middleware.ts с функцией authenticate(),
+   которая принимает токен из заголовка Authorization и проверяет его
+   через jwt.verify используя секрет из process.env.JWT_SECRET, после
+   успешной проверки устанавливает req.user и вызывает next(), а при
+   ошибке возвращает 401.
+   (это не TL;DR, это уже описание реализации)
+
+❌ TL;DR: 🎉 Готово!
+   (декорация без информации)
+```
+
+## When NOT to write TL;DR
+
+- Простая Q&A («что такое X?»)
+- Один tool call
+- Уже короткий ответ (<10 строк)
+
+В этих случаях TL;DR — оверхэд.

--- a/plugins/dev-toolkit/skills/forge-report/sections/01-templates/_index.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/01-templates/_index.md
@@ -1,0 +1,27 @@
+# 01-templates — 5 report templates
+
+Pick the one that matches your task type. If unsure, `decision-summary` is the safest default.
+
+| File | When to use |
+|------|-------------|
+| `build-summary.md` | Created/built something new (PR, feature, plugin, file) |
+| `audit-summary.md` | Reviewed/audited code, security, architecture |
+| `decision-summary.md` | Made + recorded a product/architecture decision |
+| `incident-summary.md` | Debugged or resolved an incident |
+| `migration-summary.md` | Refactored, migrated, modernised |
+
+## Common structure
+
+All templates share these sections (from `02-required-sections/`):
+
+1. TL;DR (top)
+2. Type-specific body (varies)
+3. Not done (intentional)
+4. Reversibility
+5. Drift risks
+6. Next steps
+7. Cycle metadata (tool calls, files, time)
+
+## Template selection rule
+
+If a task spans multiple types (e.g. "audit + fix" = audit + build) — use the one whose **next step** is most actionable for the reader.

--- a/plugins/dev-toolkit/skills/forge-report/sections/01-templates/audit-summary.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/01-templates/audit-summary.md
@@ -1,0 +1,82 @@
+# audit-summary — When you reviewed/audited
+
+Use after: code review, security audit, architecture review, dependency check, performance audit.
+
+## Template
+
+```
+TL;DR: <N findings, severity breakdown>. <action priority>. <biggest risk>.
+
+═══ 📊 Scope ═══════════════════════════════════════════════════════
+  Audited:   <files/modules/services>
+  Method:    <static analysis / manual review / tool used>
+  Duration:  <time spent>
+  Confidence: <High/Medium/Assumed — based on coverage>
+
+═══ ❌ Critical findings ═══════════════════════════════════════════
+  #N  <issue>                                          <where>
+       Impact: <what breaks>
+       Fix: <action>
+
+═══ ⚠️ High-priority findings ════════════════════════════════════
+  #N  <issue>  →  <where>  →  <fix>
+
+═══ 🔵 Medium / Low findings ═══════════════════════════════════
+  <count by severity, link to detailed findings file if many>
+
+═══ ✅ Strengths noted ═══════════════════════════════════════════
+  <what's done well — bias against only listing problems>
+
+═══ ⚪ Out of scope (intentional) ═══════════════════════════════
+  <what was NOT audited and why — also serves as Not-done section>
+
+═══ 🔄 Reversibility ════════════════════════════════════════════
+  Findings recorded — reversible (delete report).
+  Recommended fixes — not yet applied (no state change).
+  Irreversible: none (audit is read-only).
+
+═══ ⚠️ Drift risks ═════════════════════════════════════════════
+  Findings staleness: <when audit becomes outdated — code keeps changing>
+  Coverage gaps: <areas not audited may regress unnoticed>
+
+═══ ➡️ Next steps ══════════════════════════════════════════════
+  Immediate (P0): <fix critical>
+  This sprint (P1): <fix high>
+  Backlog (P2+): <medium/low → ticket>
+
+💰 Cycle: <N files reviewed> · <N findings> · <~minutes>
+```
+
+## Required minimums
+
+- ✅ Severity breakdown in TL;DR (e.g. "5C/17H/16M/9L")
+- ✅ At least one **Strengths** item — pure-negative audits feel hostile and miss balance
+- ✅ Confidence label on overall audit (small sample = lower confidence)
+- ⚪ Out-of-scope section is **mandatory** — defines audit boundary
+
+## Real-world example
+
+```
+TL;DR: 47 findings (5C/17H/16M/9L) in marketplace plugins. Critical: 3 hooks
+       allow injection. P0 fixes within 2 days. Strength: validation script
+       solid. Confidence: High (full plugin review).
+
+═══ ❌ Critical findings ═══════════════════════════════════════════
+  #1  prompt-type hooks bypass user consent              hooks.json (3 plugins)
+       Impact: arbitrary command execution
+       Fix: ban prompt type, require type=command
+
+═══ ✅ Strengths noted ═══════════════════════════════════════════
+  • CI validates plugin.json + hooks.json structure
+  • Hash-pinned actions in workflows (good supply chain hygiene)
+
+═══ ⚪ Out of scope (intentional) ═══════════════════════════════
+  • Agent prompts not audited (separate review needed)
+  • Performance audit (no perf SLOs defined yet)
+```
+
+## Anti-patterns
+
+- ❌ Listing only problems — appears hostile, misses what to preserve.
+- ❌ No severity → reader can't prioritise.
+- ❌ "Audited everything" — usually false; declare scope explicitly.

--- a/plugins/dev-toolkit/skills/forge-report/sections/01-templates/build-summary.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/01-templates/build-summary.md
@@ -1,0 +1,79 @@
+# build-summary — When you created something new
+
+Use after building: a feature, a plugin, a workflow, a set of files, a new repo.
+
+## Template
+
+```
+TL;DR: <what was built>. <verification status>. <one risk if any>.
+
+═══ ✅ Created ═══════════════════════════════════════════════════
+  <Component>     <Where>                              <Status>
+  <Component>     <Where>                              <Status>
+
+═══ 📝 Modified ═════════════════════════════════════════════════
+  <File>          <Type of change>                     <Lines: +/-/~>
+
+═══ ⚪ Not done (intentional) ════════════════════════════════════
+  <Item — why skipped>
+
+═══ ✅ Verification ═════════════════════════════════════════════
+  <Check>         <Result>                             <Confidence>
+  CI              <pass/fail>                          <🟢/🟡>
+  Smoke test      <pass/fail>                          <🟢/🟡>
+  Lint            <pass/fail>                          <🟢>
+
+═══ 🔄 Reversibility ════════════════════════════════════════════
+  Reversible: <list — git revert, rm files, etc.>
+  Irreversible: <list or "none">
+
+═══ ⚠️ Drift risks ═════════════════════════════════════════════
+  <Risk>          <When it bites>                      <Mitigation>
+
+═══ ➡️ Next steps ══════════════════════════════════════════════
+  1. <action>
+  2. <action>
+
+💰 Cycle: <N tool calls> · <N files> · <~minutes>
+```
+
+## Required minimums
+
+- ✅ At least one item in **Created** OR **Modified**
+- ✅ At least one **Verification** row
+- ✅ TL;DR mentions verification status
+- ⚪ Not-done section even if "nothing intentionally skipped" (then write "—")
+
+## Real-world example
+
+```
+TL;DR: forge-report skill добавлен в dev-toolkit, 23 файла, плагин bumped
+       до v1.5.0. CI green. Drift risk: cc-best PRD ссылается на этот skill.
+
+═══ ✅ Created ═══════════════════════════════════════════════════
+  forge-report SKILL.md   plugins/dev-toolkit/skills/forge-report/   New
+  /report command         plugins/dev-toolkit/commands/report.md     New
+  5 templates             sections/01-templates/                     New
+  ...
+
+═══ ✅ Verification ═════════════════════════════════════════════
+  CI                      pass (8s)                                  🟢 High
+  validate-plugins.sh     ALL PASSED                                 🟢 High
+  Smoke /report           manual test pending                        🔴 Assumed
+
+═══ 🔄 Reversibility ════════════════════════════════════════════
+  Reversible: revert PR #25, rm plugins/dev-toolkit/skills/
+  Irreversible: none
+
+═══ ➡️ Next steps ══════════════════════════════════════════════
+  1. Test /report on a real task
+  2. Update marketplace README
+
+💰 Cycle: 31 calls · 23 files · 45 min
+```
+
+## When NOT to use this template
+
+- Modified single file → just describe inline, no template needed.
+- Built something but didn't verify → use `incident-summary` (something broke).
+- Built + decided architecture → use `decision-summary` (decision is bigger).

--- a/plugins/dev-toolkit/skills/forge-report/sections/01-templates/decision-summary.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/01-templates/decision-summary.md
@@ -1,0 +1,84 @@
+# decision-summary — When you made and recorded a product/architecture decision
+
+Use after: choosing between alternatives, recording an ADR, fixing a roadmap, prioritising backlog.
+
+## Template
+
+```
+TL;DR: <decision in 1 sentence>. <why now>. <when to revisit>.
+
+═══ 🎯 Decision ════════════════════════════════════════════════════
+  What:        <chosen option>
+  Alternatives: <what was rejected and why>
+  Trigger:     <what forced this decision>
+
+═══ 📊 Trade-offs ════════════════════════════════════════════════
+  | Option   | Pros           | Cons              | Score   |
+  |----------|----------------|-------------------|---------|
+  | <chosen> | <list>         | <list>            | ✅      |
+  | <other>  | <list>         | <list>            | ❌ <reason> |
+
+═══ ✅ Recorded as ════════════════════════════════════════════════
+  <ADR-NNN / NOTE-NNN / PRD-NNN>                       <where>
+  <related artefact>                                   <where>
+
+═══ ⚪ Not decided yet (deferred) ════════════════════════════════
+  <open question>     <when to revisit>
+
+═══ 🔄 Reversibility ════════════════════════════════════════════
+  Reversible: revert artefact files (rm/git revert) — decision uncommits
+  Reversible: supersede via new ADR/PRD with `supersedes` link
+  Irreversible: <if any external commitment was made>
+
+═══ ⚠️ Drift risks ═══════════════════════════════════════════════
+  <If <X> changes>     →  <decision invalidates>
+
+═══ ➡️ Next steps / Activation triggers ═════════════════════════
+  This decision is documented but not "started". Activate when:
+  - <condition>
+  - <condition>
+
+  Or, if action is immediate:
+  1. <action>
+  2. <action>
+
+💰 Cycle: <N artefacts created> · <discussion turns> · <~minutes>
+```
+
+## Required minimums
+
+- ✅ At least 2 alternatives in trade-off table (if only 1 considered → reframe as "no real choice")
+- ✅ "Recorded as" — link to durable artefact (ADR/NOTE/PRD), not just chat
+- ⚪ Drift risks — what would invalidate this decision?
+- ➡️ Activation triggers — when does decision become an action?
+
+## Real-world example
+
+This very report (the conversation about saving 3 PRD drafts) is a `decision-summary`:
+
+```
+TL;DR: 3 PRD drafts (013/014/015) + NOTE-003 roadmap фиксированы. Drift risk:
+       PRD-015 устаревает к Q3 2026 без активации. Активировать по триггерам.
+
+═══ 🎯 Decision ════════════════════════════════════════════════════
+  What:        Делать все 3 standalone skills, в порядке 014→013→015
+  Alternatives: Делать только 1 (узко) / Не делать (потеря momentum)
+  Trigger:     User explicit: "буду делать всё, но сперва зафиксировать"
+
+═══ ✅ Recorded as ════════════════════════════════════════════════
+  PRD-013      .forgeplan/prds/PRD-013-...md         draft
+  PRD-014      .forgeplan/prds/PRD-014-...md         draft
+  PRD-015      .forgeplan/prds/PRD-015-...md         draft
+  NOTE-003     .forgeplan/notes/NOTE-003-...md       active
+
+═══ ➡️ Activation triggers ═══════════════════════════════════════
+  - Пользовательский запрос на standalone skill
+  - Adoption fpf/loux выше порога
+  - Свободное время + желание
+```
+
+## When NOT to use
+
+- Decided alone, no alternatives existed → just announce inline.
+- Decision affects only this turn → context evaporates anyway.
+- Already recorded in ADR/PRD by tool — link, don't duplicate.

--- a/plugins/dev-toolkit/skills/forge-report/sections/01-templates/incident-summary.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/01-templates/incident-summary.md
@@ -1,0 +1,98 @@
+# incident-summary — When you debugged or resolved an incident
+
+Use after: production incident, failing test investigation, mysterious bug fix, broken pipeline.
+
+## Template
+
+```
+TL;DR: <symptom>. Root cause + fix: <one line>. <prevention or risk>.
+       (Incidents may use up to 4 lines if all 4 facts cannot compress.)
+
+═══ 🔥 Symptom ═══════════════════════════════════════════════════
+  Observed:    <what user/system saw>
+  When:        <timestamp / commit / version>
+  Severity:    <P0 outage / P1 degraded / P2 cosmetic>
+  Discovered:  <how it surfaced — alert / user report / spotted>
+
+═══ 🔍 Root cause ════════════════════════════════════════════════
+  <One paragraph: what actually broke and why>
+
+  Confidence: <🟢High / 🟡Medium / 🔴Assumed>
+  Evidence: <log line / commit / test that confirms>
+
+═══ ✅ Fix applied ═══════════════════════════════════════════════
+  <Where>                              <What changed>
+  <Where>                              <What changed>
+
+═══ ✅ Verification ═════════════════════════════════════════════
+  <Check>                              <Result>
+  Failing test now passes              ✅
+  Symptom not reproducible             ✅
+  Related tests still green            ✅
+
+═══ ⚪ Not done (intentional) ════════════════════════════════════
+  <related issue not addressed in this incident — why deferred>
+  <broader refactor postponed for separate task>
+
+═══ 🔄 Reversibility ════════════════════════════════════════════
+  Fix reversible: <git revert path>
+  Workaround reversible until: <date — when proper fix lands>
+  Irreversible: <if data was modified / migrated mid-incident>
+
+═══ ⚠️ Drift risks ═══════════════════════════════════════════════
+  <If similar code path is added — same bug returns>
+  <Workaround that should be replaced with proper fix>
+
+═══ 🛡️ Prevention ═══════════════════════════════════════════════
+  <Test added / lint rule / CI check / runbook update>
+  <If "none" — explain why prevention is impractical>
+
+═══ ➡️ Next steps / Post-mortem follow-ups ═════════════════════
+  - <action>     <owner>     <due>
+  - <action>     <owner>     <due>
+
+💰 Cycle: <time-to-detect> · <time-to-fix> · <N tool calls>
+```
+
+## Required minimums
+
+- ✅ Confidence label on root cause (often we *think* we know, but didn't fully verify)
+- ✅ Verification step ≠ "code compiles" — must reproduce + fail-then-pass
+- ✅ Prevention is **mandatory** — even if it's "no test possible, added runbook entry"
+- ⚪ If incident is partially understood → say so explicitly, don't pretend full RCA
+
+## Real-world example
+
+```
+TL;DR: sync-standalone-skills.yml упал с "Input required and not supplied: token".
+       Root cause: secret STANDALONE_SYNC_TOKEN не был добавлен в маркетплейс.
+       Fix: maintainer добавил PAT через `gh secret set`. Prevention: README
+       в PR описывает шаг.
+
+═══ 🔥 Symptom ═══════════════════════════════════════════════════
+  Observed:    Workflow run 24954866577 failed at "Checkout target repo"
+  When:        2026-04-26T10:53Z (auto-trigger after PR #24 merge)
+  Severity:    P2 (cosmetic — sync mechanism not yet in production use)
+
+═══ 🔍 Root cause ════════════════════════════════════════════════
+  actions/checkout step requires token input. Token is supplied via
+  ${{ secrets.STANDALONE_SYNC_TOKEN }}. Secret was not present in
+  ForgePlan/marketplace, so the expression evaluated to empty.
+
+  Confidence: 🟢 High
+  Evidence: gh run view 25020112103 shows "token: ***" but error
+            "Input required and not supplied: token"
+
+═══ ✅ Fix applied ═══════════════════════════════════════════════
+  ForgePlan/marketplace settings   Added secret STANDALONE_SYNC_TOKEN
+
+═══ ✅ Verification ═════════════════════════════════════════════
+  Re-trigger workflow              ✅ pass (run 25020766130)
+  Idempotency (no diff = no commit) ✅ confirmed
+```
+
+## Anti-patterns
+
+- ❌ "Fixed it" without root cause — bug returns next sprint.
+- ❌ Verification = "deployed" — that's not verification, that's deployment.
+- ❌ No prevention → repeats.

--- a/plugins/dev-toolkit/skills/forge-report/sections/01-templates/migration-summary.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/01-templates/migration-summary.md
@@ -1,0 +1,89 @@
+# migration-summary — When you refactored or migrated
+
+Use after: framework upgrade, dependency migration, restructure, rename, schema migration, big refactor.
+
+## Template
+
+```
+TL;DR: <from X to Y>. <N files changed>. <verification>. <rollback path>.
+
+═══ 🔀 Migration scope ═══════════════════════════════════════════
+  From:        <old version / framework / structure>
+  To:          <new version / framework / structure>
+  Reason:      <why now — deprecation, perf, debt>
+  Strategy:    <big bang / gradual / dual-write / parallel>
+
+═══ 📝 Affected ══════════════════════════════════════════════════
+  Files:       <count + key paths>
+  Tests:       <count> updated, <count> new
+  Docs:        <updated paths>
+  Schema/DB:   <changes if any>
+
+═══ ✅ Verification ═════════════════════════════════════════════
+  <Check>                              <Result>     <Confidence>
+  All tests pass                       <result>     <label>
+  Functional smoke                     <result>     <label>
+  Performance vs baseline              <result>     <label>
+  Backward compatibility               <result>     <label>
+
+═══ ⚪ Not migrated (intentional) ════════════════════════════════
+  <Item — why skipped, when planned>
+
+═══ 🔄 Rollback procedure ════════════════════════════════════════
+  Reversible: <how to roll back if needed — git revert, feature flag, schema down>
+  Window:     <until rollback becomes risky — e.g. "before next migration runs">
+  Irreversible: <list or "none">
+
+═══ ⚠️ Drift risks ═══════════════════════════════════════════════
+  <New code may introduce old patterns — add lint rule>
+  <Stale references in docs / comments>
+
+═══ 📈 Adoption signal ═══════════════════════════════════════════
+  How we'll know this migration succeeded:
+  - <metric / signal>
+  - <metric / signal>
+
+═══ ➡️ Next steps ══════════════════════════════════════════════
+  1. <action>
+  2. <action>
+
+💰 Cycle: <N files> · <N commits> · <~hours>
+```
+
+## Required minimums
+
+- ✅ Strategy named (big-bang, gradual, dual-write, parallel)
+- ✅ Rollback procedure even if "git revert" — never skip
+- ✅ Drift risks — migrations leave half-old/half-new state somewhere
+- ✅ Adoption signal — how to know it actually worked in production
+
+## Real-world example
+
+```
+TL;DR: Auth middleware migrated from express-jwt to jose. 14 files changed,
+       all tests green. Rollback: git revert (single commit). Drift risk:
+       legacy services still import old middleware path.
+
+═══ 🔀 Migration scope ═══════════════════════════════════════════
+  From:        express-jwt 6.x (deprecated, no maintenance)
+  To:          jose 5.x (active, ESM-native)
+  Reason:      CVE-2024-XXXXX in express-jwt, no patch
+  Strategy:    Big bang (single PR, all callers updated)
+
+═══ ✅ Verification ═════════════════════════════════════════════
+  Unit tests (auth)                    98/98 pass    🟢 High
+  E2E login flow                       pass          🟢 High
+  Performance JWT verify               -8% latency   🟡 Medium (small sample)
+  Backward compat (token format)       same JWT spec 🟢 High
+
+═══ 🔄 Rollback procedure ════════════════════════════════════════
+  Reversible: `git revert <commit>` then `npm install` — 5 min
+  Window:     Before rotating signing keys (planned 2026-05-15)
+  Irreversible: none until key rotation
+```
+
+## Anti-patterns
+
+- ❌ "Migration complete!" without verification — false confidence.
+- ❌ No rollback plan — code stuck after first issue.
+- ❌ No drift risks — migration leaves zombie code paths.

--- a/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/_index.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/_index.md
@@ -1,0 +1,24 @@
+# 02-required-sections — Mandatory blocks for every report
+
+These sections appear in **every** template. Their job is to surface
+what's normally invisible: boundaries, risks, future state.
+
+## Files
+
+| File | Section | Why mandatory |
+|------|---------|---------------|
+| `tldr.md` | TL;DR | Reader scans first 3 lines |
+| `not-done.md` | What was NOT done | Confirms boundaries |
+| `reversibility.md` | What can be rolled back | Trust + safety |
+| `drift-risks.md` | What may decay over time | Future maintenance |
+| `next-steps.md` | What user does next | Pickup pointer |
+
+## Why "required" matters
+
+Optional sections get skipped, then forgotten. **Mandatory sections force the author to think about them**, even if the answer is "—" (none).
+
+A 5-line "Not done: nothing intentionally skipped" is more useful than silence — it confirms the author *thought* about boundaries.
+
+## Compactness rule
+
+Required sections should be compact. If a section needs >5 lines, consider splitting into a dedicated section under the type-specific body.

--- a/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/drift-risks.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/drift-risks.md
@@ -1,0 +1,57 @@
+# Drift risks — Required section
+
+Describe what may **decay over time** — even though it works now.
+
+## Why this matters
+
+Most production bugs are not "code is wrong" — they are "code was right when written, but conditions changed":
+- Dependency updated, breaking assumption
+- Config drifted between environments
+- Cross-references stale (file renamed, link dead)
+- API quietly changed
+- Secret expired
+
+A "drift risk" entry tells future-you: **"watch this".**
+
+## Format
+
+```
+═══ ⚠️ Drift risks ═════════════════════════════════════════════
+  <Risk>                              <When it bites>           <Mitigation>
+  <Risk>                              <When it bites>           <Mitigation>
+```
+
+## Concrete examples
+
+```
+NOTE-003 references PRD-013/014/015     If PRD renamed              Update NOTE
+PAT STANDALONE_SYNC_TOKEN expires       2027-04 (fine-grained 1y)   Calendar reminder
+actions/checkout v4 uses Node 20        2026-09-16 (deprecation)    Bump to v5
+hardcoded URL https://api.x.com         If endpoint moves           Move to .env
+```
+
+## What counts as drift
+
+| Source | Example |
+|--------|---------|
+| External API change | Stripe v2024-06 → v2024-09 |
+| Dependency breaking change | React 18 → 19 |
+| Time-based expiry | Cert / token / key rotation |
+| Linked artefacts | NOTE references PRD by ID |
+| Implicit assumptions | "user count < 1M" |
+| Config sprawl | Same value in 3 files |
+
+## When you can write "—"
+
+Truly stable change: pure isolated function, no external deps, no cross-refs. Then:
+
+```
+═══ ⚠️ Drift risks ═════════════════════════════════════════════
+  — (isolated change, no external dependencies)
+```
+
+But this should be **rare**. Most non-trivial work has some drift.
+
+## Anti-pattern
+
+Don't list every theoretical risk ("internet might go down"). Drift = **specific to this change**.

--- a/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/next-steps.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/next-steps.md
@@ -1,0 +1,59 @@
+# Next steps — Required section
+
+Tell the reader: **what should happen next, in what order, by whom**.
+
+## Why this matters
+
+The end of one task is rarely the end of the work. Without explicit "next steps":
+- User has to re-derive context to figure out what to do
+- Future-you (in next session) doesn't know where to pick up
+- Hand-offs break at agent/team boundaries
+
+This section is the **pickup pointer** for resumption.
+
+## Format
+
+```
+═══ ➡️ Next steps ══════════════════════════════════════════════
+  1. <action>     <who>     <when>
+  2. <action>     <who>     <when>
+  3. <action>     <who>     <when>
+```
+
+## Concrete examples
+
+```
+1. Test /report on a real task           you           today
+2. Update marketplace README             me            after merge
+3. Bump dev-toolkit dependents           none          when other plugins
+                                                       reference forge-report
+```
+
+## Three types of "next"
+
+| Type | Example | Notes |
+|------|---------|-------|
+| **Immediate** | "Run smoke test" | Within minutes-hours |
+| **Soon** | "Add to CI" | Within days |
+| **Conditional** | "When X happens, do Y" | Pickup trigger |
+
+Mix these — but always order by urgency.
+
+## When OK to skip
+
+If task is **fully self-contained and final**:
+- Standalone Q&A
+- Simple lookup
+- Confirmation-only response
+
+Then skip. But check honestly — most tasks have at least "verify it worked".
+
+## Pickup line for future sessions
+
+If this report will outlive the conversation, add at the end:
+
+```
+➡️ Future session pickup: open NOTE-003 → see roadmap → pick PRD-014
+```
+
+A single line that lets a fresh Claude restart effectively.

--- a/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/not-done.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/not-done.md
@@ -1,0 +1,46 @@
+# Not done (intentional) — Required section
+
+Explicitly list what was **not** done — and that this was on purpose.
+
+## Why this matters
+
+Without an explicit "Not done" section:
+- User worries "did Claude touch X by accident?"
+- Boundaries between scope and out-of-scope are unclear
+- Future Claude (different session) may assume task wasn't fully attempted
+
+A 1-line "⚪ Not done: deployment to prod (waiting for approval)" prevents 5 minutes of "did we deploy?".
+
+## Format
+
+```
+═══ ⚪ Not done (intentional) ════════════════════════════════════
+  <Item — why skipped>
+  <Item — why skipped>
+```
+
+Use ⚪ icon (not ❌ — that's failure, ⚪ is intentional skip).
+
+## What to include
+
+- **Out-of-scope** items mentioned but not done
+- **Optional steps** explicitly skipped (with reason)
+- **Tests not run** (and why — e.g. "no UI in CI")
+- **Files not modified** when they could have been
+- **Steps deferred** to future task
+
+## What NOT to include
+
+- Things you forgot (those are bugs, not "not done")
+- Trivially out-of-scope (don't list "didn't update README of unrelated repo")
+- Speculation about what user *might* want (don't list everything you imagined)
+
+## When OK to write "—"
+
+If literally nothing was intentionally skipped, write:
+```
+═══ ⚪ Not done (intentional) ════════════════════════════════════
+  — (full task scope completed)
+```
+
+This still proves you thought about it.

--- a/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/reversibility.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/reversibility.md
@@ -1,0 +1,51 @@
+# Reversibility — Required section
+
+Tell the reader: **what can be undone, what cannot, and how**.
+
+## Why this matters
+
+Trust = predictability. If user knows "I can revert this in 30 seconds", they take more risks. If they don't know — they freeze.
+
+Especially important after:
+- File creates / modifications
+- Git operations (commits, merges, branches)
+- External system effects (PR, deploy, secret added, ticket created)
+- Long-running migrations / data transformations
+
+## Format
+
+```
+═══ 🔄 Reversibility ════════════════════════════════════════════
+  Reversible: <action — how to undo>
+  Reversible: <action — how to undo>
+  Irreversible: <action OR "none">
+```
+
+## Concrete examples
+
+```
+Reversible: rm -rf plugins/dev-toolkit/skills/forge-report (single dir)
+Reversible: gh pr close 25 (PR not yet merged)
+Reversible: git revert <commit-sha> (no downstream consumers yet)
+Irreversible: secret STANDALONE_SYNC_TOKEN created (can be rotated, not undone)
+Irreversible: PR #24 merged to main (history preserved, but production state changed)
+```
+
+## Greybeards: include time window
+
+For some "reversible" things, the window closes:
+
+```
+Reversible until: 2026-05-15 (key rotation makes old auth uncallable)
+Reversible until: next migration runs
+Reversible until: customer first uses feature
+```
+
+## When reversibility is obvious
+
+Skip this section only if **all** of:
+- Pure read-only operations
+- No file changes
+- No external system effects
+
+In all other cases — include it, even if 1 line.

--- a/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/tldr.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/tldr.md
@@ -1,0 +1,31 @@
+# TL;DR — Required first block
+
+Full rules in `00-anchors/tldr-format.md`. Quick reference here:
+
+## Format
+
+```
+TL;DR: <what changed>. <action OR "no action">. <one risk if applicable>.
+```
+
+## Length: 1-3 lines, ≤80 characters per line.
+
+**Exception**: `incident-summary` may use up to 4 lines when symptom + root cause + fix + prevention all need stating.
+
+## Position: very first block, before any heading.
+
+## Three slots
+
+| Slot | Content | Required? |
+|------|---------|-----------|
+| 1 | What changed | Yes |
+| 2 | What user does | Yes (or explicit "no action") |
+| 3 | Biggest risk / dependency | Optional, omit if none |
+
+## When TL;DR can be skipped
+
+- Pure Q&A response (no actions taken)
+- Single-file edit
+- Response is already <10 lines
+
+In those cases — write the answer directly.

--- a/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/_index.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/_index.md
@@ -1,0 +1,19 @@
+# 03-anti-patterns — What NOT to do in reports
+
+Three failure modes that destroy the value of structured reports.
+
+## Files
+
+| File | Anti-pattern |
+|------|--------------|
+| `wall-of-text.md` | Long prose, no scannable structure |
+| `over-reporting.md` | Templates applied to trivial tasks |
+| `duplicate-info.md` | Same content repeated across sections |
+
+## How to use
+
+Before sending a report, scan against these. If you spot one — refactor.
+
+## The single rule
+
+A good report can be **scanned in 10 seconds** and **acted on in 30 seconds**. If your report fails either test, one of these anti-patterns is at play.

--- a/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/duplicate-info.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/duplicate-info.md
@@ -1,0 +1,52 @@
+# Duplicate info — Anti-pattern
+
+Same fact repeated across multiple sections.
+
+## Why it's bad
+
+- Report **looks longer** than it is, but reader gets less.
+- When facts inevitably **drift apart** (one edit updates one copy), report becomes contradictory.
+- Reader stops trusting any single statement because "maybe the other section is more current".
+
+## Bad
+
+```
+TL;DR: Created PR #25 with forge-report skill. Awaiting CI.
+
+═══ ✅ Created ═══════════════════════════════════════════════════
+  PR #25 with forge-report skill                       awaiting CI
+
+═══ ➡️ Next steps ══════════════════════════════════════════════
+  1. Wait for CI on PR #25 (forge-report skill)
+  2. Merge once CI passes for PR #25 with forge-report
+```
+
+(Same fact "PR #25 / forge-report / CI" stated 4 times.)
+
+## Good
+
+```
+TL;DR: PR #25 (forge-report skill) opened, CI running. ETA ~30s.
+
+═══ ➡️ Next steps ══════════════════════════════════════════════
+  1. Wait for CI green
+  2. Merge → branch auto-deletes
+```
+
+(Each fact stated once. Context flows.)
+
+## When repetition IS OK
+
+- **TL;DR + body**: TL;DR is a summary, body is detail. They restate by design.
+- **Cross-references** to other artefacts: "see PRD-016" doesn't duplicate, it links.
+- **Summary at end** of long sectional report.
+
+## How to spot duplication
+
+Read your own report from top to bottom. Mark every fact. If a fact appears 3+ times in 3+ sections — collapse.
+
+## Refactor pattern
+
+1. Identify the **canonical place** for each fact (usually first occurrence).
+2. Other places link or reference (`see ✅ Created above`).
+3. Delete pure repetition.

--- a/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/over-reporting.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/over-reporting.md
@@ -1,0 +1,62 @@
+# Over-reporting — Anti-pattern
+
+Applying full structured-report template to trivial tasks.
+
+## Why it's bad
+
+When **every** response is a structured report, the reports lose signal. A 30-line report for "fixed a typo" trains the user to skip the formal structure.
+
+The whole point of a report template is that it **stands out** when shown.
+
+## Bad
+
+User: "Fix the typo in line 42"
+Claude:
+```
+TL;DR: Typo "teh" → "the" fixed in line 42 of README.md.
+
+═══ ✅ Created ══════════════════════════════════════════════════
+  — (no new files)
+
+═══ 🔵 Modified ════════════════════════════════════════════════
+  README.md           Line 42                          1 char change
+
+═══ 🔄 Reversibility ═══════════════════════════════════════════
+  Reversible: git checkout README.md
+  Irreversible: none
+
+═══ ⚠️ Drift risks ════════════════════════════════════════════
+  — (isolated typo fix)
+
+═══ ➡️ Next steps ═════════════════════════════════════════════
+  1. Review change
+
+💰 Cycle: 2 calls · 1 file · <1 min
+```
+
+## Good
+
+User: "Fix the typo in line 42"
+Claude: "Fixed `teh` → `the` in README.md:42."
+
+## When to apply structured report
+
+Use the **2-of-4 trigger** from SKILL.md:
+- ≥5 tool calls
+- ≥3 files modified
+- TaskList ≥3 items
+- Cross-system effects
+
+If at least 2 hit, use template. Otherwise — prose.
+
+## Edge cases
+
+- **User explicitly invoked `/report`** → use template (they asked).
+- **Task started small but grew** → switch to template mid-flight.
+- **Series of small tasks** → wrap with one summary at end of session.
+
+## How to recover from over-reporting
+
+If you feel "this report is overkill", trust the feeling. Cut to:
+- One TL;DR-style line, OR
+- A small block with what changed + verification.

--- a/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/wall-of-text.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/wall-of-text.md
@@ -1,0 +1,45 @@
+# Wall of text — Anti-pattern
+
+Long flowing prose with no anchors, no tables, no structure.
+
+## Why it's bad
+
+Reader can't scan. Has to read every word to find the answer to "what changed" or "what should I do". Defeats the purpose of a report.
+
+## Bad
+
+```
+В ходе работы над задачей я создал новый skill forge-report в плагине
+dev-toolkit, который содержит SKILL.md как роутер и четыре секции:
+00-anchors с тремя файлами status-icons, tldr-format и confidence-levels,
+01-templates с пятью шаблонами для разных типов задач, 02-required-sections
+с пятью обязательными блоками для всех отчётов и 03-anti-patterns с тремя
+антипаттернами. Также добавил slash command /report и обновил версию
+плагина до 1.5.0. Все файлы прошли валидацию. Следующий шаг — отправить
+PR в маркетплейс и дождаться merge.
+```
+
+## Good
+
+```
+TL;DR: forge-report skill добавлен в dev-toolkit, 19 файлов, /report
+       command, плагин bumped до v1.5.0. CI green. Готово к PR.
+
+═══ ✅ Created ═══════════════════════════════════════════════════
+  SKILL.md            plugins/dev-toolkit/skills/forge-report/
+  00-anchors/         3 files (status-icons, tldr-format, confidence)
+  01-templates/       5 files (build/audit/decision/incident/migration)
+  02-required/        5 files (tldr, not-done, reversibility, drift, next)
+  03-anti-patterns/   3 files (wall-of-text, over-reporting, duplicate)
+  /report command     commands/report.md
+
+═══ ➡️ Next steps ══════════════════════════════════════════════
+  1. Open PR to marketplace
+```
+
+## How to fix
+
+1. Identify the **3-5 facts** the user actually needs.
+2. Put them in a **scannable structure** (table, bullet list, code block).
+3. Cut everything else.
+4. If you still have prose, ask: "would I want to read this if I weren't required to?"


### PR DESCRIPTION
## Summary
- New skill `forge-report` in `plugins/dev-toolkit/skills/forge-report/` — 5 templates + 5 mandatory sections + icon legend + 3 anti-patterns (19 files total).
- New `/report` slash command in `plugins/dev-toolkit/commands/report.md` for explicit invocation.
- Bump `dev-toolkit` 1.4.0 → 1.5.0 and marketplace catalog 1.7.0 → 1.8.0.

## Verification
- `./scripts/validate-all-plugins.sh` — **ALL PASSED** (11 plugins, 14 commands incl. /report, no collisions)
- 2 parallel audit agents (structural + content):
  - Structural: 22/22 OK, 0 findings.
  - Content: 0 CRITICAL, 2 HIGH, 3 MEDIUM, 3 LOW.
- All HIGH + MEDIUM fixed, re-verified by audit agent: **5/5 PASS**.

## What ships

| Component | Path |
|---|---|
| Skill router | `plugins/dev-toolkit/skills/forge-report/SKILL.md` |
| Anchors (3 files) | `sections/00-anchors/` |
| Templates (5 files) | `sections/01-templates/` |
| Required sections (5 files) | `sections/02-required-sections/` |
| Anti-patterns (3 files) | `sections/03-anti-patterns/` |
| Slash command | `commands/report.md` |

## Required after merge
None. Skill is auto-discovered when dev-toolkit is installed.

User has separately added a global `~/.claude/CLAUDE.md` rule that auto-triggers structured reports on tasks meeting ≥2 of 4 criteria (≥5 tool calls / ≥3 files / TaskList ≥3 / cross-system effects). That file is not in this PR (it's user-local).

## Test plan
- [x] YAML/JSON validates
- [x] Plugin validation passes
- [x] No command collisions
- [x] All cross-references between SKILL.md and section files resolved
- [x] Confidence labels (🟢🟡🔴) namespace separated from status icons (✅📝...)
- [x] All 5 templates contain all 5 mandatory required sections
- [ ] Post-merge: smoke-test `/report` on a real task

Refs: PRD-016