### PR TITLE
fix(fpl-skills): correct .forgeplan secrets contract + align READMEs (v1.0.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.10.1"
+    "version": "1.10.2"
   },
   "plugins": [
     {
       "name": "fpl-skills",
       "source": "./plugins/fpl-skills",
       "description": "Flagship workflow plugin for the ForgePlan ecosystem. 15 engineering skills (research, refine, sprint, audit, diagnose, autorun + bootstrap, /fpl-init one-shot setup, and session helpers) that delegate artifact lifecycle to forgeplan. Canonical entry point — install fpl-skills + forgeplan and you have everything you need to run the full route → shape → build → audit → activate workflow.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "ForgePlan"
       },

--- a/plugins/fpl-skills/.claude-plugin/plugin.json
+++ b/plugins/fpl-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fpl-skills",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Flagship workflow plugin for the ForgePlan ecosystem. 15 engineering skills (research, refine, sprint, audit, diagnose, autorun, plus session and project bootstrap helpers including /fpl-init) that delegate artifact lifecycle to forgeplan. Designed as the canonical entry point: install fpl-skills + forgeplan and you have everything you need to run the full route → shape → build → audit → activate workflow.",
   "author": {
     "name": "ForgePlan"

--- a/plugins/fpl-skills/skills/bootstrap/resources/guides/FORGEPLAN-SETUP.md
+++ b/plugins/fpl-skills/skills/bootstrap/resources/guides/FORGEPLAN-SETUP.md
@@ -1,0 +1,238 @@
+# Forgeplan setup contract — `.forgeplan/` workspace
+
+Authoritative reference for setting up `.forgeplan/` correctly in a project.
+Deviations break team collaboration and risk leaking API keys via `git`.
+Keep this file in sync with the actual `forgeplan` CLI behaviour — when the
+CLI changes the contract, update here first, then propagate to
+`CLAUDE.md.template` and verification scripts.
+
+---
+
+## TL;DR
+
+`config.yaml` stores the **names** of env vars holding API keys (not the
+keys themselves). The actual keys live in process env / `.env`
+(gitignored, loaded via direnv or similar). `.forgeplan/.gitignore` has a
+fixed list of derived/runtime state. All artifact kinds (including
+`memory/`, `notes/`, `state/`) are **tracked**.
+
+---
+
+## Canonical `.forgeplan/.gitignore`
+
+```gitignore
+# Forgeplan derived/cache/runtime state — NOT committed.
+# Source of truth: markdown in prds/, rfcs/, adrs/, specs/, epics/,
+# evidence/, problems/, solutions/, refresh/, notes/, memory/
+# + lifecycle YAML in state/
+# + config.yaml (project config — TRACKED, but without literal API keys)
+
+lance/                 # LanceDB vector index — derived
+.fastembed_cache/      # bge-m3 embedding model cache (~600 MB)
+logs/                  # local audit/ops logs (per-machine)
+.lock                  # runtime mutex
+session.yaml           # runtime focus/claim state (per-machine)
+trash/                 # soft-deleted artifacts
+discovery/             # ephemeral research findings
+
+# 🔴 Secrets (env var loaders)
+.env
+.env.local
+```
+
+## What is mandatory tracked
+
+`config.yaml`, and **all** artifact-kind directories: `prds/`, `rfcs/`,
+`adrs/`, `specs/`, `epics/`, `evidence/`, `problems/`, `solutions/`,
+`refresh/`, `notes/`, `memory/`, `state/`.
+
+---
+
+## How to handle API keys (the real mechanism)
+
+`.forgeplan/config.yaml` does **not** store the key itself — it stores the
+**name** of the env var:
+
+```yaml
+llm:
+  provider: gemini
+  model: gemini-2.0-flash-thinking-exp-01-21
+  api_key_env: GEMINI_API_KEY    # ← env var name, not the key itself
+  max_tokens: 8192
+
+embedding:
+  model: bge-m3
+
+# scoring, decay, fpf rules — also tracked in config.yaml
+```
+
+The actual key lives in process env. Options:
+
+- `.env` file (gitignored) + direnv or dotenv-loader in shell
+- Export in `~/.zshrc` / `~/.bashrc` (local dev machine only)
+- CI secrets (GitHub Actions secrets, GitLab CI variables, etc.)
+- `export GEMINI_API_KEY=...` before each `forgeplan` invocation
+
+When committing `config.yaml`, confirm it does not contain a literal API
+key (e.g. `api_key: "sk-..."` or `api_key: "AIza..."`). If you accidentally
+committed a literal — `git rm --cached`, rewrite to `api_key_env`, and
+**revoke the leaked key** (it is already in git history).
+
+## Env var overrides (priority: env > config.yaml > default)
+
+Forgeplan reads the following variables at runtime:
+
+- `FORGEPLAN_LLM_PROVIDER` — overrides `llm.provider` in config
+- `FORGEPLAN_LLM_MODEL` — overrides `llm.model`
+- `FORGEPLAN_LLM_BASE_URL` — overrides `llm.base_url`
+- `FORGEPLAN_LLM_MAX_TOKENS` — overrides `llm.max_tokens`
+- `FORGEPLAN_LLM_API_KEY_ENV` — overrides which env var contains the API key
+- `FORGEPLAN_EMBEDDING_MODEL` — overrides `embedding.model`
+- `FORGEPLAN_STORAGE_DRIVER` / `FORGEPLAN_STORAGE_PATH`
+- `FORGEPLAN_MEMORY_DRIVER`
+
+This means local dev can override config from shell without editing the
+file.
+
+---
+
+## Three anti-patterns to avoid
+
+### ❌ 1. Gitignoring `memory/`
+
+`memory/` is an artifact kind in Forgeplan (categories:
+`fact` / `convention` / `constraint` / `observation` / `procedure`).
+**Tracked.** Do not confuse with Hindsight MCP memory (a separate system
+with per-project banks).
+
+### ❌ 2. Literal API key in `config.yaml`
+
+```yaml
+# WRONG:
+llm:
+  api_key: "sk-proj-..."
+
+# RIGHT:
+llm:
+  api_key_env: "OPENAI_API_KEY"
+```
+
+`config.yaml` is tracked, so a literal key is a **leak in git history**.
+
+### ❌ 3. Tracked `session.yaml`
+
+`session.yaml` is per-machine runtime state (current focus, claim TTLs).
+Forgeplan writes to it on every operation. If tracked → merge conflicts on
+every PR.
+
+---
+
+## Setup steps
+
+```bash
+# 1. Init forgeplan (if not already done)
+forgeplan init -y
+
+# 2. Create the canonical .gitignore
+$EDITOR .forgeplan/.gitignore
+# (paste the content from "Canonical .forgeplan/.gitignore" above)
+
+# 3. Verify config.yaml does not contain a literal API key
+grep -E '^\s*api_key:\s*["'"'"']?[A-Za-z0-9_-]{20,}' .forgeplan/config.yaml
+# If anything matches — that is a literal key. Replace with api_key_env.
+
+# 4. Create .env (gitignored) with real keys
+cat > .env <<'EOF'
+# Local dev secrets — DO NOT commit (.env is gitignored)
+GEMINI_API_KEY=AIza...your-actual-key-here
+EOF
+
+# 5. Load env when working with forgeplan:
+# Option A — direnv (auto-load):
+echo "dotenv .env" > .envrc
+direnv allow
+
+# Option B — manual export per session:
+set -a && source .env && set +a
+
+# Option C — CI: use the platform's secrets manager.
+
+# 6. Stage the correct paths
+git add .forgeplan/.gitignore
+git add .forgeplan/config.yaml          # must use api_key_env, not literal
+git add .forgeplan/prds/ .forgeplan/rfcs/ .forgeplan/adrs/ \
+        .forgeplan/specs/ .forgeplan/epics/ \
+        .forgeplan/evidence/ .forgeplan/problems/ \
+        .forgeplan/solutions/ .forgeplan/refresh/ \
+        .forgeplan/notes/ .forgeplan/memory/ \
+        .forgeplan/state/ 2>/dev/null
+
+# 7. If something incorrect was already tracked:
+git rm --cached .forgeplan/session.yaml 2>/dev/null
+git rm -r --cached .forgeplan/lance/ 2>/dev/null
+git rm -r --cached .forgeplan/.fastembed_cache/ 2>/dev/null
+
+# 8. Commit
+git commit -m "chore(forgeplan): align .forgeplan/.gitignore with canonical contract"
+```
+
+## Verification (run after the commit)
+
+```bash
+# Should be tracked (path returned):
+git ls-files .forgeplan/.gitignore
+git ls-files .forgeplan/config.yaml
+git ls-files .forgeplan/prds/ | head -3
+git ls-files .forgeplan/notes/ | head -3
+git ls-files .forgeplan/memory/ 2>/dev/null
+
+# Should be IGNORED (empty output):
+git ls-files .forgeplan/lance/
+git ls-files .forgeplan/.fastembed_cache/
+git ls-files .forgeplan/session.yaml
+git ls-files .forgeplan/.env
+
+# config.yaml does not contain literal keys:
+! grep -qE 'api_key:\s*["'"'"']?(sk-|AIza|ant-)[A-Za-z0-9_-]{20,}' .forgeplan/config.yaml \
+  && echo "✅ config.yaml clean" \
+  || echo "❌ literal API key detected — fix before push"
+
+# CLI works:
+forgeplan health
+forgeplan list | head -5
+```
+
+---
+
+## Bonus: agent instruction for project `CLAUDE.md`
+
+Add to the AI-agent rules section of the project's `CLAUDE.md`:
+
+> Forgeplan artifact mutations through MCP/CLI **only**
+> (`mcp__forgeplan__forgeplan_*` or the `forgeplan` CLI). Never use
+> `Edit` / `Write` / `sed` directly on
+> `.forgeplan/{prds,adrs,specs,rfcs,evidence,notes,memory,solutions,problems,refresh}/*.md`
+> or `state/*.yaml`. Direct edits desync the LanceDB index, the state
+> machine, and the canonical body. Recovery:
+> `forgeplan_update id=<ID> body=<full new body>` (idempotent) or
+> `forgeplan scan-import` rebuilds LanceDB from markdown.
+
+---
+
+## Why this contract exists
+
+- **Source of truth**: markdown is human-readable, diff-friendly, survives
+  forgeplan version changes. The vector index (`lance/`) is rebuilt from
+  it on every `forgeplan scan-import`.
+- **12-factor secrets**: separating *what env var holds the key* (in
+  tracked config) from *the key itself* (in untracked env) lets the same
+  config work across dev/staging/prod without code changes, and prevents
+  accidental commits.
+- **`memory/` and `notes/` ARE artifacts**: forgeplan treats them like
+  PRDs and ADRs — typed, scored, lifecycle-managed. They aren't "user
+  notes" to be hidden in `.gitignore`.
+- **`state/*.yaml`**: lifecycle state machine per artifact. Tracked
+  because it encodes lifecycle transitions that other team members need
+  to see (e.g. who activated an artifact and when).
+- **`session.yaml`**: per-machine focus / claims. **Not tracked** because
+  it's transient and would conflict on every PR.

--- a/plugins/fpl-skills/skills/bootstrap/resources/templates/CLAUDE.md.template
+++ b/plugins/fpl-skills/skills/bootstrap/resources/templates/CLAUDE.md.template
@@ -23,9 +23,9 @@ Russian acceptable in commit body and this file when it adds clarity.
      "yes" in the current session. Don't dilute with non-critical rules. -->
 
 - **Destructive git** (`push --force`, `reset --hard`, branch/tag deletion, `rebase -i` on shared history) — only after explicit confirmation in the current session.
-- **No secrets in git** — `.env`, tokens, API keys, certificates. Run `git status` before `git add` and confirm no sensitive files staged.
+- **No secrets in git** — `.env`, tokens, API keys, certificates. Run `git status` before `git add` and confirm no sensitive files staged. Specifically: `.forgeplan/config.yaml` is tracked but must use `api_key_env: VAR_NAME`, never literal `api_key: "sk-..."`. If a literal key landed in any commit: rewrite, **revoke the leaked key**, force-push only the fix commit (with confirmation).
 - **No bypass of branch protection** — `main` (and `dev` if used) merges only via PR. No direct push.
-- **No `forgeplan` artifact direct edits** — `.forgeplan/{prds,rfcs,adrs,specs,evidence,notes}/*.md` are managed by the CLI/MCP only. Direct `Edit`/`Write`/`sed` desyncs the LanceDB index and state machine. Use `forgeplan update`/`new`/`link`/`activate`. Recovery: `forgeplan scan-import` rebuilds the index from markdown.
+- **No `forgeplan` artifact direct edits** — `.forgeplan/{prds,rfcs,adrs,specs,epics,evidence,problems,solutions,refresh,notes,memory}/*.md` and `.forgeplan/state/*.yaml` are managed by the CLI/MCP only. Direct `Edit`/`Write`/`sed` desyncs the LanceDB index, the state machine, and the canonical body. Use `forgeplan update`/`new`/`link`/`activate`/`deprecate` (or `mcp__forgeplan__forgeplan_*` MCP tools). Recovery: `forgeplan_update id=<ID> body=<full new body>` (idempotent) or `forgeplan scan-import` rebuilds LanceDB from markdown. Direct edit is OK only for non-forgeplan markdown (READMEs, this CLAUDE.md, src code).
 - **No long/expensive operations** (deploy, DB migrations, mass network/LLM calls, package publish) without explicit confirmation.
 {{IF_PUBLIC_PACKAGE}}- **No `{{PUBLISH_CMD}}` without confirmation** — this is a published package; releases go through changelog/version flow. Once published, a version cannot be deleted (only deprecated).
 {{/IF_PUBLIC_PACKAGE}}
@@ -392,16 +392,36 @@ If any step fails, fix it. Don't `--no-verify` the pre-commit hook.
 
 ## Storage layout
 
+`.forgeplan/` mixes tracked artifacts (the source of truth) with derived /
+runtime state. Get this right or risk leaking API keys / generating merge
+conflicts on every PR. Full setup contract:
+[`guides/FORGEPLAN-SETUP.md`](../bootstrap/resources/guides/FORGEPLAN-SETUP.md)
+(in the plugin source — open via `Read` for the complete reference).
+
 ```
-.forgeplan/                      ← decision artifacts (managed by CLI/MCP)
-├── prds/                        ← product requirements
-├── rfcs/                        ← architecture proposals
-├── adrs/                        ← decision records (with valid_until TTL)
-├── specs/                       ← API/interface contracts
-├── evidence/                    ← verifications linked to PRDs/ADRs
-├── notes/                       ← lightweight context not warranting a full artifact
-├── lance/                       ← ⚠️ gitignored (derived index — `forgeplan scan-import` rebuilds)
-└── .fastembed_cache/            ← ⚠️ gitignored (model weights)
+.forgeplan/                      ← managed by CLI/MCP, mostly tracked
+├── prds/                        ← TRACKED — product requirements
+├── rfcs/                        ← TRACKED — architecture proposals
+├── adrs/                        ← TRACKED — decisions (with valid_until TTL)
+├── specs/                       ← TRACKED — API / data-model contracts
+├── epics/                       ← TRACKED — groupings of PRD[]/RFC[]
+├── evidence/                    ← TRACKED — measurements / tests / audits
+├── problems/                    ← TRACKED — problem cards
+├── solutions/                   ← TRACKED — solution portfolios
+├── refresh/                     ← TRACKED — re-evaluation of stale ADRs
+├── notes/                       ← TRACKED — micro-decisions (90-day TTL)
+├── memory/                      ← TRACKED — typed memory (fact/convention/constraint/observation/procedure) — NOT Hindsight!
+├── state/                       ← TRACKED — lifecycle state machine YAML (one per artifact)
+├── config.yaml                  ← TRACKED — project config (uses api_key_env, never literal keys)
+├── .gitignore                   ← TRACKED — lists what NOT to track
+│
+├── lance/                       ← ❌ gitignored — LanceDB vector index (rebuild via `forgeplan scan-import`)
+├── .fastembed_cache/            ← ❌ gitignored — bge-m3 model cache (~600 MB)
+├── logs/                        ← ❌ gitignored — local audit/ops logs
+├── .lock                        ← ❌ gitignored — runtime mutex
+├── session.yaml                 ← ❌ gitignored — per-machine focus / claim TTLs (NOT shared)
+├── trash/                       ← ❌ gitignored — soft-deleted artifacts
+└── discovery/                   ← ❌ gitignored — ephemeral research findings
 
 docs/
 ├── agents/                      ← per-project metadata read by fpl-skills
@@ -412,15 +432,55 @@ docs/
 └── ...                          ← project-specific docs
 
 CONTEXT.md                       ← ubiquitous language / domain glossary
+.env                             ← ❌ gitignored — actual secrets (loaded via direnv or manual `source`)
 CLAUDE.md                        ← this file
 ```
 
-LLM provider keys (used by `forgeplan reason`, FPF semantic search) live in
-your shell environment (`$ANTHROPIC_API_KEY`, `$OPENAI_API_KEY`, etc.), not
-in any tracked file.
+### Secrets — 12-factor pattern
 
-**Fresh clone**: `git clone … && forgeplan init -y && forgeplan scan-import`.
-The `lance/` index is rebuilt from the canonical markdown.
+`config.yaml` is **tracked** but contains only the **name** of the env var holding the API key, never the key itself:
+
+```yaml
+llm:
+  provider: gemini
+  model: gemini-2.0-flash-thinking-exp-01-21
+  api_key_env: GEMINI_API_KEY    # ← env var NAME, not the key
+  max_tokens: 8192
+
+embedding:
+  model: bge-m3
+```
+
+The actual key (`GEMINI_API_KEY=AIza...`) lives in `.env` (gitignored), `~/.zshrc`, or CI secrets. Forgeplan reads it from process env at runtime.
+
+**Pre-commit check** — confirm no literal key slipped into `config.yaml`:
+
+```bash
+! grep -qE 'api_key:\s*["'"'"']?(sk-|AIza|ant-)[A-Za-z0-9_-]{20,}' .forgeplan/config.yaml \
+  && echo "✅ clean" || echo "❌ literal API key — revoke + rewrite to api_key_env"
+```
+
+If a literal key was committed: `git rm --cached`, rewrite to `api_key_env`, **revoke the leaked key** (it's already in git history), commit the fix.
+
+### Env var overrides
+
+Forgeplan accepts overrides without editing `config.yaml`:
+
+`FORGEPLAN_LLM_PROVIDER`, `FORGEPLAN_LLM_MODEL`, `FORGEPLAN_LLM_BASE_URL`, `FORGEPLAN_LLM_MAX_TOKENS`, `FORGEPLAN_LLM_API_KEY_ENV`, `FORGEPLAN_EMBEDDING_MODEL`, `FORGEPLAN_STORAGE_DRIVER`, `FORGEPLAN_STORAGE_PATH`, `FORGEPLAN_MEMORY_DRIVER`.
+
+Priority: env > config.yaml > built-in default.
+
+### Fresh clone protocol
+
+```bash
+git clone <repo>
+cd <repo>
+forgeplan init -y                    # creates lance/, .fastembed_cache/, etc.
+forgeplan scan-import                # rebuilds vector index from markdown
+# load .env if you have one:
+set -a && source .env && set +a      # or `direnv allow` if direnv is configured
+forgeplan health                     # verify clean state
+```
 
 ---
 
@@ -444,4 +504,5 @@ Replace these with the real constraints of *this* project. The whole point of th
 - `fpl-skills` plugin — installed via `/plugin install fpl-skills@ForgePlan-marketplace`.
 - Project decisions — `.forgeplan/adrs/` (open `*.md` directly for context; mutate via CLI/MCP only).
 - Authored guides — `guides/` if present (project-specific authoring conventions).
-- Team CLAUDE.md best practices — `~/.claude/skills/bootstrap/resources/guides/CLAUDE-MD-GUIDE.ru.md` (or in the plugin source) — explains why this file is structured the way it is.
+- CLAUDE.md best practices — `plugins/fpl-skills/skills/bootstrap/resources/guides/CLAUDE-MD-GUIDE.ru.md` — explains why this file is structured the way it is (U-curve attention, ≤7 red lines, primacy/reference/recency zones).
+- Forgeplan setup contract — `plugins/fpl-skills/skills/bootstrap/resources/guides/FORGEPLAN-SETUP.md` — canonical `.gitignore`, secrets layout, env var overrides, anti-patterns. Read before committing anything in `.forgeplan/`.


### PR DESCRIPTION
## Summary

Two related fixes shipped together as v1.0.2:

### Part 1 — secrets/gitignore contract (commit 73ac195)

The v1.0.1 template stated _"LLM provider keys live in shell environment, not in any tracked file"_. Incomplete. The real architecture is **12-factor**:

- `config.yaml` IS tracked.
- It contains `api_key_env: VAR_NAME` (the **name** of the env var).
- The actual key lives in `.env` (gitignored), `~/.zshrc`, or CI secrets.

Other v1.0.1 inaccuracies discovered while testing on a real workspace:

- Canonical `.gitignore` was incomplete — missing `logs/`, `.lock`, `session.yaml`, `trash/`, `discovery/`, `.env`, `.env.local`.
- `memory/` misclassified — it's a forgeplan artifact kind (typed: `fact`/`convention`/`constraint`/`observation`/`procedure`), tracked.
- `state/*.yaml` not mentioned — tracked, encodes lifecycle transitions.
- AI-agent rule for direct edits didn't enumerate `state/*.yaml` or all artifact kinds.

**Files changed**:
- New: `plugins/fpl-skills/skills/bootstrap/resources/guides/FORGEPLAN-SETUP.md` (238 lines) — full setup contract: canonical `.gitignore`, secrets, env var overrides, anti-patterns, pre-commit verification.
- Updated: `CLAUDE.md.template` — Storage layout rewritten with TRACKED/IGNORED labels per artifact kind, Secrets subsection, Env var overrides, Fresh clone protocol; AI-agent rule tightened to enumerate all artifact dirs + `state/*.yaml`.

### Part 2 — README alignment with marketplace template (commit 6a5db81)

The first cut of `plugins/fpl-skills/README.md` was 67 lines and didn't match the marketplace's canonical plugin README structure (tagline → Quick Start → Usage Examples → What's Included → Companion → Credits). Plus no `README-RU.md`, and the root marketplace README never got the fpl-skills catalog entry.

**Files changed**:
- `plugins/fpl-skills/README.md` (67 → 139 lines) — canonical structure with tagline, Usage Examples for `/fpl-init`/`/research`/`/audit`, Lifecycle integration table, Companion plugins table.
- `plugins/fpl-skills/README-RU.md` (new, 139 lines) — Russian mirror.
- `README.md` (root): stats updated (12 plugins, 15 commands, 5 KBs); fpl-skills added FIRST in "Available Plugins" with `[!TIP]` flagship callout; dev-toolkit moved DOWN with `[!CAUTION]` deprecation callout; "Where to Start?" matrix recommends fpl-skills as base for forgeplan users.
- `README-RU.md` (root) — mirrored.

## Verification

- [x] `./scripts/validate-all-plugins.sh` → ALL PASSED
- [x] All four READMEs render correctly
- [x] Cross-references work (CLAUDE-MD-GUIDE.ru.md, FORGEPLAN-SETUP.md, dev-toolkit/, fpl-skills/, etc.)
- [x] Stats line in root README matches reality (12 plugins, 15 commands)
- [x] CI `validate` already passed on commit 73ac195

## Test plan

- [x] Plugin README structure matches dev-toolkit/laws-of-ux/forgeplan-orchestra template
- [x] Bilingual link `[English](README.md) | [Русский](README-RU.md)` at top of every README
- [x] Quick Start has 2-3 commands max
- [x] Usage Examples section has realistic command/output blocks
- [x] What's Included is a clean table
- [x] No version bump in this commit (docs polish on top of v1.0.2)

## Version

`fpl-skills` 1.0.1 → **1.0.2** (Part 1).
Marketplace catalog **1.10.1 → 1.10.2** (Part 1).
Part 2 is documentation polish — no manifest version change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)