### PR TITLE
feat(fpl-skills): v1.2.0 — cross-skill forgeplan integration + /forge-cycle walkthrough

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.11.1"
+    "version": "1.12.0"
   },
   "plugins": [
     {
       "name": "fpl-skills",
       "source": "./plugins/fpl-skills",
       "description": "Flagship workflow plugin for the ForgePlan ecosystem. 17 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /migrate-from-dev-toolkit automation + session helpers) + dev-advisor agent + 4 hooks (safety, test reminder, forge-report auto-trigger). Full feature parity with the legacy dev-toolkit plus 14 additional skills built on forgeplan's artifact lifecycle.",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "author": {
         "name": "ForgePlan"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the ForgePlan Marketplace will be documented in this file
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - 2026-05-07
+
+Closes a real architectural gap — until now, `fpl-skills` skills (`/sprint`, `/audit`, `/research`, `/refine`, `/rfc`, `/diagnose`, `/build`, `/do`, `/restore`, `/briefing`) didn't mention `forgeplan` at all. Documentation promised they "delegate artifact lifecycle to forgeplan" but the skill bodies didn't. After this release, every workflow skill is **forgeplan-aware**: it recommends the right CLI calls (route, new prd/evidence/note/adr, link, score, activate) at the right times and points the user at `/forge-cycle` for full orchestration.
+
+### Added
+- `fpl-skills` v1.1.1 → **1.2.0** (minor — feature: cross-skill forgeplan integration):
+  - **10 workflow skills now include a "Forgeplan integration" section**: `/sprint`, `/audit`, `/research`, `/refine`, `/rfc`, `/diagnose`, `/build`, `/do`, `/restore`, `/briefing`. Each section is tailored to what the skill produces — `/sprint` recommends `forgeplan route → new prd → new evidence → activate`; `/audit` writes Evidence; `/research` proposes Note vs PRD vs ADR depending on output; `/refine` adds ADR for surfaced decisions; `/rfc` prefers `forgeplan new rfc/adr` over plain markdown; `/diagnose` writes Evidence on verified fix; `/build` activates PRD on completion; `/do` mirrors `/autorun`'s probe-and-delegate pattern; `/restore` and `/briefing` add `forgeplan health`/`blocked`/`stale` to the recall block.
+  - Each section ends with a **"Want this orchestrated for you?"** callout pointing at `/forge-cycle` (in `forgeplan-workflow`) — the one-command alternative that does all the recommended CLI calls automatically.
+- `/autorun` integration block clarified: explicit table of "what happens with/without forgeplan-workflow installed".
+
+### Changed
+- `docs/DEVELOPER-JOURNEY.md` and `-RU.md`: new section **"`/forge-cycle` — first time"** (50+ lines each) — short walkthrough showing the 8-step cycle, decision matrix `/forge-cycle` vs `/sprint` vs `/autorun` vs `/do`, setup checklist, and integration with `@forgeplan/web` for visual exploration. Closes the onboarding gap for users who want the orchestrated path rather than manual coordination.
+- Marketplace catalog metadata.version 1.11.1 → **1.12.0**.
+
+### Notes
+**This is a documentation-and-design change, not a behaviour change for the CLI side**. Skills now *recommend* the right `forgeplan` calls inline; they don't *invoke* them. This keeps `fpl-skills` simple (executors) and `forgeplan-workflow` differentiated (orchestrator). Users who want automation install `forgeplan-workflow` and get `/forge-cycle`; users who prefer manual control install just `fpl-skills` and follow the inline recommendations.
+
+The architectural decision: **don't dilute `fpl-skills` skills with `forgeplan-workflow`'s logic**. Two plugins with overlapping orchestration would create dual-pathways and divergence. Instead, every skill points to the orchestrator as the canonical "automate this" answer.
+
 ## [1.11.1] - 2026-05-07
 
 Automated migration helper.

--- a/docs/DEVELOPER-JOURNEY-RU.md
+++ b/docs/DEVELOPER-JOURNEY-RU.md
@@ -294,6 +294,55 @@ Orchestra `Status` ↔ Forgeplan `Phase` mapping автоматический:
 
 ---
 
+## `/forge-cycle` — первый раз
+
+4 персоны выше используют скиллы `fpl-skills` как **executors** и вручную координируют `forgeplan` lifecycle вызовы (или полагаются на `/autorun` для оркестровки). Для тех кто хочет **одну команду которая прогоняет всю методологию** — поставь [`forgeplan-workflow`](../plugins/forgeplan-workflow/README-RU.md):
+
+```
+/plugin install forgeplan-workflow@ForgePlan-marketplace
+/reload-plugins
+```
+
+Дальше для любой нетривиальной задачи:
+
+```
+/forge-cycle "Add PDF export for artifacts"
+```
+
+Это проходит 8 шагов end-to-end:
+
+```
+Step 1: Health check    → `forgeplan health` — выявляет blind spots до старта
+Step 2: Task            → подтверждает описание задачи с тобой
+Step 3: Route           → `forgeplan route` решает depth (Tactical/Standard/Deep/Critical)
+Step 4: Shape           → создаёт PRD (и RFC/ADR если Deep), валидирует MUST секции
+Step 5: Build           → делегирует /sprint или /do из fpl-skills для реализации
+Step 6: Audit           → спавнит ревьюеров, фиксирует findings
+Step 7: Evidence        → `forgeplan new evidence` + link к PRD + score (R_eff)
+Step 8: Activate        → `forgeplan activate` когда R_eff > 0
+                        → готовит conventional commit с `Refs: PRD-NNN`
+```
+
+### Когда `/forge-cycle` vs `/sprint` vs `/autorun`
+
+| Команда | Плагин | Лучше всего для |
+|---|---|---|
+| `/forge-cycle` | forgeplan-workflow | «Прогони методологию end-to-end по одной задаче» — единый entry point, полный lifecycle. |
+| `/sprint` | fpl-skills | Wave-based execution с file ownership и per-wave teammates. Используй когда уже сам route/shape сделал. |
+| `/autorun` | fpl-skills | Ночной / unattended. Auto-делегирует в `/forge-cycle` если установлен `forgeplan-workflow`; иначе работает standalone. |
+| `/do` | fpl-skills | Интерактивный вариант `/autorun` — пауза на границах фаз для review. |
+
+### Setup checklist для `/forge-cycle`
+
+- [ ] CLI `forgeplan` в `$PATH` (то же требование что для `/fpl-init`)
+- [ ] `.forgeplan/` инициализирован (запусти `/fpl-init` если нет)
+- [ ] Установлен плагин `forgeplan-workflow`
+- [ ] У проекта есть хотя бы черновой `CLAUDE.md` чтобы скилл знал кодовую базу
+
+После первого прогона `/forge-cycle` в `.forgeplan/` появятся реальные PRD + Evidence. Открой проект в [`@forgeplan/web`](FORGEPLAN-WEB-RU.md) чтобы увидеть граф артефактов.
+
+---
+
 ## Когда добавлять плагины
 
 Не ставь всё сразу. Добавляй по мере необходимости:

--- a/docs/DEVELOPER-JOURNEY.md
+++ b/docs/DEVELOPER-JOURNEY.md
@@ -294,6 +294,55 @@ When you `forgeplan activate <id>`, the matching Orchestra task moves to Done. W
 
 ---
 
+## `/forge-cycle` — first time
+
+The 4 personas above use `fpl-skills` skills as **executors** and orchestrate `forgeplan` lifecycle calls manually (or rely on `/autorun` to do the orchestration). For users who want **a single command that runs the full methodology**, install [`forgeplan-workflow`](../plugins/forgeplan-workflow/README.md):
+
+```
+/plugin install forgeplan-workflow@ForgePlan-marketplace
+/reload-plugins
+```
+
+Then for any non-trivial task:
+
+```
+/forge-cycle "Add PDF export for artifacts"
+```
+
+This walks 8 steps end-to-end:
+
+```
+Step 1: Health check    → `forgeplan health` — surfaces blind spots before starting
+Step 2: Task            → confirms task description with you
+Step 3: Route           → `forgeplan route` decides depth (Tactical/Standard/Deep/Critical)
+Step 4: Shape           → creates PRD (and RFC/ADR if Deep), validates MUST sections
+Step 5: Build           → delegates to fpl-skills' /sprint or /do for implementation
+Step 6: Audit           → spawns reviewers, captures findings
+Step 7: Evidence        → `forgeplan new evidence` + link to PRD + score (R_eff)
+Step 8: Activate        → `forgeplan activate` once R_eff > 0
+                        → prepares the conventional commit with `Refs: PRD-NNN`
+```
+
+### When to use `/forge-cycle` vs `/sprint` vs `/autorun`
+
+| Command | Plugin | Best for |
+|---|---|---|
+| `/forge-cycle` | forgeplan-workflow | "Run the methodology end-to-end on this one task" — single entry point, full lifecycle. |
+| `/sprint` | fpl-skills | Wave-based execution with file ownership and per-wave teammates. Use when you've already routed/shaped manually. |
+| `/autorun` | fpl-skills | Overnight / unattended. Auto-delegates to `/forge-cycle` if `forgeplan-workflow` is installed; otherwise runs standalone. |
+| `/do` | fpl-skills | Interactive variant of `/autorun` — pauses at phase boundaries for review. |
+
+### Setup checklist for `/forge-cycle`
+
+- [ ] `forgeplan` CLI on `$PATH` (same as `/fpl-init` requirement)
+- [ ] `.forgeplan/` initialised (run `/fpl-init` first if not)
+- [ ] `forgeplan-workflow` plugin installed
+- [ ] Project has at least a draft `CLAUDE.md` so the skill knows the codebase
+
+After the first `/forge-cycle` run you'll have a real PRD + Evidence in `.forgeplan/`. Open the same project in [`@forgeplan/web`](FORGEPLAN-WEB.md) to see the artifact graph.
+
+---
+
 ## When to add more plugins
 
 Don't install everything upfront. Add as you hit the need:

--- a/plugins/fpl-skills/.claude-plugin/plugin.json
+++ b/plugins/fpl-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fpl-skills",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Flagship workflow plugin for the ForgePlan ecosystem. 17 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /migrate-from-dev-toolkit automation, plus session helpers) + dev-advisor agent + 4 hooks (safety, test reminder, forge-report auto-trigger). Full feature parity with the legacy dev-toolkit plus 14 additional skills built on forgeplan's artifact lifecycle.",
   "author": {
     "name": "ForgePlan"

--- a/plugins/fpl-skills/skills/audit/SKILL.md
+++ b/plugins/fpl-skills/skills/audit/SKILL.md
@@ -423,3 +423,29 @@ completion (Mode B). See cleanup checklist in [`team`](../team/SKILL.md).
 - **Score 8/10 without consensus issues** — suspicious, ask for cross-validation.
 - **APPROVE at 50% completion** — violates the Phase 3 rule.
 - **Files passed by reference instead of content** — agents re-read and burn tokens.
+
+---
+
+## Forgeplan integration
+
+If the `forgeplan` CLI is on `$PATH`, this skill is **forgeplan-aware** — it recommends the right CLI calls but does not invoke them itself.
+
+### After `/audit` completes
+
+The audit produces severity-ranked findings (CRITICAL / HIGH / MEDIUM / LOW). Capture the verdict as Evidence:
+
+```bash
+forgeplan new evidence "<scope>: audit by N reviewers — X HIGH, Y MED resolved, Z LOW deferred"
+forgeplan link EVID-MMM PRD-NNN --relation informs
+# Add Structured Fields in the evidence body:
+#   verdict: supports | weakens | refutes
+#   congruence_level: 3      (CL3 same-context)
+#   evidence_type: code_review
+forgeplan score PRD-NNN            # R_eff updated
+```
+
+Without Evidence, an `/audit` pass disappears — `forgeplan score` won't reflect it, and `forgeplan health` may report blind spots on the audited artifact.
+
+### Want this orchestrated for you?
+
+Install [`forgeplan-workflow`](../../../../plugins/forgeplan-workflow/README.md) and use `/forge-audit` — it runs 6 parallel reviewers (logic, architecture, security, tests, performance, docs) and writes Evidence automatically.

--- a/plugins/fpl-skills/skills/autorun/SKILL.md
+++ b/plugins/fpl-skills/skills/autorun/SKILL.md
@@ -198,3 +198,27 @@ User can `TaskList` at any time to see live progress.
 - ❌ Don't run if `docs/agents/` is empty AND no project files exist. Refuse and route to `/setup`.
 - ❌ Don't generate a wave plan with file conflicts. If `sprint` produces one, regenerate before executing.
 - ❌ Don't merge or push without explicit user instruction in the original task. "implement X" doesn't mean "ship X".
+
+---
+
+## Forgeplan integration (clarified)
+
+The probe block at the start of this skill (step 2 — Detect environment) already lists `forgeplan-workflow` as a delegation target. To make the behaviour explicit:
+
+| Detected | What `/autorun` does |
+|---|---|
+| `forgeplan-workflow` plugin installed | **Delegates to `/forge-cycle "<task>"`** — full route → shape → build → evidence → activate. No pauses. |
+| `forgeplan` CLI but no `forgeplan-workflow` | Runs `research → sprint → audit → report` and **inserts manual `forgeplan` calls between phases** (route → new prd → new evidence → activate). All non-interactive. |
+| Neither | Runs the standard pipeline. Prints a single warning at the start: "no forgeplan integration; artifact graph will not be updated". |
+
+### Want full automation?
+
+For maximum forgeplan integration with zero per-phase pauses, install `forgeplan-workflow` then invoke `/autorun` — it will silently delegate to `/forge-cycle`:
+
+```
+/plugin install forgeplan-workflow@ForgePlan-marketplace
+/reload-plugins
+/autorun "<task>"
+```
+
+This is the recommended setup for overnight / unattended runs on forgeplan projects.

--- a/plugins/fpl-skills/skills/briefing/SKILL.md
+++ b/plugins/fpl-skills/skills/briefing/SKILL.md
@@ -209,3 +209,35 @@ Everything, including starred / reminders / saved. Default mode is compact and s
 - **Don't invent tasks** when no source is available — say "no data" honestly.
 - **Don't print 50 lines when 5 will do** — that's what `urgent` mode is for.
 - **Don't recommend generic actions** — a recommendation without a concrete task UID/link is useless.
+
+---
+
+## Forgeplan integration
+
+If the `forgeplan` CLI is on `$PATH`, daily briefings benefit from forgeplan-side signals beyond the tracker.
+
+### Add to the daily briefing
+
+Beyond the tracker (Orchestra/GitHub Issues/Linear/Jira/local TODO), include:
+
+```bash
+forgeplan list --status active --limit 5    # what's currently in flight
+forgeplan blocked                            # artifacts waiting on dependencies
+forgeplan stale                              # past valid_until — need renew/deprecate
+forgeplan blindspots                         # active artifacts with no evidence
+```
+
+### Why these belong in a briefing
+
+- **Active without evidence** = R_eff stays at 0 → activation gate fails silently. Briefing should flag.
+- **Blocked artifacts** = work that won't progress without unblocking. Triage daily.
+- **Stale ADRs** = decisions that may no longer apply. Renew or supersede before relying on them.
+
+Group the briefing output by:
+1. **Tracker signals** (assigned tasks, mentions, due-today)
+2. **Forgeplan signals** (active, blocked, stale, blindspots)
+3. **Synthesis** — recommended focus for the day, drawing from both
+
+### Want this orchestrated for you?
+
+`/session` (in [`forgeplan-orchestra`](../../../../plugins/forgeplan-orchestra/README.md)) is the team-grade variant — it adds Inbox Pattern over multi-source signals (forgeplan + Orchestra messages + git). Use when team coordination matters.

--- a/plugins/fpl-skills/skills/build/SKILL.md
+++ b/plugins/fpl-skills/skills/build/SKILL.md
@@ -322,3 +322,34 @@ build research/reports/{dir} --phase 1
 - [`audit`](../audit/SKILL.md) — runs after the build.
 - [`rfc`](../rfc/SKILL.md) — update RFC.
 - [`do`](../do/SKILL.md) — chains research → build → audit.
+
+---
+
+## Forgeplan integration
+
+If the `forgeplan` CLI is on `$PATH` and the IMPLEMENTATION-PLAN.md references a PRD, this skill is **forgeplan-aware** — it recommends the right CLI calls but does not invoke them.
+
+### Before `/build`
+
+The IMPLEMENTATION-PLAN.md should already reference the parent PRD/RFC (created by `/research` → `/refine` → `/rfc`). If not, create one:
+
+```bash
+forgeplan route "<scope of the IMPLEMENTATION-PLAN>"
+forgeplan new prd "<title>"            # if Standard+ depth
+forgeplan validate PRD-NNN
+```
+
+### After `/build` completes
+
+```bash
+forgeplan new evidence "<plan>: N waves merged, M tests added, build/lint clean"
+forgeplan link EVID-MMM PRD-NNN --relation informs
+forgeplan score PRD-NNN
+forgeplan activate PRD-NNN              # draft → active
+```
+
+For `/build` runs that took multiple sessions (each adding a wave), append to the same Evidence rather than creating multiple — keeps the trail single-threaded.
+
+### Want this orchestrated for you?
+
+`/forge-cycle` (in [`forgeplan-workflow`](../../../../plugins/forgeplan-workflow/README.md)) handles the full build + evidence + activate flow when you start from a task description rather than an existing IMPLEMENTATION-PLAN.

--- a/plugins/fpl-skills/skills/diagnose/SKILL.md
+++ b/plugins/fpl-skills/skills/diagnose/SKILL.md
@@ -216,3 +216,36 @@ If the bug uncovered a missing project rule (e.g. "always validate inputs at thi
 - ❌ **Test at the wrong seam.** A passing unit test that doesn't exercise the real bug pattern is false confidence.
 - ❌ **"Done" without re-running the original loop.** A green regression test ≠ a fixed bug. Re-run the original repro.
 - ❌ **Architectural recommendation before the fix.** You don't know enough yet. Recommend in Phase 6, not Phase 1.
+
+---
+
+## Forgeplan integration
+
+If the `forgeplan` CLI is on `$PATH`, this skill is **forgeplan-aware** — it recommends the right CLI calls but does not invoke them.
+
+### When `/diagnose <bug>` finds a fix
+
+A verified fix is Evidence-worthy. Capture it:
+
+```bash
+forgeplan new evidence "<bug>: root cause = <X>; fix = <Y>; verified by <test/repro>"
+# Body: include the diagnostic trace (what you tried, what worked).
+# Structured Fields:
+#   verdict: supports | refutes
+#   congruence_level: 3 (CL3 same-context)
+#   evidence_type: measurement | test_result
+forgeplan link EVID-MMM PRD-NNN --relation informs   # if linked to a feature PRD
+```
+
+If the bug surfaced a deeper architectural issue:
+
+```bash
+forgeplan new problem "<problem card>"   # category: bug, performance, security, ...
+forgeplan link PROB-NNN PRD-MMM --relation informs
+# Then create a `solution` portfolio if multiple options:
+forgeplan new solution "<solution portfolio for PROB-NNN>"
+```
+
+### Want this orchestrated for you?
+
+For complex diagnose tasks that warrant a full lifecycle (PRD → fix → evidence → activate), pair this skill with [`forgeplan-workflow`](../../../../plugins/forgeplan-workflow/README.md) — `/forge-cycle "fix <bug>"` will route, shape, build, and capture evidence in one flow.

--- a/plugins/fpl-skills/skills/do/SKILL.md
+++ b/plugins/fpl-skills/skills/do/SKILL.md
@@ -444,3 +444,39 @@ Pipeline:
 - **Don't orchestrate trivial tasks** — if one skill is enough, call it directly.
 - **Don't skip RECALL** — research is often already done.
 - **Don't forget cleanup** — every step must close cleanly (TeamDelete, memory_retain).
+
+---
+
+## Forgeplan integration
+
+If the `forgeplan` CLI is on `$PATH`, this skill is **forgeplan-aware** — interactive variant of `/autorun`. Like `/autorun`, it probes for `forgeplan-workflow` and delegates if found.
+
+### Probe at start
+
+```bash
+command -v forgeplan
+ls ~/.claude/plugins/cache/marketplaces/ForgePlan-marketplace/plugins/forgeplan-workflow 2>/dev/null
+```
+
+| Detected | Behaviour |
+|---|---|
+| `forgeplan-workflow` plugin installed | Delegate to `/forge-cycle "<task>"` for full route → shape → build → evidence → activate. Keeps interactive checkpoints. |
+| `forgeplan` CLI but no `forgeplan-workflow` | Run the standard pipeline (research → sprint → audit) but **insert manual `forgeplan` calls between phases** — `forgeplan route` before research, `forgeplan new prd` before sprint, `forgeplan new evidence + activate` after audit. Pause for user confirmation at each. |
+| Neither | Standard pipeline without artifact lifecycle. Tell the user this once at the start. |
+
+### Why `/do` differs from `/autorun`
+
+- `/do` pauses at every phase boundary for user approval.
+- `/autorun` runs end-to-end without checkpoints.
+- Both are forgeplan-aware in the same way (probe → delegate → fallback).
+
+Use `/do` when you want to **review** the artifact lifecycle steps as they happen (and intervene if needed). Use `/autorun` when you trust the methodology to run unattended.
+
+### Want this orchestrated for you?
+
+If `forgeplan-workflow` is installed, `/do` already delegates to `/forge-cycle`. If not, install it:
+
+```
+/plugin install forgeplan-workflow@ForgePlan-marketplace
+/reload-plugins
+```

--- a/plugins/fpl-skills/skills/refine/SKILL.md
+++ b/plugins/fpl-skills/skills/refine/SKILL.md
@@ -182,3 +182,38 @@ When the design tree is exhausted (every branch either resolved or explicitly de
 - ❌ **Letting contradictions slide.** If the new plan conflicts with CONTEXT.md or existing code, surface it on the spot.
 - ❌ **Going deep on leaves before trunk.** Cache TTL doesn't matter if the entity boundaries are still fuzzy.
 - ❌ **Open-ended Socratic prompts.** "What do you think?" wastes time. Provide a recommended answer with each question.
+
+---
+
+## Forgeplan integration
+
+If the `forgeplan` CLI is on `$PATH`, this skill is **forgeplan-aware** — it recommends the right CLI calls but does not invoke them.
+
+### During `/refine <plan>`
+
+Refinement often surfaces decisions worth recording. When you land on one:
+
+```bash
+forgeplan new adr "<key decision>"
+# Body: Context (why this came up) / Decision (what we picked) / Alternatives / Consequences
+forgeplan link ADR-NNN PRD-MMM --relation informs   # link to the parent PRD
+```
+
+If refinement clarifies terminology or invariants but isn't a "decision" — capture as a `note` instead:
+
+```bash
+forgeplan new note "<convention or constraint surfaced during refine>"
+```
+
+### After `/refine` completes
+
+If you refined an existing artifact (PRD/RFC):
+
+```bash
+forgeplan validate PRD-NNN          # confirm MUST sections still pass
+forgeplan reason PRD-NNN            # ADI hypotheses (Deep+: refresh after refinement)
+```
+
+### Want this orchestrated for you?
+
+Install [`forgeplan-workflow`](../../../../plugins/forgeplan-workflow/README.md). `/forge-cycle` includes refinement as the gate between Shape and Build.

--- a/plugins/fpl-skills/skills/research/SKILL.md
+++ b/plugins/fpl-skills/skills/research/SKILL.md
@@ -446,3 +446,24 @@ TOPIC, KEYWORDS — same.
 - **Don't trust TODOs alone** — verify in code.
 - **Don't dump raw outputs from all 5 agents** — synthesis is the value.
 - **Don't `TeamDelete` silently** — ask the user first.
+
+---
+
+## Forgeplan integration
+
+If the `forgeplan` CLI is on `$PATH`, this skill is **forgeplan-aware** — it recommends the right CLI calls but does not invoke them.
+
+### After `/research <topic>` completes
+
+The skill writes a report to `research/reports/<topic>/REPORT.md`. To plug it into the artifact graph:
+
+- **Background context for an existing artifact** → `forgeplan new note "<takeaway from research>"` and link to the relevant PRD/RFC/ADR.
+- **New initiative warranting a PRD** → `forgeplan new prd "<title>"`, cite the report path in Sources, run `forgeplan validate PRD-NNN`.
+- **Architecture decision surfaced** → `forgeplan new adr "<decision>"`, fill Context/Decision/Consequences from the report.
+- **Comparison/evaluation captured** → `/refine` next to formalise → `forgeplan new rfc "<scope>"` if it leads to a deep change.
+
+Without an artifact link, the research is ephemeral — `forgeplan list` won't surface it; future readers won't find it via semantic search.
+
+### Want this orchestrated for you?
+
+Install [`forgeplan-workflow`](../../../../plugins/forgeplan-workflow/README.md). `/forge-cycle "<task>"` runs research as part of its Shape phase and creates the PRD automatically.

--- a/plugins/fpl-skills/skills/restore/SKILL.md
+++ b/plugins/fpl-skills/skills/restore/SKILL.md
@@ -177,3 +177,33 @@ End with 2–4 recommendations grounded in what you found:
 - **Don't recall before every message** — this is a session-start operation, not a health check.
 - **Don't invent memory that isn't there** — if Hindsight/MCP is unavailable, mark "memory: not configured" instead of hallucinating decisions.
 - **Don't dump the full `git log`** — 10–15 lines is enough; the rest is on demand.
+
+---
+
+## Forgeplan integration
+
+If the `forgeplan` CLI is on `$PATH`, add a **forgeplan health probe** to the parallel recall block — it surfaces context that `git status + git log` cannot.
+
+### Add to step 1 (parallel collection)
+
+```bash
+forgeplan health           # active artifacts, blind spots, stubs, stale items
+forgeplan list --status active --limit 5   # what's currently in flight
+forgeplan blocked          # artifacts waiting on dependencies (if relevant)
+```
+
+This complements the git snapshot:
+- `git log` tells you **what changed**.
+- `forgeplan health` tells you **what was decided** and **what's missing evidence**.
+
+### When `forgeplan health` reports issues during restore
+
+- **Active stubs** (PRDs/RFCs declared active but with empty MUST sections) → flag as a "do this first" item before the user resumes feature work.
+- **Orphan artifacts** (no incoming/outgoing links) → mention in the restore report; user may want to `forgeplan link` them or deprecate.
+- **Stale artifacts** (past `valid_until`) → suggest `forgeplan renew` or `forgeplan deprecate`.
+
+These signals are silent unless you probe — surfacing them at session-restore time prevents drift.
+
+### Want this orchestrated for you?
+
+`/session` (in [`forgeplan-orchestra`](../../../../plugins/forgeplan-orchestra/README.md)) runs an enhanced version of this probe + Inbox Pattern with Orchestra task signals. Use it when working in a multi-developer team.

--- a/plugins/fpl-skills/skills/rfc/SKILL.md
+++ b/plugins/fpl-skills/skills/rfc/SKILL.md
@@ -269,3 +269,40 @@ If `RFC-INDEX.md` exists:
 - **Don't write "Implementation Log: TBD"** — just don't create the section yet.
 - **Don't dump API endpoints / full JSON schemas into the RFC** — those belong in `openapi.yaml` or a separate guide.
 - **Don't conflate RFC and ADR**: RFC is a broad proposal; ADR is a single decision. If the document is one decision on one page, it's an ADR.
+
+---
+
+## Forgeplan integration
+
+If the `forgeplan` CLI is on `$PATH`, prefer `forgeplan` over plain markdown for RFC/ADR creation — the CLI gives you state machine, validation, R_eff scoring, and semantic search out of the box.
+
+### Forgeplan-aware mode (recommended)
+
+```bash
+# Create
+forgeplan new rfc "<title>"        # → RFC-NNN with template (Status, Phases, Alternatives, Decision)
+forgeplan new adr "<title>"        # → ADR-NNN with template (Context, Decision, Consequences, Valid Until)
+forgeplan validate RFC-NNN         # check MUST sections
+forgeplan link RFC-NNN PRD-MMM --relation based_on   # wire to parent PRD
+
+# Read
+forgeplan get RFC-NNN              # canonical body (vs reading file directly)
+forgeplan list --kind rfc          # all RFCs
+
+# Update
+forgeplan update RFC-NNN body=<full new body>   # idempotent; keeps LanceDB in sync
+# (Direct Edit/Write on .forgeplan/rfcs/*.md desyncs the index — use update)
+
+# Lifecycle
+forgeplan activate RFC-NNN
+forgeplan supersede RFC-NNN --by RFC-MMM        # when a successor lands
+forgeplan deprecate ADR-NNN --reason "..."      # decision no longer applies
+```
+
+### Plain-markdown mode (fallback)
+
+If `forgeplan` CLI is missing, this skill falls back to plain markdown — write `docs/rfcs/RFC-NNN-...md` per project conventions. You lose the validation/scoring/search benefits.
+
+### Want this orchestrated for you?
+
+`/forge-cycle` (in [`forgeplan-workflow`](../../../../plugins/forgeplan-workflow/README.md)) creates the RFC as part of the Shape phase for Standard+ depth tasks.

--- a/plugins/fpl-skills/skills/sprint/SKILL.md
+++ b/plugins/fpl-skills/skills/sprint/SKILL.md
@@ -458,6 +458,43 @@ Emit the **Sprint Complete** report — format in [`references/OUTPUT-FORMATS.md
 - [`build`](../build/SKILL.md) — when a research report with IMPLEMENTATION-PLAN.md already exists.
 - [`restore`](../restore/SKILL.md) — at session start, before a sprint.
 
+## Forgeplan integration
+
+If the `forgeplan` CLI is on `$PATH` (probe with `command -v forgeplan`), this skill is **forgeplan-aware** — it recommends the right CLI calls but does not invoke them itself, so you stay in control of artifact lifecycle.
+
+### Before `/sprint <task>`
+
+```bash
+forgeplan health                   # observe blind spots first
+forgeplan route "<task>"           # decide depth (Tactical/Standard/Deep/Critical)
+# Standard+:
+forgeplan new prd "<title>"        # shape: PRD with MUST sections
+forgeplan validate PRD-NNN         # gate before sprint
+forgeplan reason PRD-NNN           # ADI 3+ hypotheses (Deep+: required)
+```
+
+### After `/sprint` completes
+
+```bash
+forgeplan new evidence "<task>: tests pass / smoke OK / N waves merged"
+forgeplan link EVID-MMM PRD-NNN --relation informs
+forgeplan score PRD-NNN            # R_eff > 0?
+forgeplan activate PRD-NNN         # draft → active
+```
+
+Without these, the sprint output ships but the artifact graph stays empty — `forgeplan health` will surface a blind spot ("active sprint without linked evidence").
+
+### Want this orchestrated for you?
+
+Install [`forgeplan-workflow`](../../../../plugins/forgeplan-workflow/README.md) and run `/forge-cycle "<task>"` instead — it auto-routes, creates the PRD, delegates the build to skills like this one, creates evidence, activates, and prepares the commit. `/sprint` is the **executor**; `/forge-cycle` is the **orchestrator**.
+
+```
+/plugin install forgeplan-workflow@ForgePlan-marketplace
+/reload-plugins
+```
+
+---
+
 ## Decision Guide: full sprint vs lightweight wave
 
 ```


### PR DESCRIPTION
## Summary

Closes a real architectural gap. Audit found that **3 of 17 fpl-skills skills** mentioned forgeplan; **14 didn't**. Documentation promised "every skill delegates artifact lifecycle to forgeplan" but the skill bodies were silent. Users running `/sprint` or `/audit` would never see PRD/Evidence created, and `forgeplan health` would surface blind spots after the fact.

**After this release: 13 of 17 skills are forgeplan-aware** (the remaining 4 are config/foundation skills — `/bootstrap`, `/setup`, `/team`, `forge-report` — where forgeplan integration doesn't apply).

`fpl-skills` v1.1.1 → **v1.2.0** (minor — cross-skill feature). Marketplace catalog **1.11.1 → 1.12.0**.

## What changed in each skill

Every workflow skill now ends with a tailored `## Forgeplan integration` section. Same shape (`If forgeplan CLI present → recommend these calls → otherwise / fallback`), but the **calls** differ per skill:

| Skill | New section recommends |
|---|---|
| `/sprint` | Full lifecycle: `forgeplan route → new prd → validate → reason → ... → new evidence → score → activate` |
| `/audit` | `forgeplan new evidence` with structured fields (verdict, congruence_level, evidence_type) + link to PRD |
| `/research` | Decision tree: `note` for context, `prd` for new initiative, `adr` for surfaced decision |
| `/refine` | `forgeplan new adr` when key decision surfaces; `forgeplan validate` of refined plan |
| `/rfc` | Prefers `forgeplan new rfc/adr` over plain markdown; explains `forgeplan_update` vs Edit/Write |
| `/diagnose` | `forgeplan new evidence` on verified fix; `forgeplan new problem` for deeper architectural issues |
| `/build` | `forgeplan new evidence + score + activate` on IMPLEMENTATION-PLAN completion |
| `/do` | Mirrors `/autorun`'s probe-and-delegate; explicit behaviour table per environment |
| `/restore` | Adds `forgeplan health/blocked/stale` to the parallel recall block |
| `/briefing` | Adds `forgeplan blocked/stale/blindspots` to the daily briefing |

`/autorun` already had partial integration; this PR clarifies its behaviour table:

| Detected | What `/autorun` does |
|---|---|
| `forgeplan-workflow` installed | Delegates to `/forge-cycle "<task>"` for full automation |
| `forgeplan` CLI but no `forgeplan-workflow` | Standard pipeline + manual `forgeplan` calls between phases |
| Neither | Standard pipeline; one-time warning at start |

Each skill's section ends with a **"Want this orchestrated for you?"** callout pointing at `/forge-cycle` (in `forgeplan-workflow`) as the one-command alternative.

## DEVELOPER-JOURNEY walkthrough

New section **"`/forge-cycle` — first time"** (50+ lines, EN+RU):

- Install command for `forgeplan-workflow`
- 8-step cycle walkthrough (health → task → route → shape → build → audit → evidence → activate → commit)
- Decision matrix: `/forge-cycle` vs `/sprint` vs `/autorun` vs `/do`
- Setup checklist
- Cross-reference to `@forgeplan/web` for visual exploration

Closes the onboarding gap for users who want the orchestrated path rather than manual coordination across `fpl-skills` skills.

## Architectural decision recorded

**Don't dilute `fpl-skills` skills with `forgeplan-workflow`'s orchestration logic.** Two plugins with dual-orchestration would create divergence — `/sprint` and `/forge-cycle` doing the same thing inconsistently. Instead, every skill points to the orchestrator as the canonical "automate this" answer:

- `fpl-skills` skills = **executors** (recommend forgeplan calls inline, do the work)
- `forgeplan-workflow` `/forge-cycle` = **orchestrator** (runs the full cycle, delegates build to fpl-skills' `/sprint`)
- `/autorun` = **bridge** (probes for orchestrator, delegates if found, falls back otherwise)

This keeps each plugin's purpose distinct and avoids doing-the-same-thing-twice.

## Verification

- [x] `./scripts/validate-all-plugins.sh fpl-skills` → ALL PASSED
- [x] All JSON files (plugin.json, hooks.json, marketplace.json) parse cleanly
- [x] `grep -c forgeplan plugins/fpl-skills/skills/*/SKILL.md` shows 13/17 skills now have forgeplan refs (was 3/17)
- [x] No skill claims forgeplan integration without backing prose
- [x] DEVELOPER-JOURNEY EN+RU mirrors structurally identical
- [ ] CI `validate` passes on PR open

## Files

| Type | Count | Files |
|---|---|---|
| Modified — workflow skills | 11 | sprint, audit, research, refine, rfc, diagnose, build, do, restore, briefing, autorun |
| Modified — docs | 2 | DEVELOPER-JOURNEY.md, DEVELOPER-JOURNEY-RU.md |
| Modified — manifests | 2 | plugin.json (1.1.1 → 1.2.0), marketplace.json (1.11.1 → 1.12.0) |
| Modified — CHANGELOG | 1 | 1.12.0 entry |

Total: +462 / -3 lines across 16 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)