### PR TITLE
docs(fpl-skills): align plugin and marketplace READMEs with canonical template

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -8,7 +8,7 @@
 
 Официальный маркетплейс плагинов Claude Code от [ForgePlan](https://github.com/ForgePlan) — UX, воркфлоу, инженерные и dev-инструменты.
 
-**10 плагинов** | **60+ агентов** | **13 команд** | **4 базы знаний** | [Руководство](docs/USAGE-GUIDE-RU.md)
+**12 плагинов** | **60+ агентов** | **15 команд** | **5 баз знаний** | [Руководство](docs/USAGE-GUIDE-RU.md)
 
 ## Быстрый старт
 
@@ -32,20 +32,47 @@
 
 | Ваша роль | Установить | Зачем |
 |-----------|-----------|-------|
-| Любой разработчик | dev-toolkit + agents-core | Универсальные инструменты |
-| Фронтенд | + laws-of-ux + agents-domain | UX + агенты фреймворков |
-| Архитектор | + fpf + agents-pro + agents-sparc | Мышление + SPARC |
-| Пользователь Forgeplan | + forgeplan-workflow + forgeplan-orchestra | Полный цикл |
-| Всё сразу | Все 10 плагинов | Полная экосистема |
+| **Пользователь Forgeplan (рекомендуется)** | **fpl-skills** | Одна установка, 15 скиллов, полный цикл route → ship |
+| Любой разработчик (без forgeplan) | dev-toolkit + agents-core | Универсальные инструменты, без CLI зависимости |
+| Фронтенд | fpl-skills + laws-of-ux + agents-domain | UX + агенты фреймворков |
+| Архитектор | fpl-skills + fpf + agents-pro + agents-sparc | Мышление + SPARC |
+| Многосессионная работа / команда | fpl-skills + forgeplan-orchestra | Координация + Inbox Pattern |
+| Brownfield миграция | fpl-skills + forgeplan-brownfield-pack | Ингест legacy-доков + C4/DDD/research analyses |
+| Всё сразу | Все 12 плагинов | Полная экосистема |
 
 ## Доступные плагины
 
-### [dev-toolkit](plugins/dev-toolkit/)
+### [fpl-skills](plugins/fpl-skills/)
 
 > [!TIP]
-> **Рекомендуется первым** — работает с любым проектом и языком, без зависимостей.
+> **Флагман — рекомендуется пользователям forgeplan.** Бандл из 15 инженерных скиллов поверх forgeplan lifecycle. Заменяет `dev-toolkit` (мягко-deprecated).
 
-Универсальный инженерный тулкит — аудит, спринт-планирование и восстановление контекста сессии.
+Полный цикл **route → shape → build → audit → activate** в одной установке. `/fpl-init` разворачивает проект одной командой.
+
+| Компонент | Что получаете |
+|-----------|-------------|
+| `/fpl-init` | Развёртка проекта одной командой: forgeplan init, MCP wiring, CLAUDE.md, docs/agents/ |
+| `/research`, `/refine`, `/rfc` | Discovery → планирование → формализация |
+| `/sprint`, `/do`, `/autorun`, `/build`, `/team` | Execution (интерактивно, автопилот, multi-agent) |
+| `/audit`, `/diagnose` | Multi-expert ревью + 6-фазный debug loop |
+| `/restore`, `/briefing`, `/setup`, `/bootstrap` | Сессионные и проектные хелперы |
+| **SessionStart hook** | Context-aware подсказка следующего шага (статус, /fpl-init для новых репо) |
+
+> [!WARNING]
+> Требует CLI [`forgeplan`](https://github.com/ForgePlan/forgeplan) в `$PATH`.
+
+```bash
+/plugin install fpl-skills@ForgePlan-marketplace
+```
+
+---
+
+### [dev-toolkit](plugins/dev-toolkit/) — deprecated
+
+> [!CAUTION]
+> **Superseded by [`fpl-skills`](plugins/fpl-skills/).** Новые установки — на `fpl-skills`. Существующие `dev-toolkit` продолжают работать — soft-sunset до catalog v2.0.
+
+Универсальный инженерный тулкит — аудит, спринт-планирование и восстановление контекста сессии. Без зависимости от CLI.
 
 | Компонент | Что получаете |
 |-----------|-------------|

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Official plugin marketplace for Claude Code from [ForgePlan](https://github.com/ForgePlan) — UX, workflow, engineering, and developer tools.
 
-**10 plugins** | **60+ agents** | **13 commands** | **4 knowledge bases** | [Usage Guide](docs/USAGE-GUIDE.md) | [Architecture](docs/ARCHITECTURE.md)
+**12 plugins** | **60+ agents** | **15 commands** | **5 knowledge bases** | [Usage Guide](docs/USAGE-GUIDE.md) | [Architecture](docs/ARCHITECTURE.md)
 
 ## Quick Start
 
@@ -32,21 +32,47 @@ Official plugin marketplace for Claude Code from [ForgePlan](https://github.com/
 
 | Your role | Install these | Why |
 |-----------|--------------|-----|
-| Any developer | dev-toolkit + agents-core | Universal tools |
-| Frontend | + laws-of-ux + agents-domain | UX + framework agents |
-| Architect | + fpf + agents-pro + agents-sparc | Thinking + SPARC |
-| Forgeplan user | + forgeplan-workflow + forgeplan-orchestra | Full lifecycle |
-| Brownfield migration | + forgeplan-brownfield-pack | Ingest legacy docs + C4/DDD/research analyses |
-| Everything | All 11 plugins | Complete ecosystem |
+| **Forgeplan user (recommended)** | **fpl-skills** | One install, 15 skills, full route → ship loop |
+| Any developer (no forgeplan) | dev-toolkit + agents-core | Universal tools, no CLI dependency |
+| Frontend | fpl-skills + laws-of-ux + agents-domain | UX + framework agents |
+| Architect | fpl-skills + fpf + agents-pro + agents-sparc | Thinking + SPARC |
+| Multi-session / team | fpl-skills + forgeplan-orchestra | Coordination + Inbox Pattern |
+| Brownfield migration | fpl-skills + forgeplan-brownfield-pack | Ingest legacy docs + C4/DDD/research analyses |
+| Everything | All 12 plugins | Complete ecosystem |
 
 ## Available Plugins
 
-### [dev-toolkit](plugins/dev-toolkit/)
+### [fpl-skills](plugins/fpl-skills/)
 
 > [!TIP]
-> **Recommended first install** — works with any project and language, zero dependencies.
+> **Flagship — recommended for forgeplan users.** Bundles 15 engineering skills built on top of forgeplan's artifact lifecycle. Replaces `dev-toolkit` (now soft-deprecated).
 
-Universal engineering toolkit — audit, sprint planning, and session context restore.
+Full **route → shape → build → audit → activate** loop in one install. Includes `/fpl-init` for one-command project bootstrap.
+
+| Component | What you get |
+|-----------|-------------|
+| `/fpl-init` | One-shot project bootstrap: forgeplan init, MCP wiring, CLAUDE.md, docs/agents/ |
+| `/research`, `/refine`, `/rfc` | Discovery → planning → formalisation |
+| `/sprint`, `/do`, `/autorun`, `/build`, `/team` | Execution (interactive, autopilot, multi-agent) |
+| `/audit`, `/diagnose` | Multi-expert review + 6-phase debug loop |
+| `/restore`, `/briefing`, `/setup`, `/bootstrap` | Session and project helpers |
+| **SessionStart hook** | Context-aware next-step hint (status, /fpl-init prompt for new repos) |
+
+> [!WARNING]
+> Requires the [`forgeplan`](https://github.com/ForgePlan/forgeplan) CLI on `$PATH`.
+
+```bash
+/plugin install fpl-skills@ForgePlan-marketplace
+```
+
+---
+
+### [dev-toolkit](plugins/dev-toolkit/) — deprecated
+
+> [!CAUTION]
+> **Superseded by [`fpl-skills`](plugins/fpl-skills/).** New installs should use `fpl-skills`. Existing dev-toolkit installs keep working — soft-sunset until catalog v2.0.
+
+Universal engineering toolkit — audit, sprint planning, and session context restore. No CLI dependency.
 
 | Component | What you get |
 |-----------|-------------|

--- a/plugins/fpl-skills/README-RU.md
+++ b/plugins/fpl-skills/README-RU.md
@@ -1,0 +1,139 @@
+[English](README.md) | [Русский](README-RU.md)
+
+# fpl-skills
+
+> Флагманский workflow-плагин экосистемы [ForgePlan](https://github.com/ForgePlan/forgeplan). Одна установка — 15 инженерных скиллов, построенных поверх forgeplan-артефактов.
+
+Поставь `fpl-skills` + CLI `forgeplan` — и у тебя весь цикл **route → shape → build → audit → activate** в одном плагине. Заменяет старый `dev-toolkit` (мягко-deprecated).
+
+> [!WARNING]
+> Требуется CLI [`forgeplan`](https://github.com/ForgePlan/forgeplan) в `$PATH`. Установка: `brew install ForgePlan/tap/forgeplan` или `cargo install --git https://github.com/ForgePlan/forgeplan forgeplan-cli`.
+
+## Quick Start
+
+```bash
+/plugin install fpl-skills@ForgePlan-marketplace   # установить
+/fpl-init                                          # развернуть проект (одной командой)
+/restore                                           # в любой следующей сессии
+```
+
+Полный walkthrough пустого репо → готового проекта см. [`GETTING-STARTED.md`](./GETTING-STARTED.md).
+
+## Примеры использования
+
+### `/fpl-init` — развёртка проекта одной командой
+
+```
+> /fpl-init
+
+fpl-init plan for my-new-project:
+  • forgeplan init                    ← .forgeplan/ отсутствует
+  • wire .mcp.json                    ← добавить forgeplan MCP server
+  • wire .claude/settings.json        ← добавить forgeplan PreToolUse safety hook
+  • /bootstrap                        ← создать CLAUDE.md из шаблона (stack-detected)
+  • /setup                            ← интерактивный wizard для docs/agents/
+
+Companion plugins to consider after (NOT installed by this command):
+  fpf, agents-core, forgeplan-workflow, forgeplan-orchestra
+  laws-of-ux (only if this repo has frontend)
+
+Proceed? [y/n]
+```
+
+End-to-end с одним подтверждением. Завершается верификацией через `forgeplan health` и блоком «Next steps».
+
+### `/research` — глубокое многоагентное исследование
+
+```
+> /research streaming uploads vs presigned URLs
+
+Spawning 5 parallel agents...
+
+Code         ████████████  4 findings   (existing upload paths in src/api/)
+Docs         ██████░░░░░░  2 findings   (no ADR yet — design space open)
+Status       ████████░░░░  3 findings   (issue #87, RFC-014 in flight)
+References   ████████████  6 findings   (S3, GCS, Cloudflare R2 patterns)
+Memory       ██████░░░░░░  2 findings   (prior decision in PRD-024)
+
+Synthesis written to research/reports/uploads/REPORT.md
+Next: /refine to lock terminology, then /rfc create
+```
+
+### `/audit` — многоэкспертный code review
+
+```
+> /audit
+
+Launching reviewers (4 base + ux-reviewer because this PR touches frontend)...
+
+Logic           ████████░░  3 findings
+Architecture    ████████████  0 findings
+Types           ██████████  2 findings (1 HIGH)
+Security        ████████░░  4 findings
+UX              ██████░░░░  2 findings (Hick's Law on the new menu)
+
+11 findings: 1 HIGH, 5 MEDIUM, 5 LOW
+Fix HIGH issues now? [y/n]
+```
+
+## Что в комплекте
+
+| Компонент | Описание |
+|-----------|----------|
+| `/fpl-init` | Развёртка одной командой: forgeplan init, MCP wiring, CLAUDE.md, docs/agents/. Стартуй с этого. |
+| `/research` | 5 параллельных агентов (code · docs · status · references · memory) → `research/reports/`. |
+| `/refine` | Интервью-driven уточнение планов/RFC — терминология, противоречия, ADR/CONTEXT.md по ходу. |
+| `/rfc` | Создание / чтение / обновление RFC и ADR (каноничная структура, фазы, формат). |
+| `/sprint` | Wave-based execution фичи со строгим file ownership и зависимостями между волнами. |
+| `/audit` | Multi-expert code review (≥4 ревьюера — logic, architecture, types, security; +ux-reviewer если установлен). |
+| `/diagnose` | Дисциплинированный 6-фазный debug loop. Фаза 1 («построй feedback loop») — это весь скилл. |
+| `/autorun` | Автопилот-оркестратор — research → sprint → audit → report end-to-end. Для ночных прогонов. |
+| `/do` | Интерактивная версия `/autorun` (пауза-подтверждение на каждом шаге). |
+| `/build` | Исполнение готового IMPLEMENTATION-PLAN.md из research-отчёта (wave-by-wave). |
+| `/restore` | Восстановление контекста сессии из git + working copy + (опционально) долгосрочной памяти. |
+| `/briefing` | Утренний briefing задач/сообщений из трекера (Orchestra/Linear/Jira/GitHub) или локальных TODO. |
+| `/setup` | Интерактивный wizard конфигурации проекта (пишет `docs/agents/*.md`). |
+| `/bootstrap` | Универсальный CLAUDE.md template в новый или существующий проект (stack-aware). |
+| `/team` | Фундамент multi-agent команд — TeamCreate vs sub-agents, file ownership, recipes, cleanup. |
+| **SessionStart hook** | Проверяет `.forgeplan/`, `docs/agents/`, `CLAUDE.md`, печатает context-aware подсказку следующего шага. |
+
+## Интеграция с lifecycle
+
+Все скиллы делегируют lifecycle артефактов в `forgeplan`:
+
+| Фаза | Скилл | Что производит |
+|------|-------|----------------|
+| Observe | `/restore`, `/briefing`, SessionStart hook | Снапшот ветки/PR, обзор трекера, blind-spot dashboard |
+| Route | `/fpl-init`, `/setup` | Решение о глубине (Tactical/Standard/Deep/Critical) |
+| Shape | `/refine`, `/rfc`, `/research` | Драфты PRD, RFC, ADR, Evidence |
+| Build | `/sprint`, `/build`, `/do`, `/autorun`, `/team` | Реализация с file-ownership и волнами |
+| Prove | `/audit`, `/diagnose` | Multi-expert ревью, 6-фазный debug evidence |
+| Ship | (forgeplan CLI напрямую) | `forgeplan activate <id>`, `gh pr create` |
+
+## Сопутствующие плагины
+
+`/fpl-init` печатает install-команды, **не запускает** — пользователь решает сам:
+
+| Плагин | Когда ставить |
+|---|---|
+| [`fpf`](../fpf/) | First Principles Framework — пара к `/refine` и `/diagnose` для генерации гипотез. |
+| [`agents-core`](../agents-core/) | 11 базовых сабагентов — `/audit` и `/sprint` подхватывают их если установлены. |
+| [`forgeplan-workflow`](../forgeplan-workflow/) | Узкий forgeplan-only цикл через `/forge-cycle` и `/forge-audit`. Совместим с fpl-skills. |
+| [`forgeplan-orchestra`](../forgeplan-orchestra/) | Координация мульти-сессионной работы через `/sync` и `/session`. |
+| [`laws-of-ux`](../laws-of-ux/) | Frontend-ревьюер — `/audit` спавнит `ux-reviewer` если PR трогает UI. |
+| [`dev-toolkit`](../dev-toolkit/) | **Deprecated**, superseded by `fpl-skills`. Не ставь оба. |
+
+## Resource гайды
+
+Два reference-документа в плагине (`skills/bootstrap/resources/guides/`):
+
+- [`CLAUDE-MD-GUIDE.ru.md`](skills/bootstrap/resources/guides/CLAUDE-MD-GUIDE.ru.md) — почему `CLAUDE.md` структурирован именно так (U-curve attention, ≤7 red lines, primacy/reference/recency зоны).
+- [`FORGEPLAN-SETUP.md`](skills/bootstrap/resources/guides/FORGEPLAN-SETUP.md) — каноничный `.forgeplan/` setup-contract: gitignore, секреты (12-factor pattern с `api_key_env`), env var overrides, anti-patterns.
+
+## Credits
+
+Построен поверх [`forgeplan`](https://github.com/ForgePlan/forgeplan) и [Claude Code](https://claude.com/claude-code) plugin v2 schema. Скиллы частично адаптированы из [mattpocock/skills](https://github.com/mattpocock/skills) (engineering/diagnose, engineering/grill-with-docs).
+
+## License
+
+MIT

--- a/plugins/fpl-skills/README.md
+++ b/plugins/fpl-skills/README.md
@@ -1,66 +1,138 @@
+[English](README.md) | [Русский](README-RU.md)
+
 # fpl-skills
 
-Flagship workflow plugin for the [ForgePlan](https://github.com/ForgePlan/forgeplan) ecosystem. 15 engineering skills designed to give you a complete, opinionated workflow on top of forgeplan's artifact lifecycle.
+> Flagship workflow plugin for the [ForgePlan](https://github.com/ForgePlan/forgeplan) ecosystem. One install bundles 15 engineering skills built on top of forgeplan's artifact lifecycle.
 
-## Skills
+Install `fpl-skills` + the `forgeplan` CLI and you have everything you need for the full **route → shape → build → audit → activate** loop. Replaces the older `dev-toolkit` plugin (which is now soft-deprecated).
 
-| Skill | What it does |
-|---|---|
-| `/fpl-init` | One-command project bootstrap. Probes forgeplan, runs `forgeplan init`, wires `.mcp.json` + `.claude/settings.json`, runs `/bootstrap` + `/setup`, prints next steps. Start here on a new repo. |
-| `/research` | Deep research with 5 parallel agents (code · docs · status · references · memory). |
+> [!WARNING]
+> Requires the [`forgeplan`](https://github.com/ForgePlan/forgeplan) CLI on your `$PATH`. Install via `brew install ForgePlan/tap/forgeplan` or `cargo install --git https://github.com/ForgePlan/forgeplan forgeplan-cli`.
+
+## Quick Start
+
+```bash
+/plugin install fpl-skills@ForgePlan-marketplace   # install
+/fpl-init                                          # bootstrap a project (one-shot)
+/restore                                           # any subsequent session
+```
+
+For a fresh repo from zero see [`GETTING-STARTED.md`](./GETTING-STARTED.md).
+
+## Usage Examples
+
+### `/fpl-init` — one-command project bootstrap
+
+```
+> /fpl-init
+
+fpl-init plan for my-new-project:
+  • forgeplan init                    ← .forgeplan/ missing
+  • wire .mcp.json                    ← add forgeplan MCP server
+  • wire .claude/settings.json        ← add forgeplan PreToolUse safety hook
+  • /bootstrap                        ← create CLAUDE.md from template (stack-detected)
+  • /setup                            ← interactive wizard for docs/agents/
+
+Companion plugins to consider after (NOT installed by this command):
+  fpf, agents-core, forgeplan-workflow, forgeplan-orchestra
+  laws-of-ux (only if this repo has frontend)
+
+Proceed? [y/n]
+```
+
+End-to-end with one confirmation. Verifies with `forgeplan health`, prints the next-steps block.
+
+### `/research` — deep multi-agent research
+
+```
+> /research streaming uploads vs presigned URLs
+
+Spawning 5 parallel agents...
+
+Code         ████████████  4 findings   (existing upload paths in src/api/)
+Docs         ██████░░░░░░  2 findings   (no ADR yet — design space open)
+Status       ████████░░░░  3 findings   (issue #87, RFC-014 in flight)
+References   ████████████  6 findings   (S3, GCS, Cloudflare R2 patterns)
+Memory       ██████░░░░░░  2 findings   (prior decision in PRD-024)
+
+Synthesis written to research/reports/uploads/REPORT.md
+Next: /refine to lock terminology, then /rfc create
+```
+
+### `/audit` — multi-expert code review
+
+```
+> /audit
+
+Launching reviewers (4 base + ux-reviewer because this PR touches frontend)...
+
+Logic           ████████░░  3 findings
+Architecture    ████████████  0 findings
+Types           ██████████  2 findings (1 HIGH)
+Security        ████████░░  4 findings
+UX              ██████░░░░  2 findings (Hick's Law on the new menu)
+
+11 findings: 1 HIGH, 5 MEDIUM, 5 LOW
+Fix HIGH issues now? [y/n]
+```
+
+## What's Included
+
+| Component | Description |
+|-----------|-------------|
+| `/fpl-init` | One-command bootstrap: forgeplan init, MCP wiring, CLAUDE.md, docs/agents/. Start here on any new repo. |
+| `/research` | 5-agent parallel research (code · docs · status · references · memory) → `research/reports/`. |
 | `/refine` | Interview-driven refinement of plans/RFCs — sharpens terminology, surfaces contradictions, lazy-creates CONTEXT.md/ADRs. |
 | `/rfc` | Create / read / update RFCs and ADRs (canonical structure, phase progress, ADR format). |
 | `/sprint` | Wave-based feature execution with strict file ownership and inter-wave dependencies. |
-| `/audit` | Multi-expert code review with ≥4 specialised reviewers (logic, architecture/SOLID, types, security). |
-| `/diagnose` | 6-phase disciplined debug loop. Phase 1 ("build a feedback loop") is the entire skill — the rest is mechanics. |
-| `/autorun` | Autopilot orchestrator: one prompt → research → sprint → audit → report with no approval checkpoints. For overnight runs. |
-| `/do` | Interactive task orchestrator — pauses for approval at each step. The non-overnight variant of `/autorun`. |
+| `/audit` | Multi-expert code review (≥4 reviewers — logic, architecture, types, security; +ux-reviewer if installed). |
+| `/diagnose` | 6-phase disciplined debug loop. Phase 1 ("build a feedback loop") is the entire skill. |
+| `/autorun` | Autopilot orchestrator — research → sprint → audit → report end-to-end. For overnight runs. |
+| `/do` | Interactive variant of `/autorun` (pauses for approval at each step). |
 | `/build` | Execute an existing IMPLEMENTATION-PLAN.md from a research report (wave-by-wave). |
-| `/restore` | Restore session context from git + working copy + (optional) persistent memory. |
-| `/briefing` | Daily morning briefing of tasks/messages from your task tracker (Orchestra/Linear/Jira/GitHub) or local TODO files. |
+| `/restore` | Session-context recall from git + working copy + (optional) persistent memory. |
+| `/briefing` | Daily morning briefing of tasks/messages from your tracker (Orchestra/Linear/Jira/GitHub) or local TODO files. |
 | `/setup` | Interactive wizard that configures the current project for fpl-skills (writes `docs/agents/*.md`). |
 | `/bootstrap` | Drops the universal CLAUDE.md template into a new or existing project (stack-aware). |
 | `/team` | Foundation for multi-agent teams — TeamCreate vs sub-agents, file ownership, recipes, cleanup. |
+| **SessionStart hook** | Probes `.forgeplan/`, `docs/agents/`, `CLAUDE.md` and prints a context-aware next-step hint. |
 
-## Install
+## Lifecycle integration
 
-Prerequisites: Claude Code, git, [forgeplan CLI](https://github.com/ForgePlan/forgeplan) on `$PATH`.
+Every skill delegates artifact lifecycle to `forgeplan`:
 
-```bash
-# In any Claude Code session:
-/plugin marketplace add ForgePlan/marketplace
-/plugin install fpl-skills@ForgePlan-marketplace
-/reload-plugins
-```
+| Phase | Skill | What it produces |
+|-------|-------|-------------------|
+| Observe | `/restore`, `/briefing`, SessionStart hook | Branch/PR snapshot, tracker overview, blind-spot dashboard |
+| Route | `/fpl-init`, `/setup` | Decide depth (Tactical/Standard/Deep/Critical) |
+| Shape | `/refine`, `/rfc`, `/research` | PRD, RFC, ADR, Evidence drafts |
+| Build | `/sprint`, `/build`, `/do`, `/autorun`, `/team` | Implementation with file-ownership and waves |
+| Prove | `/audit`, `/diagnose` | Multi-expert reviews, 6-phase debug evidence |
+| Ship | (forgeplan CLI directly) | `forgeplan activate <id>`, `gh pr create` |
 
-For full project bootstrap (a new project from zero), see [`GETTING-STARTED.md`](./GETTING-STARTED.md).
+## Companion plugins
 
-## Relationship to other ForgePlan plugins
+Print-and-paste, never auto-installed by `/fpl-init`:
 
-- **forgeplan CLI** — required runtime dependency. fpl-skills delegates artifact lifecycle (PRD/RFC/ADR creation, R_eff scoring, validation, health) to forgeplan.
-- **forgeplan-workflow** — companion plugin. Provides `/forge-cycle` and `/forge-audit` as a tighter forgeplan-only workflow. fpl-skills is broader (research, refine, diagnose, multi-tracker briefing, etc.).
-- **forgeplan-orchestra** — companion. Multi-session coordination via `/sync` and `/session`. Use alongside fpl-skills when working across sessions/agents.
-- **agents-core / agents-domain / agents-pro** — agent packs. fpl-skills' `/audit` and `/sprint` reference these `subagent_type`s when available; install if you want richer reviewer/teammate options.
-- **fpf** — First Principles Framework. Pairs naturally with `/refine` and `/diagnose` Phase 3 (hypothesis generation).
-- **laws-of-ux** — frontend reviewer. `/audit` will spawn `ux-reviewer` from this plugin if installed and the changeset is frontend-heavy.
-- **dev-toolkit** — superseded by fpl-skills (overlapping `/audit` and `/sprint`). Don't install both.
+| Plugin | When to add |
+|---|---|
+| [`fpf`](../fpf/) | First Principles Framework — pairs with `/refine` and `/diagnose` for hypothesis generation. |
+| [`agents-core`](../agents-core/) | 11 baseline subagents — `/audit` and `/sprint` use them when present. |
+| [`forgeplan-workflow`](../forgeplan-workflow/) | Tighter forgeplan-only loop via `/forge-cycle` and `/forge-audit`. Compatible with fpl-skills. |
+| [`forgeplan-orchestra`](../forgeplan-orchestra/) | Multi-session coordination via `/sync` and `/session`. |
+| [`laws-of-ux`](../laws-of-ux/) | Frontend reviewer — `/audit` will spawn `ux-reviewer` when changesets are frontend-heavy. |
+| [`dev-toolkit`](../dev-toolkit/) | **Deprecated**, superseded by `fpl-skills`. Don't install both. |
 
-## Repository layout
+## Resource guides
 
-```
-plugins/fpl-skills/
-├── .claude-plugin/plugin.json     ← plugin manifest
-├── hooks/
-│   ├── hooks.json                 ← SessionStart hook
-│   └── scripts/session-start.sh
-├── skills/                        ← 15 skills (canonical source)
-│   ├── fpl-init/                  ← one-shot setup (start here)
-│   ├── bootstrap/                 ← CLAUDE.md template + stack detection
-│   ├── setup/                     ← docs/agents/ wizard
-│   └── ...                        ← research, refine, sprint, audit, …
-├── README.md                      ← this file
-└── GETTING-STARTED.md             ← human-readable bootstrap walkthrough
-```
+Two reference docs ship inside the plugin (`skills/bootstrap/resources/guides/`):
+
+- [`CLAUDE-MD-GUIDE.ru.md`](skills/bootstrap/resources/guides/CLAUDE-MD-GUIDE.ru.md) — why `CLAUDE.md` is structured the way it is (U-curve attention, ≤7 red lines, primacy/reference/recency zones).
+- [`FORGEPLAN-SETUP.md`](skills/bootstrap/resources/guides/FORGEPLAN-SETUP.md) — canonical `.forgeplan/` setup contract: gitignore, secrets layout (12-factor `api_key_env` pattern), env var overrides, anti-patterns.
+
+## Credits
+
+Built on top of [`forgeplan`](https://github.com/ForgePlan/forgeplan) and the [Claude Code](https://claude.com/claude-code) plugin v2 schema. Skills adapted in part from [mattpocock/skills](https://github.com/mattpocock/skills) (engineering/diagnose, engineering/grill-with-docs).
 
 ## License
 


### PR DESCRIPTION
## Summary

Documentation polish on top of v1.0.2 (PR #33). The first cut of `plugins/fpl-skills/README.md` (67 lines) didn't match the marketplace's other plugin READMEs (90-115 lines, bilingual, canonical structure: tagline → Quick Start → Usage Examples → What's Included → Companion → Credits → License). Plus there was no `README-RU.md`, and the root marketplace README never got the fpl-skills catalog entry.

This PR aligns all four affected READMEs.

## What changed

### `plugins/fpl-skills/README.md` (67 → 139 lines)
- Tagline blockquote
- `[!WARNING]` admonition for forgeplan CLI dependency
- Quick Start (3 commands)
- Usage Examples — `/fpl-init`, `/research`, `/audit` with realistic command/output blocks
- What's Included table (15 skills + SessionStart hook)
- Lifecycle integration table (Observe → Route → Shape → Build → Prove → Ship)
- Companion plugins table with cross-links + dev-toolkit deprecation note
- Resource guides reference (CLAUDE-MD-GUIDE, FORGEPLAN-SETUP)

### `plugins/fpl-skills/README-RU.md` (new, 139 lines)
Russian mirror with the same structure.

### `README.md` (root marketplace catalog)
- Stats line: `10 plugins | 13 commands | 4 KBs` → `12 plugins | 15 commands | 5 KBs`
- "Where to Start?" matrix:
  - **New row**: "Forgeplan user (recommended) → fpl-skills"
  - dev-toolkit row reframed: "Any developer (no forgeplan)"
  - Other personas updated to recommend fpl-skills as base
- "Available Plugins":
  - **fpl-skills entry added FIRST** (flagship recommendation, `[!TIP]` callout)
  - dev-toolkit moved DOWN with `[!CAUTION]` deprecation callout

### `README-RU.md` (root)
Mirrored.

## Verification

- [x] `./scripts/validate-all-plugins.sh` → ALL PASSED
- [x] All four READMEs render correctly (Github admonitions: `[!TIP]`, `[!WARNING]`, `[!CAUTION]`)
- [x] Cross-references work (CLAUDE-MD-GUIDE.ru.md, FORGEPLAN-SETUP.md, dev-toolkit/, fpl-skills/, etc.)
- [x] Stats line in root README matches reality (12 plugins, 15 commands, 5 knowledge bases)
- [x] Bilingual link `[English](README.md) | [Русский](README-RU.md)` at top of every README
- [x] Plugin README structure matches dev-toolkit/laws-of-ux/forgeplan-orchestra template

## Test plan

- [x] Quick Start has 2-3 commands max
- [x] Usage Examples section has realistic command/output blocks
- [x] What's Included is a clean table
- [x] Companion plugins table cross-links to other plugins in the marketplace
- [x] No version bump in this commit (docs polish, no manifest/code changes)

## Version

No bump — this is documentation polish on top of v1.0.2. Plugin code, manifest, and marketplace.json metadata are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)