### PR TITLE
fix(dev-toolkit): rewrite forge-report templates in card-based format (v1.5.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.8.0"
+    "version": "1.8.1"
   },
   "plugins": [
     {
@@ -53,8 +53,8 @@
     {
       "name": "dev-toolkit",
       "source": "./plugins/dev-toolkit",
-      "description": "Universal engineering toolkit: multi-expert audit, wave-based sprints, session context recall, structured reports, and safety hooks. Works with any project and language.",
-      "version": "1.5.0",
+      "description": "Universal engineering toolkit: multi-expert audit, wave-based sprints, session context recall, card-based structured reports, and safety hooks. Works with any project and language.",
+      "version": "1.5.1",
       "author": {
         "name": "ForgePlan"
       },

--- a/plugins/dev-toolkit/.claude-plugin/plugin.json
+++ b/plugins/dev-toolkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-toolkit",
-  "version": "1.5.0",
-  "description": "Universal engineering toolkit: multi-expert audit, wave-based sprints, session context recall, structured reports, and safety hooks. Works with any project and language.",
+  "version": "1.5.1",
+  "description": "Universal engineering toolkit: multi-expert audit, wave-based sprints, session context recall, card-based structured reports, and safety hooks. Works with any project and language.",
   "author": {
     "name": "ForgePlan"
   },

--- a/plugins/dev-toolkit/skills/forge-report/SKILL.md
+++ b/plugins/dev-toolkit/skills/forge-report/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: forge-report
-description: "Structured report formats for Claude. Use when finishing a multi-step task (≥5 tool calls, ≥3 files modified, multi-task TaskList, or cross-system effects like git push/PR/deploy). Triggers on: report, summary, summarise, отчёт, итоги, завершение задачи, build complete, audit complete, deployment complete, decision recorded, incident resolved, migration done. Provides 5 templates (build/audit/decision/incident/migration), anchor conventions (status icons, TL;DR, confidence), required sections (not-done, reversibility, drift-risks, next-steps), and anti-patterns. Not for simple Q&A or single-file edits."
+description: "Structured report formats for Claude — card-based, human-readable, no ASCII frame noise. Use when finishing a multi-step task (≥5 tool calls, ≥3 files modified, multi-task TaskList, or cross-system effects like git push/PR/deploy). Triggers on: report, summary, summarise, отчёт, итоги, завершение задачи, build complete, audit complete, deployment complete, decision recorded, incident resolved, migration done. Provides 5 templates (build/audit/decision/incident/migration), anchor conventions (section icons, plain-prose TL;DR, confidence labels), required sections (not-done, reversibility, drift-risks, next-steps), and 5 anti-patterns. Not for simple Q&A or single-file edits."
 license: MIT
 ---
 
-# forge-report — Structured Report Formats
+# forge-report — Card-based Structured Reports
 
-A library of templates and conventions for producing **clear, scannable, actionable** finishing reports after multi-step tasks. Designed for Claude Code agents.
+A library of templates and conventions for finishing reports after multi-step tasks. **Designed to be readable by a human in 30 seconds**, not impressive to look at.
+
+## Core philosophy
+
+> **Cards over tables. Full sentences over labels. Plain prose TL;DR over one-liner.**
+
+Reports are for the **reader**, not the author. If a reader has to decode `🟢 Pass` or `5/5 PASS` — the report failed.
 
 ## When to use this skill
 
@@ -21,78 +27,133 @@ For smaller tasks → use plain prose. Don't over-report.
 
 ## How to use this skill (agentic RAG)
 
-This skill is a **router**. Follow these steps:
-
 ### Step 1 — Pick the right template
 
-| Task type | Template | Section file |
+| Task type | Template file |
+|---|---|
+| Built/created something new | `01-templates/build-summary.md` |
+| Reviewed/audited code | `01-templates/audit-summary.md` |
+| Made a product/architecture decision | `01-templates/decision-summary.md` |
+| Debugged / resolved incident | `01-templates/incident-summary.md` |
+| Refactored / migrated something | `01-templates/migration-summary.md` |
+
+### Step 2 — Read anchor conventions (once per session)
+
+- `00-anchors/status-icons.md` — section icons only (✅ 📈 ⚪ 🔄 ⚠️ ➡️ 💰), not row decorations
+- `00-anchors/tldr-format.md` — TL;DR as a plain sentence-or-paragraph in italics, not a code block
+- `00-anchors/confidence-levels.md` — when to mark High/Medium/Assumed (used inline, sparingly)
+
+### Step 3 — Required sections (always present)
+
+| Section | Heading | Why |
 |---|---|---|
-| Built/created something new | `build-summary` | `01-templates/build-summary.md` |
-| Reviewed/audited code | `audit-summary` | `01-templates/audit-summary.md` |
-| Made + recorded a product decision | `decision-summary` | `01-templates/decision-summary.md` |
-| Debugged / resolved incident | `incident-summary` | `01-templates/incident-summary.md` |
-| Refactored / migrated something | `migration-summary` | `01-templates/migration-summary.md` |
+| TL;DR | (no heading, italic prose at top) | Reader scans first 2-3 sentences |
+| What's done | `## ✅ Что сделано` | Card per artefact |
+| What's NOT done | `## ⚪ Что не сделано — намеренно` | Confirms boundaries |
+| Reversibility | `## 🔄 Что можно откатить` | Trust + safety |
+| Drift risks | `## ⚠️ Что может поломаться со временем` | Future maintenance |
+| Next steps | `## ➡️ Что делать дальше` | Pickup pointer with addressee |
+| Cycle metadata | `## 💰 Сколько это стоило` | Cost/effort transparency |
 
-Don't see exact match? Pick the closest and adapt.
+### Step 4 — Card format (the key change)
 
-### Step 2 — Load the anchor conventions
+Every "thing" in a report is a **card**, not a table row. A card has explicit field labels:
 
-Read these once per session (compact, ~30 lines each):
+```
+  Что:    <human-readable name of the artefact>
+  Где:    <path or URL>
+  Зачем:  <1-2 sentences explaining purpose for someone who didn't follow the work>
+  Статус: <full sentence — "Готов и работает", not "🟢 Pass">
+```
 
-- `00-anchors/status-icons.md` — single legend for ✅⏳⚠️❌🔵⚪➡️
-- `00-anchors/tldr-format.md` — TL;DR rules (1-3 lines, ≤80 chars)
-- `00-anchors/confidence-levels.md` — when to mark High/Medium/Assumed
+Cards are separated by a thin horizontal line:
+```
+  ───────────────────────────────────────────────────────────────
+```
 
-### Step 3 — Include required sections
+**Why cards beat tables**: tables force every row into the same columns. Some artefacts need 4 fields, some need 6. Cards adapt. Plus reader's eye doesn't get lost in column 3 of row 7.
 
-Every report must include (load from `02-required-sections/`):
-
-| Section | When | Why |
-|---|---|---|
-| TL;DR | Always, very top | Reader decides if they read further |
-| Not done | Always, even if obvious | Confirms boundaries respected |
-| Reversibility | When changes touch git/files/external | Trust + safety |
-| Drift risks | When artefacts cross-reference each other | Prevents future bit-rot |
-| Next steps | Always | Future-self / future-session pickup |
-
-### Step 4 — Avoid anti-patterns
+### Step 5 — Avoid anti-patterns
 
 Before sending, scan against `03-anti-patterns/`:
 
-- `wall-of-text.md` — break into bullets/tables
-- `over-reporting.md` — small tasks don't need reports
-- `duplicate-info.md` — say it once, link the rest
+- `wall-of-text.md` — break prose into cards
+- `over-reporting.md` — small tasks don't need full reports
+- `duplicate-info.md` — say it once
+- `ascii-frames.md` — no `═══ Section ═══` rectangles, use clean `##` headings + thin lines
+- `label-less-data.md` — never columns of numbers without explicit labels
 
 ## Quick template skeleton
 
-```
-TL;DR: <1-3 lines, ≤80 chars per line>
+```markdown
+> _<TL;DR as plain italic sentence — what changed, what user needs to do,
+> one risk if any. 1-3 sentences, natural English. No code block.>_
 
-═══ ✅ <What was done> ═══════════════════════════════════════════
-  <items with What/Where/Status>
+## ✅ Что сделано
 
-═══ ⚪ Not done (intentional) ════════════════════════════════════
-  <items>
+  Что:    <Artefact name>
+  Где:    <path>
+  Зачем:  <Purpose for someone who didn't follow the work>
+  Статус: <Full sentence with context>
+  ───────────────────────────────────────────────────────────────
+  Что:    <Next artefact>
+  Где:    <path>
+  ...
 
-═══ 🔄 Reversibility ════════════════════════════════════════════
-  Reversible: <items>
-  Irreversible: <items or "none">
+## 📈 Что обновлено
 
-═══ ⚠️ Drift risks ═════════════════════════════════════════════
-  <items with mitigation>
+  Файл:  <path>
+  Было:  <old value>
+  Стало: <new value + brief explanation>
+  ───────────────────────────────────────────────────────────────
+  ...
 
-═══ ➡️ Next steps ══════════════════════════════════════════════
-  1. <action>
-  2. <action>
+## ⚪ Что не сделано — намеренно
 
-💰 Cycle: <tool calls / files / time>
+  Не сделано: <Item>
+  Почему:     <Reason — if "out of scope" then say so explicitly>
+  ───────────────────────────────────────────────────────────────
+  ...
+
+## 🔄 Что можно откатить если передумаешь
+
+  Действие: <What to undo>
+  Команда:  <copy-paste command>
+  Время:    <how long the undo takes>
+  Риски:    <what might go wrong, or "Никаких">
+  ───────────────────────────────────────────────────────────────
+  ...
+
+## ⚠️ Что может поломаться со временем
+
+  Риск:   <Specific drift risk, not theoretical>
+  Когда:  <Trigger condition — date, event, action>
+  Что:    <What breaks if trigger fires>
+  Защита: <How to prevent or recover>
+  ───────────────────────────────────────────────────────────────
+  ...
+
+## ➡️ Что делать дальше
+
+  Шаг 1: <АДРЕСАТ> — <imperative action with context>
+  Шаг 2: <АДРЕСАТ> — <imperative action>
+  Шаг 3: <АДРЕСАТ> — <imperative action>
+
+  (АДРЕСАТ ∈ ТЕБЕ / МНЕ / ПОТОМ / АВТОМАТУ)
+
+## 💰 Сколько это стоило
+
+  Время:        <wall clock>
+  Действий:     <tool call count + brief category>
+  Файлов:       <new + modified counts>
+  Стоимость:    <retries / rollbacks / surprises if any>
 ```
 
 ## Cross-references
 
 - Inside dev-toolkit: `/audit`, `/sprint`, `/recall` — sister utilities
-- Marketplace: `forge-report` is the format that other dev-toolkit commands should output to
+- Marketplace: `forge-report` is the format other dev-toolkit commands should output to
 
 ## Versioning
 
-This skill is shipped with `dev-toolkit` plugin. Version moves together.
+This skill ships with `dev-toolkit`. Version moves together.

--- a/plugins/dev-toolkit/skills/forge-report/sections/00-anchors/confidence-levels.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/00-anchors/confidence-levels.md
@@ -1,57 +1,62 @@
-# Confidence Levels — Mark facts vs assumptions
+# Confidence Levels — Inline, Sparingly
 
-**Most bugs from Claude come from confidently stating assumptions.** Confidence labels separate verified facts from inference.
+**Most bugs from Claude come from confidently stating assumptions.** Confidence labels separate verified facts from inference. But — used sparingly, inline in card values, never as visual decoration.
 
-## Three levels — traffic-light icons
+## Three levels
 
 | Label | When to use | Example |
 |-------|-------------|---------|
-| 🟢 **High** | Verified by tool output (Read/Bash/test result) | `🟢 High: PR #24 merged (gh pr view returned state=MERGED)` |
-| 🟡 **Medium** | Inferred from context, not directly tested | `🟡 Medium: workflow likely green (last 3 runs were green)` |
-| 🔴 **Assumed** | Estimate, opinion, or unverified prediction | `🔴 Assumed: 4-6 hours to build (based on similar past tasks)` |
+| 🟢 **High** | Verified by tool output (Read/Bash/test result) | `Готов и проверен (🟢 high — gh pr view confirmed merged)` |
+| 🟡 **Medium** | Inferred from context, not directly tested | `Скорее всего работает (🟡 medium — last 3 similar PRs were green)` |
+| 🔴 **Assumed** | Estimate, opinion, or unverified prediction | `Займёт ~4 часа (🔴 assumed — оценка по похожим задачам)` |
 
-**Important**: confidence icons (🟢🟡🔴) are a **separate namespace** from status icons (✅📝⏳⚠️❌🔵⚪➡️). Never mix them in the same column or sentence.
+**Important**: confidence labels (🟢🟡🔴) are a **separate namespace** from section icons (✅📈⚪🔄⚠️➡️💰). Never use 🟢 as a section icon, never use ✅ as a confidence label.
 
-## When to label
+## How to write inline
 
-Apply confidence when:
-- Stating **time estimates** ("X hours")
-- Making **predictions** ("this will work / fail")
-- Reporting **status** of things you didn't directly check
-- Claiming **causation** ("X happened because Y")
-
-Don't label when:
-- Direct quote from tool output (already verified)
-- Self-evident facts ("the file exists")
-- Obvious inferences ("PR is green because all 3 checks pass")
-
-## Format inline
-
+In card values:
 ```
-🟢 High confidence — Workflow green (verified via gh run view 25020766130)
-🟡 Medium — Likely takes 2 minutes (not measured, similar to last sync)
-🔴 Assumed — Users will adopt by Q3 (no metrics yet)
+  Статус: Готов и проверен на CI (🟢 high — gh pr view returned MERGED)
+  Время:  ~4 часа (🔴 assumed — оценка по похожим задачам)
 ```
 
-## Format in tables
-
+In prose:
 ```
-| Item | Status | Confidence |
-|------|--------|------------|
-| Repo created | ✅ | High |
-| CI will work | 🟡 | Medium (untested with secret) |
-| Adoption next month | ⚠️ | Assumed |
+> _Workflow вероятно зелёный (🟡 medium — последние 3 запуска green, но
+> этот ещё не проверял)._
+```
+
+## When to label vs not
+
+**Label when**:
+- Stating time estimates (`5 минут`, `2 часа`)
+- Making predictions (`будет работать`, `сломается`)
+- Reporting status of things you didn't directly check
+- Claiming causation (`X произошло потому что Y`)
+
+**Don't label when**:
+- Direct quote from tool output (already verified by reader)
+- Self-evident facts (`файл существует` — Read returned its content)
+- Obvious inferences from immediately-prior tool calls
+
+## Anti-pattern: hedging language
+
+❌ Don't sprinkle "I think" / "probably" / "maybe" everywhere — that's noise:
+```
+  Статус: Думаю наверное всё хорошо. Скорее всего pass. Возможно медленно.
+```
+
+✅ One explicit confidence label > five hedged sentences:
+```
+  Статус: Pass на CI (🟢 high). Производительность — ~200ms (🟡 medium,
+          измерение из 3 запусков, не статистически значимо).
 ```
 
 ## Why this matters
 
 Without labels, the reader can't tell:
-- "It works" = verified or hoped?
-- "Takes 5 min" = measured or guessed?
-- "Safe to deploy" = tested in staging or based on dry-run?
+- "Работает" = проверено или предположено?
+- "Займёт 5 минут" = измерено или оценено?
+- "Безопасно деплоить" = протестировано в staging или dry-run?
 
 A 5-line report with confidence labels is more useful than a 50-line report without.
-
-## Anti-pattern
-
-Don't sprinkle "I think" / "probably" / "maybe" everywhere — that's noise. Use the 3-label system instead. 1 explicit label > 5 hedged sentences.

--- a/plugins/dev-toolkit/skills/forge-report/sections/00-anchors/status-icons.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/00-anchors/status-icons.md
@@ -1,58 +1,59 @@
-# Status Icons — Single Legend
+# Section Icons — One Per Heading, Not Per Row
 
-**Use these icons consistently across all reports. Don't invent new ones.**
+**Icons live in section headings only.** Decoration of every row makes reports visually noisy and hard to scan.
 
-| Icon | Meaning | Example |
-|------|---------|---------|
-| ✅ | Done — verified successful | `✅ PR #24 merged, CI green` |
-| 📝 | Modified — files edited (vs created) | `📝 README.md (line 42, 1 char)` |
-| ⏳ | Pending — in progress or queued | `⏳ Deploy starting, ETA 5m` |
-| ⚠️ | Risk / warning — works but watch out | `⚠️ Rate limit at 80% capacity` |
-| ❌ | Failed — explicit failure to record | `❌ Migration rollback required` |
-| 🔵 | Info — context, no action needed | `🔵 Total tokens used: 6078` |
-| ⚪ | Not done — intentional, not forgotten | `⚪ Skipped UI tests (no display in CI)` |
-| ➡️ | Next step — action user should take | `➡️ Run gh secret set TOKEN ...` |
+## The 7 section icons
 
-## Confidence labels (separate system)
+Use one of these **only as the second character of an `## h2` heading** (e.g. `## ✅ Что сделано`):
 
-Confidence uses a **distinct traffic-light set** to avoid colliding with status icons:
-
-| Icon | Meaning | Example |
-|------|---------|---------|
-| 🟢 | High — directly verified | `🟢 PR merged (gh pr view confirmed)` |
-| 🟡 | Medium — inferred, not tested | `🟡 Likely takes 2 min (similar to last sync)` |
-| 🔴 | Assumed — estimate or prediction | `🔴 4-6 hours to build (gut estimate)` |
-
-See `confidence-levels.md` for when to use each.
+| Icon | Section meaning | Example heading |
+|------|-----------------|-----------------|
+| ✅ | Things you created / accomplished | `## ✅ Что сделано` |
+| 📈 | Things you modified / updated | `## 📈 Что обновлено` |
+| ⚪ | Things explicitly not done (boundaries) | `## ⚪ Что не сделано — намеренно` |
+| 🔄 | Reversibility / rollback | `## 🔄 Что можно откатить если передумаешь` |
+| ⚠️ | Drift risks / future warnings | `## ⚠️ Что может поломаться со временем` |
+| ➡️ | Next steps for the reader | `## ➡️ Что делать дальше` |
+| 💰 | Cycle cost / metadata | `## 💰 Сколько это стоило` |
 
 ## Rules
 
-1. **One icon per row** — don't combine like `✅⚠️`.
-2. **Icon goes first** — `✅ Item` not `Item ✅`.
-3. **Don't redecorate** — no 🎉🚀🔥 unless there's a real reason.
-4. **No icon = neutral statement** — that's also fine.
+1. **Exactly one icon per heading.** No `## ✅⚠️ Done with risks`.
+2. **Never inside cards.** The card body is plain text; icons are reserved for the heading above.
+3. **No new icons.** If you want to invent ❌ or 🔥 — restructure into one of the 7 sections instead.
+4. **Plain bullet lists never get icons.** Use `-` or numbered `1.` for items, never `✅` for "this item is done".
 
-## Anti-patterns
+## Why row-level icons fail
 
-- ❌ Using `✅` for "I tried" — only for verified.
-- ❌ Using `⚠️` for everything mildly uncertain — reserve for real risk.
-- ❌ Mixing emojis for the same concept (`✓` vs `✅`).
+❌ Bad — visual noise, eye loses anchors:
+```
+## Что сделано
+  ✅ skill создан       
+  ✅ command добавлен   
+  ✅ PR замержен        
+  ⚠️ smoke не пройден   
+```
 
-## Why these 8 status + 3 confidence
+✅ Good — section icon labels the category, items inside are full sentences:
+```
+## ✅ Что сделано
+  Что: forge-report skill (готов, проверен)
+  Что: /report command (готов)
+  Что: PR #26 (замержен)
 
-Status icons cover state:
-- Result: ✅ ❌
-- Change: 📝
-- In motion: ⏳
-- Caution: ⚠️
-- Context: 🔵
-- Boundaries: ⚪
-- Action: ➡️
+## ⚠️ Что может поломаться
+  Риск: smoke test не сделан — нужна реальная задача для проверки
+```
 
-Confidence icons (🟢🟡🔴) live in a parallel "traffic-light" namespace — never mix them with status icons in the same column.
+## Confidence labels — separate system
 
-Adding more icons makes the legend forgettable. If you feel the urge to invent one — try harder with the existing 11.
+Confidence (🟢 High / 🟡 Medium / 🔴 Assumed) is documented in `confidence-levels.md`. Use confidence labels **inline in card values**, never as section headings or row decorations:
 
-## Section-header convention
+```
+  Статус: Готов и проверен на CI (🟢 high — gh pr view confirmed merged)
+```
 
-Some templates use icons as section markers, e.g. `═══ ✅ Created ═════`. In that context the icon **groups** items by category (here: completed items), it does NOT mean "this heading is verified". Treat the icon as a label, not a status.
+NOT:
+```
+  🟢 Статус: Готов
+```

--- a/plugins/dev-toolkit/skills/forge-report/sections/00-anchors/tldr-format.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/00-anchors/tldr-format.md
@@ -1,59 +1,67 @@
-# TL;DR Format
+# TL;DR — Plain Italic Sentence at the Top
 
-**TL;DR is the first thing the reader sees. It decides whether they read further.**
-
-## Rules
-
-1. **Position**: very top, before any heading.
-2. **Length**: 1-3 lines, ≤80 characters per line. Exception: `incident-summary` may extend to 4 lines.
-3. **Content**: what changed + what user must do (if anything) + 1 risk if any.
-4. **Tense**: past for completed, present for state, imperative for actions.
+**TL;DR is the first thing the reader sees. It must read like natural language, not like a status code.**
 
 ## Format
 
+A blockquote with italic prose, 1-3 sentences. Position: very top, before any heading.
+
+```markdown
+> _<What changed in human language>. <What user needs to do or "no action needed">.
+> <One risk or dependency if relevant.>_
 ```
-TL;DR: <what changed in 1 line>. <action user needs OR "no action needed">.
-       <one risk if applicable, omit otherwise>.
-```
+
+That's it. No code block, no labels, no rigid template.
+
+## Length
+
+- **Most cases**: 1-2 sentences fit in 1-2 lines.
+- **Long incidents** (`incident-summary`): up to 4 sentences allowed.
+- **Word count**: aim for 30-60 words. Over 80 words → split or simplify.
 
 ## Good examples
 
-```
-TL;DR: 3 PRD draft + NOTE-003 + Hindsight bank сохранены. Никаких действий не
-       требуется. Готово к активации по триггеру (см. NOTE-003).
-```
-
-```
-TL;DR: PR #24 merged, sync workflow зелёный. Установка ForgePlan/fpf и /loux
-       работает через npx. Дрейф: NOTE-002 — обновить actions/checkout до сент.
+```markdown
+> _Сделал новый skill `forge-report` для структурированных отчётов в плагине
+> `dev-toolkit`. Плюс slash command `/report` и правило в `~/.claude/CLAUDE.md`.
+> Всё работает, готово к использованию. Главное что нужно тебе — попробовать
+> на реальной задаче._
 ```
 
+```markdown
+> _PR #24 замержен, sync workflow зелёный. Установка `ForgePlan/fpf` и
+> `ForgePlan/loux` через `npx skills add` теперь работает. Один риск:
+> NOTE-002 напоминает обновить `actions/checkout` до сентября._
 ```
-TL;DR: Auth middleware добавлен, 12 тестов pass. Требуется secret JWT_SECRET
-       в .env перед деплоем.
+
+```markdown
+> _Auth middleware добавлен, 12 тестов проходят. Перед деплоем нужен secret
+> `JWT_SECRET` в `.env`._
 ```
 
 ## Bad examples
 
+```markdown
+> _Готово._
 ```
-❌ TL;DR: Я выполнил задачу, всё хорошо.
-   (no specifics, no action, no risk)
+(no specifics, no action, no risk)
 
-❌ TL;DR: Создал файл src/auth/middleware.ts с функцией authenticate(),
-   которая принимает токен из заголовка Authorization и проверяет его
-   через jwt.verify используя секрет из process.env.JWT_SECRET, после
-   успешной проверки устанавливает req.user и вызывает next(), а при
-   ошибке возвращает 401.
-   (это не TL;DR, это уже описание реализации)
-
-❌ TL;DR: 🎉 Готово!
-   (декорация без информации)
+```markdown
+> _Создал файл src/auth/middleware.ts с функцией authenticate(),
+> которая принимает токен из заголовка Authorization и проверяет его
+> через jwt.verify используя секрет JWT_SECRET..._
 ```
+(too long — this is implementation detail, not summary)
 
-## When NOT to write TL;DR
+```markdown
+TL;DR: 21 files / 7 tasks / 1 PR / 0 errors
+```
+(no sentences — that's a status code, not a summary)
 
-- Простая Q&A («что такое X?»)
-- Один tool call
-- Уже короткий ответ (<10 строк)
+## When to skip TL;DR entirely
 
-В этих случаях TL;DR — оверхэд.
+- Pure Q&A response (no actions taken)
+- Single-file edit
+- Response is already short (<10 lines)
+
+In these cases, write the answer directly with no TL;DR overhead.

--- a/plugins/dev-toolkit/skills/forge-report/sections/01-templates/audit-summary.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/01-templates/audit-summary.md
@@ -2,81 +2,90 @@
 
 Use after: code review, security audit, architecture review, dependency check, performance audit.
 
-## Template
+## Skeleton
 
-```
-TL;DR: <N findings, severity breakdown>. <action priority>. <biggest risk>.
+```markdown
+> _<TL;DR — what was audited, severity breakdown, top action.
+> 1-3 italic sentences.>_
 
-═══ 📊 Scope ═══════════════════════════════════════════════════════
-  Audited:   <files/modules/services>
-  Method:    <static analysis / manual review / tool used>
-  Duration:  <time spent>
-  Confidence: <High/Medium/Assumed — based on coverage>
+## 📊 Что и как проверено
 
-═══ ❌ Critical findings ═══════════════════════════════════════════
-  #N  <issue>                                          <where>
-       Impact: <what breaks>
-       Fix: <action>
+  Что проверял:  <files / modules / services>
+  Метод:         <static analysis / manual review / tool used>
+  Время:         <how long>
+  Уверенность:   <High / Medium / Assumed — based on coverage>
 
-═══ ⚠️ High-priority findings ════════════════════════════════════
-  #N  <issue>  →  <where>  →  <fix>
+## ❌ Критичные проблемы
 
-═══ 🔵 Medium / Low findings ═══════════════════════════════════
+  Проблема: <What's wrong>
+  Где:      <file:line>
+  Эффект:   <What breaks if not fixed>
+  Что делать: <action>
+  ───────────────────────────────────────────────────────────────
+  ...
+
+## ⚠️ Серьёзные (high-priority)
+
+  Проблема: <What's wrong>
+  Где:      <file:line>
+  Эффект:   <Impact>
+  Что делать: <action>
+
+## 📈 Средние и низкие
+
   <count by severity, link to detailed findings file if many>
 
-═══ ✅ Strengths noted ═══════════════════════════════════════════
-  <what's done well — bias against only listing problems>
+## ✅ Что сделано хорошо
 
-═══ ⚪ Out of scope (intentional) ═══════════════════════════════
-  <what was NOT audited and why — also serves as Not-done section>
+  <Aspect 1 — what's well-done, not just problems>
+  <Aspect 2>
 
-═══ 🔄 Reversibility ════════════════════════════════════════════
-  Findings recorded — reversible (delete report).
-  Recommended fixes — not yet applied (no state change).
-  Irreversible: none (audit is read-only).
+## ⚪ Что не проверял — намеренно
 
-═══ ⚠️ Drift risks ═════════════════════════════════════════════
-  Findings staleness: <when audit becomes outdated — code keeps changing>
-  Coverage gaps: <areas not audited may regress unnoticed>
+  Не проверял: <Item>
+  Почему:      <Out of scope / separate review needed>
 
-═══ ➡️ Next steps ══════════════════════════════════════════════
-  Immediate (P0): <fix critical>
-  This sprint (P1): <fix high>
-  Backlog (P2+): <medium/low → ticket>
+## 🔄 Что можно откатить
 
-💰 Cycle: <N files reviewed> · <N findings> · <~minutes>
+  Действие: Удалить этот аудит-отчёт
+  Команда:  rm <path>
+  Время:    Мгновенно
+  Риски:    Никаких — аудит read-only, ничего в коде не менялось
+
+## ⚠️ Что может поломаться со временем
+
+  Риск:   Findings устаревают по мере изменения кода
+  Когда:  Через 1-2 спринта
+  Что:    Этот отчёт станет неактуальным
+  Защита: Перепрогнать аудит при следующем major release
+  ───────────────────────────────────────────────────────────────
+  Риск:   Области не покрыты этим аудитом могут регрессировать
+  Когда:  Постоянно
+  Что:    Возможно скрытые проблемы в untouched зонах
+  Защита: Расширить scope в следующий раз — см. секцию «не проверял»
+
+## ➡️ Что делать дальше
+
+  Сейчас (P0):    <fix критичных>
+  Этот спринт (P1): <fix серьёзных>
+  В беклог (P2+): <medium/low в тикеты>
+
+## 💰 Сколько это стоило
+
+  Время:    <how long>
+  Файлов:   <reviewed count>
+  Findings: <total count>
 ```
 
 ## Required minimums
 
-- ✅ Severity breakdown in TL;DR (e.g. "5C/17H/16M/9L")
-- ✅ At least one **Strengths** item — pure-negative audits feel hostile and miss balance
+- ✅ Blockquote TL;DR with severity breakdown (e.g. "5 критичных, 17 серьёзных")
+- ✅ At least one item in **Что сделано хорошо** — pure-negative audits feel hostile
 - ✅ Confidence label on overall audit (small sample = lower confidence)
-- ⚪ Out-of-scope section is **mandatory** — defines audit boundary
-
-## Real-world example
-
-```
-TL;DR: 47 findings (5C/17H/16M/9L) in marketplace plugins. Critical: 3 hooks
-       allow injection. P0 fixes within 2 days. Strength: validation script
-       solid. Confidence: High (full plugin review).
-
-═══ ❌ Critical findings ═══════════════════════════════════════════
-  #1  prompt-type hooks bypass user consent              hooks.json (3 plugins)
-       Impact: arbitrary command execution
-       Fix: ban prompt type, require type=command
-
-═══ ✅ Strengths noted ═══════════════════════════════════════════
-  • CI validates plugin.json + hooks.json structure
-  • Hash-pinned actions in workflows (good supply chain hygiene)
-
-═══ ⚪ Out of scope (intentional) ═══════════════════════════════
-  • Agent prompts not audited (separate review needed)
-  • Performance audit (no perf SLOs defined yet)
-```
+- ⚪ "Что не проверял" is mandatory — defines audit boundary
 
 ## Anti-patterns
 
-- ❌ Listing only problems — appears hostile, misses what to preserve.
-- ❌ No severity → reader can't prioritise.
-- ❌ "Audited everything" — usually false; declare scope explicitly.
+- ❌ Listing only problems — appears hostile, misses what to preserve
+- ❌ No severity → reader can't prioritise
+- ❌ "Audited everything" — usually false; declare scope explicitly

--- a/plugins/dev-toolkit/skills/forge-report/sections/01-templates/build-summary.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/01-templates/build-summary.md
@@ -2,78 +2,120 @@
 
 Use after building: a feature, a plugin, a workflow, a set of files, a new repo.
 
-## Template
+## Skeleton
 
-```
-TL;DR: <what was built>. <verification status>. <one risk if any>.
+```markdown
+> _<TL;DR — what was built, current state, what user needs to do.
+> 1-3 italic sentences in a blockquote.>_
 
-═══ ✅ Created ═══════════════════════════════════════════════════
-  <Component>     <Where>                              <Status>
-  <Component>     <Where>                              <Status>
+## ✅ Что создано
 
-═══ 📝 Modified ═════════════════════════════════════════════════
-  <File>          <Type of change>                     <Lines: +/-/~>
+  Что:    <Artefact name in human language>
+  Где:    <path or URL>
+  Размер: <e.g. "21 файл (1 router + 4 индекса + 16 страниц)">
+  Зачем:  <Purpose for someone who didn't follow the work>
+  Статус: <Full sentence — "Готов. Прошёл проверку.">
+  ───────────────────────────────────────────────────────────────
+  Что:    <Next artefact>
+  Где:    <path>
+  Зачем:  <Purpose>
+  Статус: <Status>
 
-═══ ⚪ Not done (intentional) ════════════════════════════════════
-  <Item — why skipped>
+## 📈 Что обновлено
 
-═══ ✅ Verification ═════════════════════════════════════════════
-  <Check>         <Result>                             <Confidence>
-  CI              <pass/fail>                          <🟢/🟡>
-  Smoke test      <pass/fail>                          <🟢/🟡>
-  Lint            <pass/fail>                          <🟢>
+  Файл:  <path>
+  Было:  <old value>
+  Стало: <new value + brief reason>
+  ───────────────────────────────────────────────────────────────
+  PR:    <PR number / URL>
+  Что:   <one-line summary>
+  CI:    <result + duration>
+  Merge: <yes/no, who did it>
 
-═══ 🔄 Reversibility ════════════════════════════════════════════
-  Reversible: <list — git revert, rm files, etc.>
-  Irreversible: <list or "none">
+## ⚪ Что не сделано — намеренно
 
-═══ ⚠️ Drift risks ═════════════════════════════════════════════
-  <Risk>          <When it bites>                      <Mitigation>
+  Не сделано: <Item>
+  Почему:     <Reason — out of scope / deferred / user's job>
+  ───────────────────────────────────────────────────────────────
+  ...
 
-═══ ➡️ Next steps ══════════════════════════════════════════════
-  1. <action>
-  2. <action>
+## 🔄 Что можно откатить если передумаешь
 
-💰 Cycle: <N tool calls> · <N files> · <~minutes>
+  Действие: <What to undo>
+  Команда:  <copy-paste command>
+  Время:    <how long undo takes>
+  Риски:    <what might go wrong, or "Никаких">
+  ───────────────────────────────────────────────────────────────
+  ...
+
+## ⚠️ Что может поломаться со временем
+
+  Риск:   <Specific drift, not theoretical>
+  Когда:  <Trigger condition>
+  Что:    <What breaks>
+  Защита: <Prevention or recovery>
+
+## ➡️ Что делать дальше
+
+  Шаг 1: ТЕБЕ — <imperative action with context>
+  Шаг 2: ТЕБЕ — <imperative action>
+  Шаг 3: ПОТОМ — <when X happens, do Y>
+
+## 💰 Сколько это стоило
+
+  Время:        ~<wall clock>
+  Действий:     ~<tool call count>
+  Файлов:       <new + modified counts>
+  Стоимость:    <retries / rollbacks / surprises if any, or "Без откатов">
 ```
 
 ## Required minimums
 
-- ✅ At least one item in **Created** OR **Modified**
-- ✅ At least one **Verification** row
-- ✅ TL;DR mentions verification status
-- ⚪ Not-done section even if "nothing intentionally skipped" (then write "—")
+- ✅ Blockquote TL;DR at top, italic prose, 1-3 sentences
+- ✅ At least one card in **Что создано** OR **Что обновлено**
+- ✅ All 5 mandatory sections present (use one card with `Не сделано: —` if none apply)
+- ✅ Card fields use **full sentences**, not codes like `🟢 Pass`
 
 ## Real-world example
 
-```
-TL;DR: forge-report skill добавлен в dev-toolkit, 23 файла, плагин bumped
-       до v1.5.0. CI green. Drift risk: cc-best PRD ссылается на этот skill.
+```markdown
+> _Сделал новый skill `forge-report` для структурированных отчётов в плагине
+> `dev-toolkit`. Плюс slash command `/report` и правило в `~/.claude/CLAUDE.md`.
+> Всё работает, готово к использованию. Главное что нужно тебе — попробовать
+> на реальной задаче._
 
-═══ ✅ Created ═══════════════════════════════════════════════════
-  forge-report SKILL.md   plugins/dev-toolkit/skills/forge-report/   New
-  /report command         plugins/dev-toolkit/commands/report.md     New
-  5 templates             sections/01-templates/                     New
-  ...
+## ✅ Что создано
 
-═══ ✅ Verification ═════════════════════════════════════════════
-  CI                      pass (8s)                                  🟢 High
-  validate-plugins.sh     ALL PASSED                                 🟢 High
-  Smoke /report           manual test pending                        🔴 Assumed
+  Что:    Skill «forge-report» — шаблоны структурированных отчётов
+  Где:    plugins/dev-toolkit/skills/forge-report/
+  Размер: 21 файл (1 главный SKILL.md + 4 индекса + 16 страниц)
+  Зачем:  Чтобы Claude по завершении больших задач писал отчёты
+          в едином формате — TL;DR, что сделано, что не сделано,
+          что можно откатить, что в риске.
+  Статус: Готов. Прошёл два раунда проверки (5 проблем найдено и исправлено).
+  ───────────────────────────────────────────────────────────────
+  Что:    Slash-команда /report
+  Где:    plugins/dev-toolkit/commands/report.md
+  Зачем:  Если автотриггер не сработал — пишешь /report
+          и получаешь отчёт по последним действиям вручную.
+  Статус: Готов.
 
-═══ 🔄 Reversibility ════════════════════════════════════════════
-  Reversible: revert PR #25, rm plugins/dev-toolkit/skills/
-  Irreversible: none
+## 📈 Что обновлено
 
-═══ ➡️ Next steps ══════════════════════════════════════════════
-  1. Test /report on a real task
-  2. Update marketplace README
+  Файл:  plugins/dev-toolkit/.claude-plugin/plugin.json
+  Было:  версия 1.4.0
+  Стало: версия 1.5.0 (+1 команда, +1 skill)
 
-💰 Cycle: 31 calls · 23 files · 45 min
+## ➡️ Что делать дальше
+
+  Шаг 1: ТЕБЕ — открой новую сессию и дай задачу с 3+ файлами.
+                Если выйдет structured-отчёт — правило работает.
+  Шаг 2: ТЕБЕ — через неделю оцени навязчивость, поправим триггер.
+  Шаг 3: ПОТОМ — при активации PRD-014 добавить ссылку на forge-report.
 ```
 
 ## When NOT to use this template
 
-- Modified single file → just describe inline, no template needed.
-- Built something but didn't verify → use `incident-summary` (something broke).
-- Built + decided architecture → use `decision-summary` (decision is bigger).
+- Modified single file → describe inline, no template
+- Built something but didn't verify → use `incident-summary` (something went wrong)
+- Built + decided architecture → use `decision-summary` (decision is bigger)

--- a/plugins/dev-toolkit/skills/forge-report/sections/01-templates/decision-summary.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/01-templates/decision-summary.md
@@ -2,83 +2,100 @@
 
 Use after: choosing between alternatives, recording an ADR, fixing a roadmap, prioritising backlog.
 
-## Template
+## Skeleton
 
-```
-TL;DR: <decision in 1 sentence>. <why now>. <when to revisit>.
+```markdown
+> _<TL;DR — decision in one sentence, why now, when to revisit.
+> 1-3 italic sentences.>_
 
-═══ 🎯 Decision ════════════════════════════════════════════════════
-  What:        <chosen option>
-  Alternatives: <what was rejected and why>
-  Trigger:     <what forced this decision>
+## 🎯 Решение
 
-═══ 📊 Trade-offs ════════════════════════════════════════════════
-  | Option   | Pros           | Cons              | Score   |
-  |----------|----------------|-------------------|---------|
-  | <chosen> | <list>         | <list>            | ✅      |
-  | <other>  | <list>         | <list>            | ❌ <reason> |
+  Выбрали:    <chosen option>
+  Альтернативы: <what was rejected and why — 1-2 lines per option>
+  Триггер:    <what forced this decision>
 
-═══ ✅ Recorded as ════════════════════════════════════════════════
-  <ADR-NNN / NOTE-NNN / PRD-NNN>                       <where>
-  <related artefact>                                   <where>
+## 📊 Почему выбрали именно это
 
-═══ ⚪ Not decided yet (deferred) ════════════════════════════════
-  <open question>     <when to revisit>
+  Опция: <chosen>
+  Плюсы: <list>
+  Минусы: <list>
+  Оценка: Выбрана
+  ───────────────────────────────────────────────────────────────
+  Опция: <alternative>
+  Плюсы: <list>
+  Минусы: <list>
+  Оценка: Отклонена — <reason>
 
-═══ 🔄 Reversibility ════════════════════════════════════════════
-  Reversible: revert artefact files (rm/git revert) — decision uncommits
-  Reversible: supersede via new ADR/PRD with `supersedes` link
-  Irreversible: <if any external commitment was made>
+## ✅ Где зафиксировано
 
-═══ ⚠️ Drift risks ═══════════════════════════════════════════════
-  <If <X> changes>     →  <decision invalidates>
+  Что:    <ADR-NNN / NOTE-NNN / PRD-NNN>
+  Где:    <file path>
+  Связи:  <linked to PRD-X / blocks PRD-Y>
 
-═══ ➡️ Next steps / Activation triggers ═════════════════════════
-  This decision is documented but not "started". Activate when:
-  - <condition>
-  - <condition>
+## ⚪ Что не решено — отложили
 
-  Or, if action is immediate:
-  1. <action>
-  2. <action>
+  Открытый вопрос: <Question>
+  Когда вернёмся:  <Trigger or date>
 
-💰 Cycle: <N artefacts created> · <discussion turns> · <~minutes>
+## 🔄 Что можно откатить
+
+  Действие: Отменить решение через новый ADR/PRD с supersedes
+  Команда:  forgeplan new adr "<reverse decision>"
+  Время:    ~15 минут
+  Риски:    Если уже сделали что-то по этому решению — нужен rollback кода
+
+## ⚠️ Что может поломаться со временем
+
+  Риск:   Если изменится X
+  Когда:  При условии Y
+  Что:    Решение теряет силу
+  Защита: Пересмотреть decision
+
+## ➡️ Что делать дальше
+
+  Решение зафиксировано, но действие пока не запущено. Запускать когда:
+  - <triggering condition 1>
+  - <triggering condition 2>
+
+  Или, если действие нужно сразу:
+  Шаг 1: ТЕБЕ — <imperative action>
+  Шаг 2: МНЕ — <imperative action>
+
+## 💰 Сколько это стоило
+
+  Время:        <how long>
+  Артефактов:   <created count>
+  Обсуждений:   <turns>
 ```
 
 ## Required minimums
 
-- ✅ At least 2 alternatives in trade-off table (if only 1 considered → reframe as "no real choice")
-- ✅ "Recorded as" — link to durable artefact (ADR/NOTE/PRD), not just chat
+- ✅ Blockquote TL;DR with decision + revisit trigger
+- ✅ At least 2 alternatives in trade-off cards (if only 1 considered → reframe as "no real choice")
+- ✅ "Где зафиксировано" — link to durable artefact (ADR/NOTE/PRD), not just chat
 - ⚪ Drift risks — what would invalidate this decision?
-- ➡️ Activation triggers — when does decision become an action?
 
 ## Real-world example
 
-This very report (the conversation about saving 3 PRD drafts) is a `decision-summary`:
+This very report (the conversation about saving 3 PRD drafts as roadmap) is a `decision-summary`:
 
-```
-TL;DR: 3 PRD drafts (013/014/015) + NOTE-003 roadmap фиксированы. Drift risk:
-       PRD-015 устаревает к Q3 2026 без активации. Активировать по триггерам.
+```markdown
+> _Зафиксировал три PRD-черновика (013/014/015) и NOTE-003 с roadmap.
+> Активировать по триггерам, не вслепую. Главный риск: PRD-015 (cc-best)
+> станет неактуальным к Q3 2026 если откладывать._
 
-═══ 🎯 Decision ════════════════════════════════════════════════════
-  What:        Делать все 3 standalone skills, в порядке 014→013→015
-  Alternatives: Делать только 1 (узко) / Не делать (потеря momentum)
-  Trigger:     User explicit: "буду делать всё, но сперва зафиксировать"
+## 🎯 Решение
+  Выбрали:    Делать все 3 standalone skills, в порядке 014→013→015
+  Альтернативы: Делать только 1 / Не делать
+  Триггер:    User explicit: "буду делать всё, но сперва зафиксировать"
 
-═══ ✅ Recorded as ════════════════════════════════════════════════
-  PRD-013      .forgeplan/prds/PRD-013-...md         draft
-  PRD-014      .forgeplan/prds/PRD-014-...md         draft
-  PRD-015      .forgeplan/prds/PRD-015-...md         draft
-  NOTE-003     .forgeplan/notes/NOTE-003-...md       active
-
-═══ ➡️ Activation triggers ═══════════════════════════════════════
-  - Пользовательский запрос на standalone skill
-  - Adoption fpf/loux выше порога
-  - Свободное время + желание
+## ✅ Где зафиксировано
+  Что:    PRD-013, PRD-014, PRD-015 — drafts
+  Что:    NOTE-003 — strategic roadmap (active)
 ```
 
 ## When NOT to use
 
-- Decided alone, no alternatives existed → just announce inline.
-- Decision affects only this turn → context evaporates anyway.
-- Already recorded in ADR/PRD by tool — link, don't duplicate.
+- Decided alone, no alternatives existed → announce inline
+- Decision affects only this turn → context evaporates anyway
+- Already recorded by tool — link, don't duplicate

--- a/plugins/dev-toolkit/skills/forge-report/sections/01-templates/incident-summary.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/01-templates/incident-summary.md
@@ -2,97 +2,98 @@
 
 Use after: production incident, failing test investigation, mysterious bug fix, broken pipeline.
 
-## Template
+## Skeleton
 
-```
-TL;DR: <symptom>. Root cause + fix: <one line>. <prevention or risk>.
-       (Incidents may use up to 4 lines if all 4 facts cannot compress.)
+```markdown
+> _<TL;DR — symptom, root cause, fix, prevention. Up to 4 italic sentences
+> for incidents because all 4 facts usually need stating.>_
 
-═══ 🔥 Symptom ═══════════════════════════════════════════════════
-  Observed:    <what user/system saw>
-  When:        <timestamp / commit / version>
-  Severity:    <P0 outage / P1 degraded / P2 cosmetic>
-  Discovered:  <how it surfaced — alert / user report / spotted>
+## 🔥 Что случилось
 
-═══ 🔍 Root cause ════════════════════════════════════════════════
+  Симптом:     <What user/system saw>
+  Когда:       <timestamp / commit / version>
+  Серьёзность: <P0 outage / P1 degraded / P2 cosmetic>
+  Как нашли:   <alert / user report / spotted>
+
+## 🔍 Корневая причина
+
   <One paragraph: what actually broke and why>
 
-  Confidence: <🟢High / 🟡Medium / 🔴Assumed>
-  Evidence: <log line / commit / test that confirms>
+  Уверенность: High / Medium / Assumed
+  Доказательство: <log line / commit / test that confirms>
 
-═══ ✅ Fix applied ═══════════════════════════════════════════════
-  <Where>                              <What changed>
-  <Where>                              <What changed>
+## ✅ Что починено
 
-═══ ✅ Verification ═════════════════════════════════════════════
-  <Check>                              <Result>
-  Failing test now passes              ✅
-  Symptom not reproducible             ✅
-  Related tests still green            ✅
+  Что:  <change applied>
+  Где:  <file:line>
+  Как:  <what was changed>
+  ───────────────────────────────────────────────────────────────
+  ...
 
-═══ ⚪ Not done (intentional) ════════════════════════════════════
-  <related issue not addressed in this incident — why deferred>
-  <broader refactor postponed for separate task>
+## ✅ Как проверили что работает
 
-═══ 🔄 Reversibility ════════════════════════════════════════════
-  Fix reversible: <git revert path>
-  Workaround reversible until: <date — when proper fix lands>
-  Irreversible: <if data was modified / migrated mid-incident>
+  Проверка: Failing test now passes
+  Результат: ✅
+  ───────────────────────────────────────────────────────────────
+  Проверка: Симптом не воспроизводится
+  Результат: ✅
+  ───────────────────────────────────────────────────────────────
+  Проверка: Соседние тесты всё ещё green
+  Результат: ✅
 
-═══ ⚠️ Drift risks ═══════════════════════════════════════════════
-  <If similar code path is added — same bug returns>
-  <Workaround that should be replaced with proper fix>
+## ⚪ Что не сделано — намеренно
 
-═══ 🛡️ Prevention ═══════════════════════════════════════════════
-  <Test added / lint rule / CI check / runbook update>
-  <If "none" — explain why prevention is impractical>
+  Не сделано: <related issue not addressed>
+  Почему:     <deferred to separate task>
 
-═══ ➡️ Next steps / Post-mortem follow-ups ═════════════════════
-  - <action>     <owner>     <due>
-  - <action>     <owner>     <due>
+## 🔄 Что можно откатить
 
-💰 Cycle: <time-to-detect> · <time-to-fix> · <N tool calls>
+  Действие: Откатить fix
+  Команда:  git revert <commit>
+  Время:    ~1 минута
+  Риски:    Симптом вернётся — нужен alternative fix наготове
+  ───────────────────────────────────────────────────────────────
+  Действие: Workaround активен до даты X
+  Когда:    <when proper fix lands>
+  Что:     После этой даты workaround нужно убрать
+
+## ⚠️ Что может поломаться со временем
+
+  Риск:   Похожий код может появиться в новых features
+  Когда:  Постоянно
+  Что:    Тот же баг вернётся
+  Защита: Lint правило / тест / runbook — см. «Профилактика»
+
+## 🛡️ Профилактика
+
+  Что добавили: <test / lint rule / CI check / runbook update>
+  Где:          <path>
+  Зачем:        <prevents recurrence>
+
+  Если ничего: <explain why prevention impractical>
+
+## ➡️ Что делать дальше — post-mortem
+
+  Шаг 1: <АДРЕСАТ> — <action>     <due date>
+  Шаг 2: <АДРЕСАТ> — <action>     <due date>
+
+## 💰 Сколько это стоило
+
+  Время до обнаружения: <minutes/hours>
+  Время до фикса:       <minutes/hours>
+  Действий:             <tool calls>
 ```
 
 ## Required minimums
 
+- ✅ Blockquote TL;DR — incidents may use up to 4 sentences (symptom + root cause + fix + prevention)
 - ✅ Confidence label on root cause (often we *think* we know, but didn't fully verify)
-- ✅ Verification step ≠ "code compiles" — must reproduce + fail-then-pass
-- ✅ Prevention is **mandatory** — even if it's "no test possible, added runbook entry"
+- ✅ Verification ≠ "code compiles" — must reproduce + fail-then-pass
+- ✅ Profilactica is **mandatory** — even if "no test possible, added runbook entry"
 - ⚪ If incident is partially understood → say so explicitly, don't pretend full RCA
-
-## Real-world example
-
-```
-TL;DR: sync-standalone-skills.yml упал с "Input required and not supplied: token".
-       Root cause: secret STANDALONE_SYNC_TOKEN не был добавлен в маркетплейс.
-       Fix: maintainer добавил PAT через `gh secret set`. Prevention: README
-       в PR описывает шаг.
-
-═══ 🔥 Symptom ═══════════════════════════════════════════════════
-  Observed:    Workflow run 24954866577 failed at "Checkout target repo"
-  When:        2026-04-26T10:53Z (auto-trigger after PR #24 merge)
-  Severity:    P2 (cosmetic — sync mechanism not yet in production use)
-
-═══ 🔍 Root cause ════════════════════════════════════════════════
-  actions/checkout step requires token input. Token is supplied via
-  ${{ secrets.STANDALONE_SYNC_TOKEN }}. Secret was not present in
-  ForgePlan/marketplace, so the expression evaluated to empty.
-
-  Confidence: 🟢 High
-  Evidence: gh run view 25020112103 shows "token: ***" but error
-            "Input required and not supplied: token"
-
-═══ ✅ Fix applied ═══════════════════════════════════════════════
-  ForgePlan/marketplace settings   Added secret STANDALONE_SYNC_TOKEN
-
-═══ ✅ Verification ═════════════════════════════════════════════
-  Re-trigger workflow              ✅ pass (run 25020766130)
-  Idempotency (no diff = no commit) ✅ confirmed
-```
 
 ## Anti-patterns
 
-- ❌ "Fixed it" without root cause — bug returns next sprint.
-- ❌ Verification = "deployed" — that's not verification, that's deployment.
-- ❌ No prevention → repeats.
+- ❌ "Fixed it" without root cause — bug returns next sprint
+- ❌ Verification = "deployed" — that's not verification
+- ❌ No prevention → repeats

--- a/plugins/dev-toolkit/skills/forge-report/sections/01-templates/migration-summary.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/01-templates/migration-summary.md
@@ -2,88 +2,98 @@
 
 Use after: framework upgrade, dependency migration, restructure, rename, schema migration, big refactor.
 
-## Template
+## Skeleton
 
-```
-TL;DR: <from X to Y>. <N files changed>. <verification>. <rollback path>.
+```markdown
+> _<TL;DR — what migrated from/to, files touched, verification status,
+> rollback availability. 1-3 italic sentences.>_
 
-═══ 🔀 Migration scope ═══════════════════════════════════════════
-  From:        <old version / framework / structure>
-  To:          <new version / framework / structure>
-  Reason:      <why now — deprecation, perf, debt>
-  Strategy:    <big bang / gradual / dual-write / parallel>
+## 🔀 Что мигрировали
 
-═══ 📝 Affected ══════════════════════════════════════════════════
-  Files:       <count + key paths>
-  Tests:       <count> updated, <count> new
-  Docs:        <updated paths>
-  Schema/DB:   <changes if any>
+  Откуда:    <old version / framework / structure>
+  Куда:      <new version / framework / structure>
+  Причина:   <why now — deprecation, perf, debt>
+  Стратегия: <big bang / gradual / dual-write / parallel>
 
-═══ ✅ Verification ═════════════════════════════════════════════
-  <Check>                              <Result>     <Confidence>
-  All tests pass                       <result>     <label>
-  Functional smoke                     <result>     <label>
-  Performance vs baseline              <result>     <label>
-  Backward compatibility               <result>     <label>
+## 📈 Что затронули
 
-═══ ⚪ Not migrated (intentional) ════════════════════════════════
-  <Item — why skipped, when planned>
+  Файлы:    <count + key paths>
+  Тесты:    <count> обновлено, <count> новых
+  Документация: <updated paths>
+  Схема/БД: <changes if any>
 
-═══ 🔄 Rollback procedure ════════════════════════════════════════
-  Reversible: <how to roll back if needed — git revert, feature flag, schema down>
-  Window:     <until rollback becomes risky — e.g. "before next migration runs">
-  Irreversible: <list or "none">
+## ✅ Как проверили
 
-═══ ⚠️ Drift risks ═══════════════════════════════════════════════
-  <New code may introduce old patterns — add lint rule>
-  <Stale references in docs / comments>
+  Проверка:  <name>
+  Результат: <pass/fail + numbers>
+  Уверенность: High / Medium
+  ───────────────────────────────────────────────────────────────
+  Проверка:  All tests pass
+  Результат: 98/98 pass
+  Уверенность: High
+  ───────────────────────────────────────────────────────────────
+  Проверка:  Performance vs baseline
+  Результат: -8% latency (small sample)
+  Уверенность: Medium
+  ───────────────────────────────────────────────────────────────
+  Проверка:  Backward compat
+  Результат: <result>
+  Уверенность: <label>
 
-═══ 📈 Adoption signal ═══════════════════════════════════════════
-  How we'll know this migration succeeded:
-  - <metric / signal>
-  - <metric / signal>
+## ⚪ Что не мигрировано — намеренно
 
-═══ ➡️ Next steps ══════════════════════════════════════════════
-  1. <action>
-  2. <action>
+  Не мигрировали: <Item>
+  Почему:         <skipped this round / planned for later>
 
-💰 Cycle: <N files> · <N commits> · <~hours>
+## 🔄 Как откатить если что-то пошло не так
+
+  Действие: Полный rollback миграции
+  Команда:  git revert <commit-sha>
+  Время:    <how long>
+  Окно:     До <дата — когда rollback станет небезопасным>
+  Риски:    <if any>
+
+## ⚠️ Что может поломаться со временем
+
+  Риск:   Новый код может ввести старые паттерны
+  Когда:  Если разработчики не знают про миграцию
+  Что:    Recidivism — старые антипаттерны вернутся
+  Защита: Lint правило / документация / PR template
+  ───────────────────────────────────────────────────────────────
+  Риск:   Stale references в docs / комментариях
+  Когда:  Со временем
+  Что:    Документация введёт в заблуждение
+  Защита: Поиск по grep + обновление
+
+## 📊 Как поймём что миграция удалась
+
+  Сигнал 1: <metric / observable>
+  Сигнал 2: <metric / observable>
+
+## ➡️ Что делать дальше
+
+  Шаг 1: ТЕБЕ — <verify in prod>
+  Шаг 2: МНЕ — <follow-up cleanup>
+  Шаг 3: ПОТОМ — <next migration step if multi-phase>
+
+## 💰 Сколько это стоило
+
+  Время:        <hours>
+  Файлов:       <count>
+  Коммитов:     <count>
+  Стоимость:    <surprises / rework if any>
 ```
 
 ## Required minimums
 
-- ✅ Strategy named (big-bang, gradual, dual-write, parallel)
+- ✅ Blockquote TL;DR with from/to + verification status
+- ✅ Strategy named (big-bang / gradual / dual-write / parallel)
 - ✅ Rollback procedure even if "git revert" — never skip
 - ✅ Drift risks — migrations leave half-old/half-new state somewhere
-- ✅ Adoption signal — how to know it actually worked in production
-
-## Real-world example
-
-```
-TL;DR: Auth middleware migrated from express-jwt to jose. 14 files changed,
-       all tests green. Rollback: git revert (single commit). Drift risk:
-       legacy services still import old middleware path.
-
-═══ 🔀 Migration scope ═══════════════════════════════════════════
-  From:        express-jwt 6.x (deprecated, no maintenance)
-  To:          jose 5.x (active, ESM-native)
-  Reason:      CVE-2024-XXXXX in express-jwt, no patch
-  Strategy:    Big bang (single PR, all callers updated)
-
-═══ ✅ Verification ═════════════════════════════════════════════
-  Unit tests (auth)                    98/98 pass    🟢 High
-  E2E login flow                       pass          🟢 High
-  Performance JWT verify               -8% latency   🟡 Medium (small sample)
-  Backward compat (token format)       same JWT spec 🟢 High
-
-═══ 🔄 Rollback procedure ════════════════════════════════════════
-  Reversible: `git revert <commit>` then `npm install` — 5 min
-  Window:     Before rotating signing keys (planned 2026-05-15)
-  Irreversible: none until key rotation
-```
+- ✅ Adoption signal — how to know it actually worked
 
 ## Anti-patterns
 
-- ❌ "Migration complete!" without verification — false confidence.
-- ❌ No rollback plan — code stuck after first issue.
-- ❌ No drift risks — migration leaves zombie code paths.
+- ❌ "Migration complete!" without verification — false confidence
+- ❌ No rollback plan — code stuck after first issue
+- ❌ No drift risks — migration leaves zombie code paths

--- a/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/_index.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/_index.md
@@ -1,24 +1,35 @@
 # 02-required-sections — Mandatory blocks for every report
 
-These sections appear in **every** template. Their job is to surface
-what's normally invisible: boundaries, risks, future state.
+These sections appear in **every** template under their canonical headings.
+Their job is to surface what's normally invisible: boundaries, risks, future state.
 
-## Files
+## The 6 required sections
 
-| File | Section | Why mandatory |
-|------|---------|---------------|
-| `tldr.md` | TL;DR | Reader scans first 3 lines |
-| `not-done.md` | What was NOT done | Confirms boundaries |
-| `reversibility.md` | What can be rolled back | Trust + safety |
-| `drift-risks.md` | What may decay over time | Future maintenance |
-| `next-steps.md` | What user does next | Pickup pointer |
+| # | Section heading (Russian) | What it answers | File |
+|---|---|---|---|
+| 1 | TL;DR (italic blockquote at top) | "What changed and what do I need to do?" | `tldr.md` |
+| 2 | `## ⚪ Что не сделано — намеренно` | "Did you stay in scope?" | `not-done.md` |
+| 3 | `## 🔄 Что можно откатить если передумаешь` | "Can I undo this safely?" | `reversibility.md` |
+| 4 | `## ⚠️ Что может поломаться со временем` | "What watches do I need on this?" | `drift-risks.md` |
+| 5 | `## ➡️ Что делать дальше` | "What's next, and who does it?" | `next-steps.md` |
+| 6 | `## 💰 Сколько это стоило` | "How much effort did this take?" | (in template skeleton) |
+
+Plus the type-specific body (Что создано / Что обновлено / Корневая причина / etc.) per template.
 
 ## Why "required" matters
 
-Optional sections get skipped, then forgotten. **Mandatory sections force the author to think about them**, even if the answer is "—" (none).
+Optional sections get skipped, then forgotten. **Mandatory sections force the author to think about them**, even if the answer is "Не сделано: —".
 
-A 5-line "Not done: nothing intentionally skipped" is more useful than silence — it confirms the author *thought* about boundaries.
+A 3-line "Не сделано: ничего намеренно не пропущено" is more useful than silence — it confirms the author *thought* about boundaries.
 
 ## Compactness rule
 
-Required sections should be compact. If a section needs >5 lines, consider splitting into a dedicated section under the type-specific body.
+Required sections should be compact:
+- TL;DR: 1-3 sentences
+- Не сделано: 1-3 cards
+- Откатить: 1-2 cards
+- Поломается: 1-3 cards
+- Что дальше: 2-5 numbered steps with addressee
+- Стоимость: 4-5 lines
+
+If a required section needs more — split into the type-specific body.

--- a/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/drift-risks.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/drift-risks.md
@@ -1,4 +1,4 @@
-# Drift risks — Required section
+# `## ⚠️ Что может поломаться со временем` — Required section
 
 Describe what may **decay over time** — even though it works now.
 
@@ -13,21 +13,38 @@ Most production bugs are not "code is wrong" — they are "code was right when w
 
 A "drift risk" entry tells future-you: **"watch this".**
 
-## Format
+## Card format
 
-```
-═══ ⚠️ Drift risks ═════════════════════════════════════════════
-  <Risk>                              <When it bites>           <Mitigation>
-  <Risk>                              <When it bites>           <Mitigation>
+```markdown
+## ⚠️ Что может поломаться со временем
+
+  Риск:   <Specific risk, not theoretical>
+  Когда:  <Trigger — date, event, or condition>
+  Что:    <What breaks if trigger fires>
+  Защита: <How to prevent or recover>
+  ───────────────────────────────────────────────────────────────
+  ...
 ```
 
 ## Concrete examples
 
-```
-NOTE-003 references PRD-013/014/015     If PRD renamed              Update NOTE
-PAT STANDALONE_SYNC_TOKEN expires       2027-04 (fine-grained 1y)   Calendar reminder
-actions/checkout v4 uses Node 20        2026-09-16 (deprecation)    Bump to v5
-hardcoded URL https://api.x.com         If endpoint moves           Move to .env
+```markdown
+## ⚠️ Что может поломаться со временем
+
+  Риск:   NOTE-003 ссылается на PRD-013/014/015
+  Когда:  Если переименуешь PRD
+  Что:    Ссылки в NOTE будут битые
+  Защита: При rename PRD — обновить NOTE-003
+  ───────────────────────────────────────────────────────────────
+  Риск:   PAT STANDALONE_SYNC_TOKEN истекает
+  Когда:  2027-04 (fine-grained PAT, 1 год)
+  Что:    Auto-sync workflow перестанет работать
+  Защита: Календарный reminder за 2 недели
+  ───────────────────────────────────────────────────────────────
+  Риск:   actions/checkout@v4 использует Node.js 20
+  Когда:  2026-09-16 (deprecation date)
+  Что:    Workflow упадёт с warning, потом с ошибкой
+  Защита: Bump до v5 (см. NOTE-002)
 ```
 
 ## What counts as drift
@@ -43,11 +60,13 @@ hardcoded URL https://api.x.com         If endpoint moves           Move to .env
 
 ## When you can write "—"
 
-Truly stable change: pure isolated function, no external deps, no cross-refs. Then:
+Truly stable change: pure isolated function, no external deps, no cross-refs:
 
-```
-═══ ⚠️ Drift risks ═════════════════════════════════════════════
-  — (isolated change, no external dependencies)
+```markdown
+## ⚠️ Что может поломаться со временем
+
+  Риск:   —
+  Что:    Изменение изолированное, без внешних зависимостей
 ```
 
 But this should be **rare**. Most non-trivial work has some drift.

--- a/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/next-steps.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/next-steps.md
@@ -1,10 +1,10 @@
-# Next steps — Required section
+# `## ➡️ Что делать дальше` — Required section
 
 Tell the reader: **what should happen next, in what order, by whom**.
 
 ## Why this matters
 
-The end of one task is rarely the end of the work. Without explicit "next steps":
+The end of one task is rarely the end of the work. Without explicit next-steps:
 - User has to re-derive context to figure out what to do
 - Future-you (in next session) doesn't know where to pick up
 - Hand-offs break at agent/team boundaries
@@ -13,47 +13,57 @@ This section is the **pickup pointer** for resumption.
 
 ## Format
 
+Numbered list with explicit addressee:
+
+```markdown
+## ➡️ Что делать дальше
+
+  Шаг 1: <АДРЕСАТ> — <imperative action with context>
+  Шаг 2: <АДРЕСАТ> — <imperative action>
+  Шаг 3: <АДРЕСАТ> — <imperative action>
 ```
-═══ ➡️ Next steps ══════════════════════════════════════════════
-  1. <action>     <who>     <when>
-  2. <action>     <who>     <when>
-  3. <action>     <who>     <when>
-```
+
+## Addressee values
+
+| Addressee | When |
+|---|---|
+| `ТЕБЕ` | User must do this — typically verification, manual step, decision |
+| `МНЕ` | Claude/AI does this in the next message — typically continuation |
+| `ПОТОМ` | Conditional — when X happens, do Y |
+| `АВТОМАТУ` | CI / cron / hook will do this — no human action needed |
 
 ## Concrete examples
 
+```markdown
+## ➡️ Что делать дальше
+
+  Шаг 1: ТЕБЕ — открой новую сессию Claude (любой проект)
+                и дай задачу с 3+ файлами или 5+ действиями.
+                Если выйдет structured-отчёт — правило работает.
+
+  Шаг 2: ТЕБЕ — через неделю реального использования оцени:
+                • Не раздражает ли отчёт на средних задачах?
+                • Не пропускает ли важные?
+
+  Шаг 3: ПОТОМ — когда возьмёмся за PRD-014 (agentic-rag),
+                добавить туда ссылку на forge-report как живой пример.
 ```
-1. Test /report on a real task           you           today
-2. Update marketplace README             me            after merge
-3. Bump dev-toolkit dependents           none          when other plugins
-                                                       reference forge-report
-```
 
-## Three types of "next"
+## When OK to skip this section
 
-| Type | Example | Notes |
-|------|---------|-------|
-| **Immediate** | "Run smoke test" | Within minutes-hours |
-| **Soon** | "Add to CI" | Within days |
-| **Conditional** | "When X happens, do Y" | Pickup trigger |
-
-Mix these — but always order by urgency.
-
-## When OK to skip
-
-If task is **fully self-contained and final**:
+If task is **fully self-contained and final** AND nothing requires follow-up:
 - Standalone Q&A
 - Simple lookup
 - Confirmation-only response
 
 Then skip. But check honestly — most tasks have at least "verify it worked".
 
-## Pickup line for future sessions
+## Pickup pointer for future sessions
 
-If this report will outlive the conversation, add at the end:
+If the report will outlive the conversation, the last step should be a session-pickup line:
 
-```
-➡️ Future session pickup: open NOTE-003 → see roadmap → pick PRD-014
+```markdown
+  Шаг N: ПОТОМ — в новой сессии открой NOTE-003 → see roadmap → pick PRD-014
 ```
 
 A single line that lets a fresh Claude restart effectively.

--- a/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/not-done.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/not-done.md
@@ -1,25 +1,27 @@
-# Not done (intentional) — Required section
+# `## ⚪ Что не сделано — намеренно` — Required section
 
 Explicitly list what was **not** done — and that this was on purpose.
 
 ## Why this matters
 
-Without an explicit "Not done" section:
+Without an explicit "Не сделано" section:
 - User worries "did Claude touch X by accident?"
 - Boundaries between scope and out-of-scope are unclear
 - Future Claude (different session) may assume task wasn't fully attempted
 
-A 1-line "⚪ Not done: deployment to prod (waiting for approval)" prevents 5 minutes of "did we deploy?".
+A 1-card "Не сделано: deployment to prod / Почему: waiting for approval" prevents 5 minutes of "did we deploy?".
 
-## Format
+## Card format
 
+```markdown
+## ⚪ Что не сделано — намеренно
+
+  Не сделано: <Item>
+  Почему:     <Reason — out of scope / deferred / user's job>
+  ───────────────────────────────────────────────────────────────
+  Не сделано: <Item>
+  Почему:     <Reason>
 ```
-═══ ⚪ Not done (intentional) ════════════════════════════════════
-  <Item — why skipped>
-  <Item — why skipped>
-```
-
-Use ⚪ icon (not ❌ — that's failure, ⚪ is intentional skip).
 
 ## What to include
 
@@ -33,14 +35,17 @@ Use ⚪ icon (not ❌ — that's failure, ⚪ is intentional skip).
 
 - Things you forgot (those are bugs, not "not done")
 - Trivially out-of-scope (don't list "didn't update README of unrelated repo")
-- Speculation about what user *might* want (don't list everything you imagined)
+- Speculation about what user *might* want
 
-## When OK to write "—"
+## When OK to write a single "—" card
 
-If literally nothing was intentionally skipped, write:
-```
-═══ ⚪ Not done (intentional) ════════════════════════════════════
-  — (full task scope completed)
+If literally nothing was intentionally skipped:
+
+```markdown
+## ⚪ Что не сделано — намеренно
+
+  Не сделано: —
+  Почему:     Полный объём задачи выполнен, ничего не отложено
 ```
 
 This still proves you thought about it.

--- a/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/reversibility.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/reversibility.md
@@ -1,4 +1,4 @@
-# Reversibility — Required section
+# `## 🔄 Что можно откатить если передумаешь` — Required section
 
 Tell the reader: **what can be undone, what cannot, and how**.
 
@@ -12,33 +12,50 @@ Especially important after:
 - External system effects (PR, deploy, secret added, ticket created)
 - Long-running migrations / data transformations
 
-## Format
+## Card format
 
-```
-═══ 🔄 Reversibility ════════════════════════════════════════════
-  Reversible: <action — how to undo>
-  Reversible: <action — how to undo>
-  Irreversible: <action OR "none">
+```markdown
+## 🔄 Что можно откатить если передумаешь
+
+  Действие: <What to undo>
+  Команда:  <copy-paste command>
+  Время:    <how long the undo takes>
+  Риски:    <what might go wrong, or "Никаких">
+  ───────────────────────────────────────────────────────────────
+  Действие: <Another rollback>
+  ...
 ```
 
 ## Concrete examples
 
-```
-Reversible: rm -rf plugins/dev-toolkit/skills/forge-report (single dir)
-Reversible: gh pr close 25 (PR not yet merged)
-Reversible: git revert <commit-sha> (no downstream consumers yet)
-Irreversible: secret STANDALONE_SYNC_TOKEN created (can be rotated, not undone)
-Irreversible: PR #24 merged to main (history preserved, but production state changed)
+```markdown
+## 🔄 Что можно откатить если передумаешь
+
+  Действие: Удалить весь skill forge-report
+  Команда:  rm -rf plugins/dev-toolkit/skills/forge-report
+  Время:    Мгновенно
+  Риски:    /report команда станет бесполезной (но не сломается)
+  ───────────────────────────────────────────────────────────────
+  Действие: Откатить PR #25 целиком
+  Команда:  gh pr revert 25 --repo ForgePlan/marketplace
+  Время:    1 минута
+  Риски:    Никаких — единый коммит
+  ───────────────────────────────────────────────────────────────
+  Действие: Откатить bump версии
+  Команда:  Восстановить plugin.json и marketplace.json вручную
+  Время:    2 минуты
+  Риски:    Если кто-то уже установил v1.5.0 — у него будут несовпадения
 ```
 
-## Greybeards: include time window
+## Time windows
 
-For some "reversible" things, the window closes:
+Some "reversible" things have a window. Add explicit `Окно:` field:
 
-```
-Reversible until: 2026-05-15 (key rotation makes old auth uncallable)
-Reversible until: next migration runs
-Reversible until: customer first uses feature
+```markdown
+  Действие: Откатить миграцию схемы БД
+  Команда:  flyway undo
+  Окно:     До запуска следующей миграции (планируется 2026-05-15)
+  Риски:    После запуска новой — undo невозможен
 ```
 
 ## When reversibility is obvious
@@ -48,4 +65,4 @@ Skip this section only if **all** of:
 - No file changes
 - No external system effects
 
-In all other cases — include it, even if 1 line.
+In all other cases — include it, even if 1 card with "Действие: Никаких изменений делать не нужно".

--- a/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/tldr.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/02-required-sections/tldr.md
@@ -1,25 +1,32 @@
-# TL;DR — Required first block
+# TL;DR — Required first block (italic blockquote at top)
 
 Full rules in `00-anchors/tldr-format.md`. Quick reference here:
 
 ## Format
 
+```markdown
+> _<What changed in human language>. <What user needs to do or "no action needed">.
+> <One risk or dependency if relevant.>_
 ```
-TL;DR: <what changed>. <action OR "no action">. <one risk if applicable>.
-```
 
-## Length: 1-3 lines, ≤80 characters per line.
+That's it. Italic prose inside a blockquote, 1-3 sentences.
 
-**Exception**: `incident-summary` may use up to 4 lines when symptom + root cause + fix + prevention all need stating.
+## Position
 
-## Position: very first block, before any heading.
+Very first block of the report, **before** any heading.
 
-## Three slots
+## Length
+
+- Most cases: 1-2 sentences (30-60 words)
+- Long incidents (`incident-summary`): up to 4 sentences
+- Over 80 words → split or simplify
+
+## Three slots inside
 
 | Slot | Content | Required? |
 |------|---------|-----------|
 | 1 | What changed | Yes |
-| 2 | What user does | Yes (or explicit "no action") |
+| 2 | What user does | Yes (or explicit "no action needed") |
 | 3 | Biggest risk / dependency | Optional, omit if none |
 
 ## When TL;DR can be skipped

--- a/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/_index.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/_index.md
@@ -1,6 +1,6 @@
 # 03-anti-patterns — What NOT to do in reports
 
-Three failure modes that destroy the value of structured reports.
+Five failure modes that destroy the value of structured reports.
 
 ## Files
 
@@ -9,6 +9,8 @@ Three failure modes that destroy the value of structured reports.
 | `wall-of-text.md` | Long prose, no scannable structure |
 | `over-reporting.md` | Templates applied to trivial tasks |
 | `duplicate-info.md` | Same content repeated across sections |
+| `ascii-frames.md` | `═══ Section ═══` rectangles add visual noise |
+| `label-less-data.md` | Columns of numbers without explicit labels |
 
 ## How to use
 
@@ -16,4 +18,14 @@ Before sending a report, scan against these. If you spot one — refactor.
 
 ## The single rule
 
-A good report can be **scanned in 10 seconds** and **acted on in 30 seconds**. If your report fails either test, one of these anti-patterns is at play.
+A good report can be **scanned in 30 seconds** and **acted on in another 30 seconds**. If your report fails either test, one of these anti-patterns is at play.
+
+## Order of severity (worst first)
+
+1. **wall-of-text** — kills scannability completely
+2. **ascii-frames** — adds noise that competes with content
+3. **label-less-data** — reader can't decode without context
+4. **duplicate-info** — wastes time, breeds inconsistency
+5. **over-reporting** — context-dependent, often forgivable
+
+If short on time, fix in this order.

--- a/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/ascii-frames.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/ascii-frames.md
@@ -1,0 +1,59 @@
+# ASCII frames — Anti-pattern
+
+Wrapping every section heading in `═══ ✅ Section ═══════` rectangles.
+
+## Why it's bad
+
+- **Visual noise**: rectangles compete with content for attention
+- **Width brittleness**: 65 `═` characters look fine in one terminal, broken in another
+- **Markdown rendering**: in rendered Markdown viewers (web, IDE), `═══` doesn't compile to anything semantic — it's just a long horizontal slug
+- **Copy-paste pain**: reader can't easily copy a section without trimming the frame
+- **No semantic value**: a `##` heading already says "this is a section" — the frame adds nothing the heading didn't
+
+## Bad
+
+```markdown
+═══ ✅ Created ═══════════════════════════════════════════════════
+  Что:    forge-report skill
+  Где:    plugins/dev-toolkit/skills/forge-report/
+
+═══ 📈 Modified ════════════════════════════════════════════════
+  ...
+```
+
+## Good
+
+```markdown
+## ✅ Что сделано
+
+  Что:    forge-report skill
+  Где:    plugins/dev-toolkit/skills/forge-report/
+
+## 📈 Что обновлено
+
+  ...
+```
+
+The `##` heading is semantic, renders correctly in any Markdown viewer, and the section icon (✅) gives the same visual anchor without the noise.
+
+## Where lines ARE good
+
+Thin horizontal lines **between cards inside a section** are fine — they separate items of the same kind:
+
+```markdown
+## ✅ Что сделано
+
+  Что:    Skill «forge-report»
+  Где:    plugins/dev-toolkit/skills/forge-report/
+  ───────────────────────────────────────────────────────────────
+  Что:    Slash-команда /report
+  Где:    plugins/dev-toolkit/commands/report.md
+```
+
+Use simple `─` Unicode lines, not `═` doubles. One purpose: separate items, not decorate sections.
+
+## How to fix
+
+1. Find every `═══` block in your report.
+2. Replace with `## <icon> <Section name>`.
+3. Add `─` thin lines only between cards inside a section.

--- a/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/duplicate-info.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/duplicate-info.md
@@ -10,27 +10,32 @@ Same fact repeated across multiple sections.
 
 ## Bad
 
-```
-TL;DR: Created PR #25 with forge-report skill. Awaiting CI.
+```markdown
+> _Created PR #25 with forge-report skill. Awaiting CI._
 
-═══ ✅ Created ═══════════════════════════════════════════════════
-  PR #25 with forge-report skill                       awaiting CI
+## ✅ Что сделано
+  Что: PR #25 с forge-report skill
+  Статус: Awaiting CI
 
-═══ ➡️ Next steps ══════════════════════════════════════════════
+## ➡️ Что делать дальше
   1. Wait for CI on PR #25 (forge-report skill)
-  2. Merge once CI passes for PR #25 with forge-report
+  2. Merge once CI passes for PR #25 with forge-report skill
 ```
 
 (Same fact "PR #25 / forge-report / CI" stated 4 times.)
 
 ## Good
 
-```
-TL;DR: PR #25 (forge-report skill) opened, CI running. ETA ~30s.
+```markdown
+> _PR #25 (forge-report skill) opened, CI running. ETA ~30s._
 
-═══ ➡️ Next steps ══════════════════════════════════════════════
-  1. Wait for CI green
-  2. Merge → branch auto-deletes
+## ✅ Что сделано
+  Что: forge-report skill в dev-toolkit
+  PR:  #25 (CI запущен)
+
+## ➡️ Что делать дальше
+  Шаг 1: МНЕ — дождаться CI
+  Шаг 2: МНЕ — merge
 ```
 
 (Each fact stated once. Context flows.)
@@ -48,5 +53,5 @@ Read your own report from top to bottom. Mark every fact. If a fact appears 3+ t
 ## Refactor pattern
 
 1. Identify the **canonical place** for each fact (usually first occurrence).
-2. Other places link or reference (`see ✅ Created above`).
+2. Other places link or reference (`см. ✅ Что сделано выше`).
 3. Delete pure repetition.

--- a/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/label-less-data.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/label-less-data.md
@@ -1,0 +1,71 @@
+# Label-less data — Anti-pattern
+
+Showing columns of numbers, results, or values without explicit labels — forcing the reader to decode them.
+
+## Why it's bad
+
+- Reader has to **guess** what each column/value means
+- Same data point may mean different things in different contexts (`5` could be tasks, files, errors, minutes)
+- Codes like `🟢 Pass / 🟡 Medium / 🔴 Assumed` look terse but require legend lookup
+- Numbers without units (`200`) require context (200 ms? 200 lines? 200 USD?)
+
+## Bad
+
+```markdown
+## Verification
+  CI                pass (8s)               🟢 High
+  Smoke             pending                  🔴 Assumed
+  Lint              pass                     🟢 High
+```
+
+Reader thinks: "What's `🟢 High`? Confidence in what? In CI passing? In my judgment of CI? Are pending and Assumed related?"
+
+## Good
+
+```markdown
+## ✅ Как проверили
+
+  Проверка: CI на PR #26
+  Результат: Прошёл за 8 секунд
+  Уверенность: Высокая (gh pr view вернул "all checks passed")
+  ───────────────────────────────────────────────────────────────
+  Проверка: Smoke test /report на реальной задаче
+  Результат: Не выполнено
+  Уверенность: Не применимо — это шаг для пользователя
+  ───────────────────────────────────────────────────────────────
+  Проверка: Linting (ESLint, Prettier)
+  Результат: Прошёл без warnings
+  Уверенность: Высокая (стандартный CI шаг)
+```
+
+Each row stands alone. Reader knows what's measured, how, and how confident we are.
+
+## When labels are unnecessary
+
+Single-column tables where heading is the label, like:
+
+```markdown
+**Tests pass**: 98/98 (auth module, 2026-04-27)
+```
+
+The bold prefix is the label.
+
+## When you have many similar rows
+
+If 5+ rows have the same shape — a Markdown table is appropriate, but each column **must** have a header:
+
+```markdown
+| Проверка | Результат | Когда |
+|---|---|---|
+| CI | Прошёл за 8s | После push |
+| Lint | Прошёл | Локально |
+| Tests | 98/98 | В CI |
+```
+
+Tables work for **comparable** rows. Cards work for **different** items.
+
+## How to fix
+
+1. Find every value, status, or number in your report.
+2. Ask: "would a reader who didn't follow this work understand this?"
+3. If no — add explicit label or full sentence.

--- a/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/over-reporting.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/over-reporting.md
@@ -12,51 +12,52 @@ The whole point of a report template is that it **stands out** when shown.
 
 User: "Fix the typo in line 42"
 Claude:
-```
-TL;DR: Typo "teh" → "the" fixed in line 42 of README.md.
+```markdown
+> _Typo "teh" → "the" fixed in line 42 of README.md._
 
-═══ ✅ Created ══════════════════════════════════════════════════
-  — (no new files)
+## ✅ Что сделано
 
-═══ 🔵 Modified ════════════════════════════════════════════════
-  README.md           Line 42                          1 char change
+  Что: Typo fix
+  Где: README.md:42
+  Зачем: Improve readability
+  Статус: Done
 
-═══ 🔄 Reversibility ═══════════════════════════════════════════
-  Reversible: git checkout README.md
-  Irreversible: none
+## ⚪ Что не сделано
+  Не сделано: —
 
-═══ ⚠️ Drift risks ════════════════════════════════════════════
-  — (isolated typo fix)
+## 🔄 Что можно откатить
+  Действие: git checkout README.md
+  Время:    Мгновенно
 
-═══ ➡️ Next steps ═════════════════════════════════════════════
-  1. Review change
-
-💰 Cycle: 2 calls · 1 file · <1 min
+## 💰 Сколько это стоило
+  Время: 30 секунд
+  Действий: 1
 ```
 
 ## Good
 
 User: "Fix the typo in line 42"
-Claude: "Fixed `teh` → `the` in README.md:42."
+Claude: "Fixed `teh` → `the` in `README.md:42`."
 
 ## When to apply structured report
 
 Use the **2-of-4 trigger** from SKILL.md:
+
 - ≥5 tool calls
 - ≥3 files modified
 - TaskList ≥3 items
-- Cross-system effects
+- Cross-system effects (PR, deploy, secret added, external API)
 
 If at least 2 hit, use template. Otherwise — prose.
 
 ## Edge cases
 
-- **User explicitly invoked `/report`** → use template (they asked).
-- **Task started small but grew** → switch to template mid-flight.
-- **Series of small tasks** → wrap with one summary at end of session.
+- **User explicitly invoked `/report`** → use template (they asked)
+- **Task started small but grew** → switch to template mid-flight
+- **Series of small tasks in one session** → wrap with one summary at end
 
 ## How to recover from over-reporting
 
 If you feel "this report is overkill", trust the feeling. Cut to:
 - One TL;DR-style line, OR
-- A small block with what changed + verification.
+- A single small block with what changed + verification.

--- a/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/wall-of-text.md
+++ b/plugins/dev-toolkit/skills/forge-report/sections/03-anti-patterns/wall-of-text.md
@@ -1,6 +1,6 @@
 # Wall of text — Anti-pattern
 
-Long flowing prose with no anchors, no tables, no structure.
+Long flowing prose with no anchors, no cards, no structure.
 
 ## Why it's bad
 
@@ -13,7 +13,7 @@ Reader can't scan. Has to read every word to find the answer to "what changed" o
 dev-toolkit, который содержит SKILL.md как роутер и четыре секции:
 00-anchors с тремя файлами status-icons, tldr-format и confidence-levels,
 01-templates с пятью шаблонами для разных типов задач, 02-required-sections
-с пятью обязательными блоками для всех отчётов и 03-anti-patterns с тремя
+с пятью обязательными блоками для всех отчётов и 03-anti-patterns с пятью
 антипаттернами. Также добавил slash command /report и обновил версию
 плагина до 1.5.0. Все файлы прошли валидацию. Следующий шаг — отправить
 PR в маркетплейс и дождаться merge.
@@ -21,25 +21,35 @@ PR в маркетплейс и дождаться merge.
 
 ## Good
 
-```
-TL;DR: forge-report skill добавлен в dev-toolkit, 19 файлов, /report
-       command, плагин bumped до v1.5.0. CI green. Готово к PR.
+```markdown
+> _Создал skill `forge-report` в `dev-toolkit`. Версия плагина 1.5.0.
+> Готово к PR в marketplace._
 
-═══ ✅ Created ═══════════════════════════════════════════════════
-  SKILL.md            plugins/dev-toolkit/skills/forge-report/
-  00-anchors/         3 files (status-icons, tldr-format, confidence)
-  01-templates/       5 files (build/audit/decision/incident/migration)
-  02-required/        5 files (tldr, not-done, reversibility, drift, next)
-  03-anti-patterns/   3 files (wall-of-text, over-reporting, duplicate)
-  /report command     commands/report.md
+## ✅ Что сделано
 
-═══ ➡️ Next steps ══════════════════════════════════════════════
-  1. Open PR to marketplace
+  Что:    Skill «forge-report»
+  Где:    plugins/dev-toolkit/skills/forge-report/
+  Размер: 21 файл (1 router + 4 индекса + 16 страниц)
+  Зачем:  Шаблоны структурированных отчётов
+  Статус: Готов, валидация прошла
+
+  Что:    /report slash command
+  Где:    plugins/dev-toolkit/commands/report.md
+  Зачем:  Явный вызов отчёта когда автотриггер не сработал
+  Статус: Готов
+
+## ➡️ Что делать дальше
+
+  Шаг 1: МНЕ — открыть PR в marketplace
 ```
 
 ## How to fix
 
 1. Identify the **3-5 facts** the user actually needs.
-2. Put them in a **scannable structure** (table, bullet list, code block).
+2. Put them in **cards** (not tables, not paragraphs).
 3. Cut everything else.
 4. If you still have prose, ask: "would I want to read this if I weren't required to?"
+
+## Border case — explanations belong in prose
+
+Some content is genuinely paragraphs of reasoning (architectural decisions, post-mortem analysis). For those, prose is correct — but **break it up** with subheadings every 3-5 sentences.


### PR DESCRIPTION
## Summary
- Rewrite all 5 forge-report templates in **card-based format** based on user UX feedback.
- TL;DR is now italic blockquote prose, not a code block.
- Section icons live only in `## h2` headings — no row decorations.
- 2 new anti-pattern files: `ascii-frames.md`, `label-less-data.md`.
- Bump dev-toolkit 1.5.0 → 1.5.1 (patch), marketplace 1.8.0 → 1.8.1.

## Why
Previous format failed the "30-second scan" test:
- `═══ Section ═══` ASCII frames added visual noise
- Tables without labels: `🟢 Pass / 🔴 Assumed` required legend lookup
- Jargon: `smoke test`, `Audit round 1`, `5/5 PASS` — unclear without context

User feedback was specific: prefer explicit `Что: / Где: / Статус:` labels with horizontal `─` separators between cards.

## What changed (23 files, +1027/-646)

| Type | Files |
|---|---|
| Templates rewritten | 5 (build/audit/decision/incident/migration) |
| Anchors updated | 3 (status-icons, tldr-format, confidence-levels) |
| Required-sections updated | 6 (_index + 5 section files) |
| Anti-patterns added | 2 (ascii-frames, label-less-data) |
| Anti-patterns updated | 4 (_index, wall-of-text, over-reporting, duplicate-info) |
| SKILL.md router | rewritten |
| Plugin manifest + marketplace catalog | bumped |

## Verification
- `./scripts/validate-all-plugins.sh` — ALL PASSED (11 plugins, 14 commands)
- All cross-references between SKILL.md and section files preserved
- Section icons (✅📈⚪🔄⚠️➡️💰) and confidence labels (🟢🟡🔴) namespace separation preserved

## Test plan
- [x] Plugin validation passes
- [x] No command collisions
- [x] Frontmatter intact in SKILL.md
- [ ] Post-merge: produce a real report using new format on next multi-step task

Refs: PRD-016 (extends initial implementation)