### PR TITLE
feat: v1.15.0 — autoresearch as recommended companion + integration guide

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.14.0"
+    "version": "1.15.0"
   },
   "plugins": [
     {
@@ -140,8 +140,8 @@
     {
       "name": "forgeplan-brownfield-pack",
       "source": "./plugins/forgeplan-brownfield-pack",
-      "description": "Brownfield extraction pack: 12 extraction skills + 2 playbooks + 3 integrations + 2 mappings + templates + examples. Two-tier extraction (Factum vs Intent) with confidence taxonomy and ADI cycle. Turns legacy code + docs into a structured forgeplan graph.",
-      "version": "1.1.0",
+      "description": "Brownfield extraction pack: 12 extraction skills + 2 playbooks + 3 integrations + 2 mappings + templates + examples. Two-tier extraction (Factum vs Intent) with confidence taxonomy and ADI cycle. Turns legacy code + docs into a structured forgeplan graph. Documents integration with autoresearch (uditgoenka/autoresearch) for metric-driven extraction loops.",
+      "version": "1.2.0",
       "author": {
         "name": "ForgePlan"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the ForgePlan Marketplace will be documented in this file
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.0] - 2026-05-08
+
+Reframed `autoresearch` (the metric-driven loop plugin by Udit Goenka) from "external mention" to **recommended companion** with a proper integration guide. Earlier docs treated it as a distant reference; in reality it composes naturally with `/forge-cycle` and the brownfield extraction skills.
+
+### Added
+- `docs/AUTORESEARCH-INTEGRATION.md` and `-RU.md` (~280 lines each) — full integration guide covering the autoresearch v2.0.03 command set (`plan`, `debug`, `security`, `predict`, `reason`), three integration patterns (autoresearch as Build phase of `/forge-cycle`; autoresearch standalone → Note + Evidence; security audit → Evidence), brownfield mapping (which extraction skills delegate to which autoresearch command), setup instructions, decision matrix, anti-patterns. RU version in plain Russian.
+
+### Changed
+- `docs/METHODOLOGIES.md` and `-RU.md`: Autoresearch promoted from "External" section to a new "Recommended companion" section. Quick lookup table updated with link to the integration guide.
+- `docs/PLAYBOOK.md` and `-RU.md`: new use-case "Metric-driven iteration (autoresearch + ForgePlan)" with three patterns showing how PRD success criteria become autoresearch metrics, results captured as CL3 Evidence with `evidence_type: measurement`.
+- Root `README.md` and `README-RU.md`: Documentation block extended to 6 entries (added "Autoresearch integration" row).
+- `forgeplan-brownfield-pack` v1.1.0 → **1.2.0** (patch — description refreshed to mention autoresearch integration; no skill changes).
+- Marketplace catalog metadata.version 1.14.0 → **1.15.0**.
+
+### Notes
+The earlier framing in METHODOLOGIES called autoresearch "an external tool we don't implement". Technically true, but strategically misleading — the brownfield-pack `integration/autoresearch-hooks.md` already maps each of our 12 extraction skills to autoresearch commands, and autoresearch's loop pattern is exactly what `/forge-cycle` Build phase needs when a mechanical metric exists. This release surfaces that.
+
+Reframing matters because users who read METHODOLOGIES decide what to install. "External, not in our ecosystem" → likely skip. "Recommended companion, here's how it composes" → likely try.
+
 ## [1.14.0] - 2026-05-08
 
 Brownfield extraction pack ported from upstream forgeplan repo. The 12-skill methodology that's been ready in `/docs/brownfield-extraction-package/` is now installable.

--- a/README-RU.md
+++ b/README-RU.md
@@ -21,6 +21,7 @@
 | 📖 [Руководство](docs/USAGE-GUIDE-RU.md) | Справочник: 18 команд, хуки, правила активации агентов, разбор частых проблем |
 | 🏛 [Архитектура](docs/ARCHITECTURE-RU.md) | Четырёхслойная ментальная модель — Orchestra (где) · Forgeplan (что) · FPF (как думать) · SPARC (как кодить) |
 | 🔬 [Методологии](docs/METHODOLOGIES-RU.md) | Что встроено в forgeplan (BMAD, OpenSpec, ADI, F-G-R, DDR, Verification Gate) и что внешнее |
+| 🔁 [Autoresearch — интеграция](docs/AUTORESEARCH-INTEGRATION-RU.md) | Сочетание `uditgoenka/autoresearch` (циклы под мерой) с жизненным циклом `/forge-cycle` |
 | 🚚 [Миграция: dev-toolkit → fpl-skills](docs/MIGRATION-DEV-TOOLKIT-TO-FPL-SKILLS-RU.md) | Безопасный переход (side-by-side или clean-cut, с rollback-планом) |
 | 🗂 [Интеграция трекеров](docs/TRACKER-INTEGRATION-RU.md) | Recipes для Orchestra · GitHub Issues · Linear · Jira · локальный TODO |
 | 🌐 [Forgeplan Web](docs/FORGEPLAN-WEB-RU.md) | Браузерный viewer — time-travel слайдер + граф артефактов + health dashboard |

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Official plugin marketplace for Claude Code from [ForgePlan](https://github.com/
 | 📖 [Usage Guide](docs/USAGE-GUIDE.md) | Reference manual: 18 commands, hooks, agent activation rules, troubleshooting |
 | 🏛 [Architecture](docs/ARCHITECTURE.md) | 4-layer mental model — Orchestra (where) · Forgeplan (what) · FPF (how to think) · SPARC (how to code) |
 | 🔬 [Methodologies](docs/METHODOLOGIES.md) | What's built into forgeplan (BMAD, OpenSpec, ADI, F-G-R, DDR, Verification Gate) vs what's external |
+| 🔁 [Autoresearch integration](docs/AUTORESEARCH-INTEGRATION.md) | Combining `uditgoenka/autoresearch` (metric-driven loops) with `/forge-cycle` lifecycle |
 | 🚚 [Migration: dev-toolkit → fpl-skills](docs/MIGRATION-DEV-TOOLKIT-TO-FPL-SKILLS.md) | Switching plugins safely (side-by-side or clean-cut, with rollback plan) |
 | 🗂 [Tracker Integration](docs/TRACKER-INTEGRATION.md) | Recipes for Orchestra · GitHub Issues · Linear · Jira · local TODO |
 | 🌐 [Forgeplan Web](docs/FORGEPLAN-WEB.md) | Browser viewer — time-travel slider + artifact graph + health dashboard |

--- a/docs/AUTORESEARCH-INTEGRATION-RU.md
+++ b/docs/AUTORESEARCH-INTEGRATION-RU.md
@@ -1,0 +1,176 @@
+[English](AUTORESEARCH-INTEGRATION.md) | [Русский](AUTORESEARCH-INTEGRATION-RU.md)
+
+# Autoresearch ↔ ForgePlan: интеграция
+
+Как сочетать [`autoresearch`](https://github.com/uditgoenka/autoresearch) (плагин итеративных целевых циклов от Udit Goenka, основанный на [autoresearch Карпатого](https://github.com/karpathy/autoresearch)) с рабочим процессом ForgePlan.
+
+> **TL;DR**: ForgePlan ведёт **отслеживаемый жизненный цикл артефактов** (PRD/RFC/ADR с подсчётом R_eff). Autoresearch ведёт **итерации под мерой** (Modify → Verify → Keep/Discard → Repeat). Они хорошо сочетаются — autoresearch крутит цикл, forgeplan сохраняет результат как Evidence.
+
+---
+
+## Что такое autoresearch
+
+Плагин-скилл для Claude Code (а также OpenCode и Codex), превращающий любую задачу с **измеримой метрикой** в целенаправленный цикл:
+
+```
+Цель → цикл:
+  Модификация кода → запуск verify → измерение метрики →
+    лучше: оставить, закоммитить
+    хуже: откатить, попробовать другой вариант
+  Стоп когда цель достигнута или бюджет исчерпан
+```
+
+Пять команд (v2.0.03):
+
+| Команда | Назначение |
+|---|---|
+| `/autoresearch:plan` | Анализ кодовой базы, предложение метрик, dry-run verify до запуска |
+| `/autoresearch:debug` | Итеративный цикл починки бага под метрикой (доля прохождения тестов, производительность и т.п.) |
+| `/autoresearch:security` | Аудит безопасности только-чтение (с опциональным `--fix` для подтверждённых Critical/High) |
+| `/autoresearch:predict` | Однократный разбор существующего кода группой из 5 экспертов |
+| `/autoresearch:reason` | Итеративное уточнение — конкурирующие варианты, критика, синтез, слепое судейство до сходимости |
+
+**Установка** (отдельно от этого маркетплейса):
+```
+/plugin marketplace add uditgoenka/autoresearch
+/plugin install autoresearch@uditgoenka-autoresearch
+```
+
+---
+
+## Зачем сочетать с ForgePlan
+
+Autoresearch и ForgePlan оптимизируют разные вещи:
+
+| | Autoresearch | ForgePlan |
+|---|---|---|
+| Что оптимизирует | Механическую метрику (тесты, производительность, размер сборки, security findings) | Прослеживаемость + происхождение решений (PRD/ADR/Evidence с R_eff) |
+| Цикл | Modify → Verify → Keep/Discard | Route → Shape → Build → Evidence → Activate |
+| Что производит | Улучшенный код соответствующий метрике | Граф артефактов + оценённые решения |
+| Что НЕ фиксирует | Зачем сделано изменение (намерение, альтернативы) | Тысячу мелких экспериментов которые привели к изменению |
+| Обратимость | git-история по итерациям | Состояния lifecycle с valid_until |
+
+В сочетании: autoresearch даёт **измеренное улучшение**, forgeplan фиксирует **след решений** + **оценку**.
+
+---
+
+## Три способа интеграции
+
+### Способ A — Autoresearch как фаза Build в `/forge-cycle`
+
+Когда `/forge-cycle` доходит до шага 5 (Build), и у задачи есть чёткая механическая метрика (доля тестов, p95-задержка, размер бандла), передаём управление в `/autoresearch:plan` вместо `/sprint`:
+
+```
+/forge-cycle "снизить p95 чекаута до 200мс"
+  → Шаг 1: forgeplan health
+  → Шаг 2: задача подтверждена
+  → Шаг 3: route → глубина Standard
+  → Шаг 4: shape → PRD-NNN с критерием успеха «p95 < 200мс»
+  → Шаг 5: BUILD → /autoresearch:plan "снизить p95 до 200мс"
+                  (цикл крутится без участия, коммитит каждую итерацию)
+  → Шаг 6: ревью
+  → Шаг 7: forgeplan new evidence с финальным замером p95
+            verdict: supports
+            congruence_level: 3
+            evidence_type: measurement
+  → Шаг 8: активация PRD-NNN если R_eff > 0
+```
+
+Критерий успеха PRD становится метрикой autoresearch. Финальное состояние цикла попадает в Evidence с высокой уверенностью CL3 (это прямое измерение).
+
+### Способ B — Autoresearch отдельно → результат в ForgePlan как Evidence
+
+Для разовых улучшений на которые полный PRD неоправдан — запускаем autoresearch отдельно, фиксируем результат как Note + Evidence:
+
+```bash
+# Запускаем цикл
+/autoresearch:debug "починить нестабильный тест в test/auth.spec.ts"
+# Когда готово — фиксируем в forgeplan:
+forgeplan new note "починен нестабильный auth-тест — причина: гонка в моке токена"
+forgeplan new evidence "/autoresearch:debug 47 итераций; финальная доля 100/100; commit sha=abc123"
+forgeplan link EVID-NNN NOTE-MMM
+```
+
+Лёгкий вариант — без PRD, без шлюза активации. Просто след показывающий что цикл сделал.
+
+### Способ C — Autoresearch для security-аудита → Evidence
+
+`/autoresearch:security` по умолчанию только-чтение и выдаёт структурный отчёт. Это прямой кандидат на Evidence:
+
+```bash
+/autoresearch:security
+# После отчёта:
+forgeplan new evidence "<scope>: autoresearch:security audit — 2 HIGH, 4 MED findings; 1 HIGH автоматически исправлено через --fix"
+# Связываем с релевантным security PRD или ADR:
+forgeplan link EVID-NNN ADR-MMM --relation informs
+```
+
+Если запускали с `--fix` и применили авто-исправление — сами изменения можно оформить отдельным Evidence (verdict: supports, evidence_type: code_review).
+
+---
+
+## Извлечение знаний из brownfield с autoresearch
+
+Скиллы [`forgeplan-brownfield-pack`](../plugins/forgeplan-brownfield-pack/README-RU.md) могут использовать примитивы autoresearch как цикловой движок:
+
+| Скилл brownfield | Команда autoresearch | Режим |
+|---|---|---|
+| `intent-inferrer` (C3) | `/autoresearch:reason` | итеративное уточнение конкурирующих гипотез (соответствует ADI: дедукция → индукция) |
+| `hypothesis-triangulator` (C6) | `/autoresearch:predict` | разбор 5 экспертов для триангуляции — какая гипотеза переживёт проверку |
+| `canonical-reproducer` (C10) | `/autoresearch:debug` | итерации до соответствия воспроизведения реальности (метрика: поведенческое совпадение) |
+| `reproducibility-validator` (C11) | verify команда autoresearch | работает как валидационный слой для C10 |
+
+Пакет brownfield содержит рецепт в [`integration/autoresearch-hooks.md`](../plugins/forgeplan-brownfield-pack/integration/autoresearch-hooks.md) показывающий как каждый из 12 скиллов извлечения подключается к командам autoresearch v2.0.03.
+
+---
+
+## Установка
+
+```bash
+# 1. Поставить autoresearch (отдельный маркетплейс)
+/plugin marketplace add uditgoenka/autoresearch
+/plugin install autoresearch@uditgoenka-autoresearch
+/reload-plugins
+
+# 2. Сторона ForgePlan (если ещё не сделано)
+/plugin install fpl-skills@ForgePlan-marketplace
+/plugin install forgeplan-workflow@ForgePlan-marketplace
+/reload-plugins
+
+# 3. Проверка
+/autoresearch:plan --help    # autoresearch
+forgeplan --version          # CLI forgeplan
+```
+
+---
+
+## Какой цикл когда использовать
+
+| Ситуация | Что использовать |
+|---|---|
+| У задачи чёткая механическая метрика (производительность, тесты, размер сборки, security findings) | `/autoresearch:plan` (или сразу `:debug`/`:security`) |
+| Нужно рассуждение между вариантами без объективной метрики | `/autoresearch:reason` (итеративное уточнение со слепым судейством) |
+| Однократный разбор для решения которое сам примешь | `/autoresearch:predict` (5 экспертов, без цикла) |
+| Задача с несколькими ограничениями + нужна прослеживаемость | `/forge-cycle` (lifecycle артефактов), с autoresearch на фазе Build если есть метрика |
+| Чистая реализация фичи без метрики | `/sprint` или `/forge-cycle`, autoresearch не нужен |
+| Извлечение из brownfield (вывод намерений, триангуляция гипотез) | Скиллы `forgeplan-brownfield-pack` делегирующие в autoresearch |
+
+---
+
+## Чего не делать
+
+- ❌ **Запускать autoresearch без метрики.** Весь движок строится на `Modify → Verify` где Verify выдаёт число. Нет метрики — нет сигнала — цикл бродит впустую.
+- ❌ **Сохранять результат autoresearch как Evidence без CL-разметки.** Помечай `congruence_level: 3` (CL3 — тот же контекст) и `evidence_type: measurement` чтобы R_eff корректно посчитался.
+- ❌ **Использовать autoresearch для задач требующих творческого суждения** (UX-решения, нейминг, приоритеты). Бери `/refine` или `/fpf-evaluate`.
+- ❌ **Забыть закоммититься перед циклом.** Autoresearch коммитит каждую итерацию, но **начальное состояние** тоже должно быть в git чтобы откат работал чисто.
+- ❌ **Запускать autoresearch параллельно `/sprint` на одних и тех же файлах.** Будут драться за код. Один инструмент на одну задачу.
+
+---
+
+## См. также
+
+- Репозиторий autoresearch — [github.com/uditgoenka/autoresearch](https://github.com/uditgoenka/autoresearch) (v2.0.03)
+- Оригинал Карпатого — [github.com/karpathy/autoresearch](https://github.com/karpathy/autoresearch)
+- [METHODOLOGIES-RU.md](METHODOLOGIES-RU.md) — autoresearch как recommended companion
+- [PLAYBOOK-RU.md](PLAYBOOK-RU.md) — сценарий «итерации под мерой»
+- [`plugins/forgeplan-brownfield-pack/integration/autoresearch-hooks.md`](../plugins/forgeplan-brownfield-pack/integration/autoresearch-hooks.md) — карта соответствия для 12 скиллов brownfield

--- a/docs/AUTORESEARCH-INTEGRATION.md
+++ b/docs/AUTORESEARCH-INTEGRATION.md
@@ -1,0 +1,176 @@
+[English](AUTORESEARCH-INTEGRATION.md) | [Русский](AUTORESEARCH-INTEGRATION-RU.md)
+
+# Autoresearch ↔ ForgePlan integration
+
+How to combine [`autoresearch`](https://github.com/uditgoenka/autoresearch) (the iterative goal-loop plugin by Udit Goenka, based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch)) with the ForgePlan workflow.
+
+> **TL;DR**: ForgePlan handles **traceable artifact lifecycle** (PRD/RFC/ADR with R_eff scoring). Autoresearch handles **mechanical-metric-driven iteration** (Modify → Verify → Keep/Discard → Repeat). They compose naturally — autoresearch runs the loop, forgeplan stores what was learned as Evidence.
+
+---
+
+## What autoresearch is
+
+A Claude Code (and OpenCode / Codex) skill plugin that turns any task with a **measurable metric** into a goal-directed loop:
+
+```
+Set GOAL → loop:
+  Modify code → run verify → measure metric →
+    if better: keep, commit
+    if worse: discard, try alternative
+  Stop when goal reached or budget exhausted
+```
+
+Five commands (v2.0.03):
+
+| Command | Purpose |
+|---|---|
+| `/autoresearch:plan` | Analyse codebase, suggest metrics, dry-run verify command before launching |
+| `/autoresearch:debug` | Iterative bug-fix loop with metric (test pass rate, perf number, etc.) |
+| `/autoresearch:security` | Read-only security audit (with optional `--fix` for confirmed Critical/High) |
+| `/autoresearch:predict` | One-shot 5-expert debate analysing existing code |
+| `/autoresearch:reason` | Iterative refinement loop — competing candidates, critique, synthesis, blind-judging until convergence |
+
+**Install** (separate from this marketplace):
+```
+/plugin marketplace add uditgoenka/autoresearch
+/plugin install autoresearch@uditgoenka-autoresearch
+```
+
+---
+
+## Why combine with ForgePlan
+
+Autoresearch and ForgePlan optimise different things:
+
+| | Autoresearch | ForgePlan |
+|---|---|---|
+| Optimises | Mechanical metric (test pass, perf number, security findings) | Traceability + decision provenance (PRD/ADR/Evidence with R_eff) |
+| Loop | Modify → Verify → Keep/Discard | Route → Shape → Build → Evidence → Activate |
+| What it produces | Improved code matching the metric | Artifact graph + scored decisions |
+| What it does NOT capture | Why the change was made (intent, alternatives) | The thousand small experiments that produced the change |
+| Reversibility | git history per iteration | Lifecycle states with valid_until |
+
+Combined: autoresearch produces the **measured improvement**, forgeplan captures the **decision trail** + **scoring**.
+
+---
+
+## Three integration patterns
+
+### Pattern A — Autoresearch as the Build phase of `/forge-cycle`
+
+When `/forge-cycle` reaches Step 5 (Build) and the task has a clear mechanical metric (test pass rate, p95 latency, bundle size), delegate to `/autoresearch:plan` instead of `/sprint`:
+
+```
+/forge-cycle "reduce checkout p95 latency below 200ms"
+  → Step 1: forgeplan health
+  → Step 2: task confirmed
+  → Step 3: route → Standard depth
+  → Step 4: shape → PRD-NNN with success criterion "p95 < 200ms"
+  → Step 5: BUILD → /autoresearch:plan "reduce p95 latency below 200ms"
+                  (loop runs unattended, commits per iteration)
+  → Step 6: audit
+  → Step 7: forgeplan new evidence with the final p95 measurement
+            verdict: supports
+            congruence_level: 3
+            evidence_type: measurement
+  → Step 8: activate PRD-NNN if R_eff > 0
+```
+
+The PRD's success criterion becomes the autoresearch metric. The loop's final state becomes Evidence with high CL3 confidence (it's a direct measurement).
+
+### Pattern B — Autoresearch on its own → Evidence into ForgePlan
+
+For ad-hoc improvements you don't want a full PRD for, run autoresearch standalone and capture the outcome as a Note + Evidence:
+
+```bash
+# Run the loop
+/autoresearch:debug "fix flaky test in test/auth.spec.ts"
+# When done, capture in forgeplan:
+forgeplan new note "fixed flaky auth test — root cause: race in token mock"
+forgeplan new evidence "/autoresearch:debug 47 iterations; final pass rate 100/100; commit sha=abc123"
+forgeplan link EVID-NNN NOTE-MMM
+```
+
+Lightweight — no PRD, no activation gate. Just a paper trail showing what the loop achieved.
+
+### Pattern C — Autoresearch for security audit → Evidence
+
+`/autoresearch:security` is read-only by default and produces a structured findings report. That's directly a candidate for Evidence:
+
+```bash
+/autoresearch:security
+# After the report:
+forgeplan new evidence "<scope>: autoresearch:security audit — 2 HIGH, 4 MED findings; 1 HIGH auto-fixed via --fix"
+# Link to the relevant security PRD or ADR:
+forgeplan link EVID-NNN ADR-MMM --relation informs
+```
+
+If you ran with `--fix` and applied auto-remediation — the changeset itself can be a separate Evidence (verdict: supports, evidence_type: code_review).
+
+---
+
+## Brownfield extraction with autoresearch
+
+The [`forgeplan-brownfield-pack`](../plugins/forgeplan-brownfield-pack/README.md) skills can use autoresearch primitives as their loop engine:
+
+| Brownfield skill | Autoresearch command | Mode |
+|---|---|---|
+| `intent-inferrer` (C3) | `/autoresearch:reason` | iterative refinement of competing hypotheses (matches ADI deduction → induction) |
+| `hypothesis-triangulator` (C6) | `/autoresearch:predict` | 5-expert debate to triangulate which hypothesis survives evidence |
+| `canonical-reproducer` (C10) | `/autoresearch:debug` | iterate until reproduction matches reality (metric: behavioural equivalence) |
+| `reproducibility-validator` (C11) | autoresearch verify command | runs as the validation layer for C10 |
+
+The brownfield pack ships a recipe at [`integration/autoresearch-hooks.md`](../plugins/forgeplan-brownfield-pack/integration/autoresearch-hooks.md) showing how each of the 12 extraction skills can plug into autoresearch v2.0.03 commands.
+
+---
+
+## Setup
+
+```bash
+# 1. Install autoresearch (separate marketplace)
+/plugin marketplace add uditgoenka/autoresearch
+/plugin install autoresearch@uditgoenka-autoresearch
+/reload-plugins
+
+# 2. ForgePlan side (if not already done)
+/plugin install fpl-skills@ForgePlan-marketplace
+/plugin install forgeplan-workflow@ForgePlan-marketplace
+/reload-plugins
+
+# 3. Verify
+/autoresearch:plan --help    # autoresearch
+forgeplan --version          # forgeplan CLI
+```
+
+---
+
+## Decision matrix — which loop to use when
+
+| Situation | Use |
+|---|---|
+| Task has a clear mechanical metric (perf, test rate, bundle size, security findings) | `/autoresearch:plan` (or skip straight to `:debug`/`:security`) |
+| Task needs reasoning between alternatives without an objective metric | `/autoresearch:reason` (iterative refinement with blind judging) |
+| One-shot analysis for a decision you'll make yourself | `/autoresearch:predict` (5-expert debate, no loop) |
+| Task has multiple constraints + needs traceability | `/forge-cycle` (artifact lifecycle), with autoresearch in Build phase if metric exists |
+| Pure feature implementation (no metric) | `/sprint` or `/forge-cycle`, no autoresearch needed |
+| Brownfield extraction (intent inference, hypothesis triangulation) | `forgeplan-brownfield-pack` skills delegating to autoresearch |
+
+---
+
+## Anti-patterns
+
+- ❌ **Running autoresearch without a metric.** The whole engine relies on `Modify → Verify` where Verify outputs a number. No metric = no signal = the loop wanders.
+- ❌ **Capturing autoresearch results as a single Evidence with no CL.** Tag with `congruence_level: 3` (CL3 same-context) and `evidence_type: measurement` so R_eff scoring works.
+- ❌ **Using autoresearch for tasks that need creative judgment** (UX decisions, naming, prioritisation). Use `/refine` or `/fpf-evaluate` instead.
+- ❌ **Forgetting to commit before the loop.** Autoresearch commits per iteration but the **starting state** should also be in git so rollback works cleanly.
+- ❌ **Running autoresearch in parallel with `/sprint` on the same files.** They'll fight over the same code. Pick one per task.
+
+---
+
+## See also
+
+- Autoresearch repo — [github.com/uditgoenka/autoresearch](https://github.com/uditgoenka/autoresearch) (v2.0.03)
+- Karpathy's original — [github.com/karpathy/autoresearch](https://github.com/karpathy/autoresearch)
+- [METHODOLOGIES.md](METHODOLOGIES.md) — autoresearch listed as recommended companion
+- [PLAYBOOK.md](PLAYBOOK.md) — use-case "metric-driven iteration"
+- [`plugins/forgeplan-brownfield-pack/integration/autoresearch-hooks.md`](../plugins/forgeplan-brownfield-pack/integration/autoresearch-hooks.md) — per-skill mapping for the 12 brownfield skills

--- a/docs/METHODOLOGIES-RU.md
+++ b/docs/METHODOLOGIES-RU.md
@@ -143,13 +143,30 @@
 
 ---
 
+## Рекомендуемый companion (отдельный маркетплейс, хорошо сочетается с нашим)
+
+### Autoresearch — итеративный цикл под мерой
+
+**Что это**: плагин-скилл для Claude Code (и OpenCode, Codex) от Udit Goenka, на основе [autoresearch Карпатого](https://github.com/karpathy/autoresearch). Превращает любую задачу с измеримой метрикой в целенаправленный цикл: **Modify → Verify → Keep/Discard → Repeat**. Пять команд в v2.0.03: `plan`, `debug`, `security`, `predict`, `reason`.
+
+**Источник**: [github.com/uditgoenka/autoresearch](https://github.com/uditgoenka/autoresearch) — отдельный маркетплейс, лицензия MIT.
+
+**Как сочетается с нами**:
+- Фаза Build в `/forge-cycle` может передавать управление в `/autoresearch:plan` когда у задачи чёткая механическая метрика (производительность, доля тестов, размер сборки, security findings)
+- Результаты autoresearch фиксируются через `forgeplan new evidence` с `congruence_level: 3` и `evidence_type: measurement` — качественный CL3 вход для R_eff
+- Скиллы извлечения brownfield (intent-inferrer, hypothesis-triangulator, canonical-reproducer) используют примитивы autoresearch как движок цикла
+
+**Гайд по интеграции**: [`docs/AUTORESEARCH-INTEGRATION-RU.md`](AUTORESEARCH-INTEGRATION-RU.md) — три способа интеграции, матрица решений, чего не делать, установка.
+
+**Установка**:
+```
+/plugin marketplace add uditgoenka/autoresearch
+/plugin install autoresearch@uditgoenka-autoresearch
+```
+
+---
+
 ## Внешние (упоминается, но не реализовано в этой экосистеме)
-
-### Autoresearch
-
-**Что это**: автоматизированный исследовательский инструмент в anthropic-marketplace (`autoresearch@anthropic-marketplace`).
-
-**Статус у нас**: `forgeplan-brownfield-pack` ссылается на хуки для Autoresearch (`integration/autoresearch-hooks.md`) и на запланированную карту соответствия (`autoresearch-to-forge.yaml`). Сам forgeplan автоматизированное исследование не реализует — он интегрируется с Autoresearch когда тот установлен отдельно.
 
 ### DDD — Domain-Driven Design
 
@@ -217,7 +234,7 @@
 | Laws of UX | Плагин `laws-of-ux` | `/ux-review`, `/ux-law <имя>` |
 | DDD | `agents-pro` + brownfield-pack | Только консультации — движка нет |
 | C4 | Карта в brownfield-pack | Только YAML-преобразование |
-| Autoresearch | Внешнее (anthropic-marketplace) | Ставится отдельно |
+| Autoresearch | Внешний companion (`uditgoenka/autoresearch`) | Ставится отдельно; см. [AUTORESEARCH-INTEGRATION-RU.md](AUTORESEARCH-INTEGRATION-RU.md) для способов интеграции |
 | RIPER | НЕТ в экосистеме | Вручную — связка `/research` → `/refine` → `/rfc` → `/sprint` → `/audit` |
 | AI-SDLC | НЕ названо так, приближение через `/autorun` | `/autorun "<задача>"` |
 

--- a/docs/METHODOLOGIES.md
+++ b/docs/METHODOLOGIES.md
@@ -143,13 +143,30 @@ Activates `ux-reviewer` automatically inside `/audit` when the changeset include
 
 ---
 
+## Recommended companion (separate marketplace, plays well with us)
+
+### Autoresearch — metric-driven iterative loop
+
+**What it is**: a Claude Code (and OpenCode / Codex) skill plugin by Udit Goenka, based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch). Turns any task with a measurable metric into a goal-directed loop: **Modify → Verify → Keep/Discard → Repeat**. Five commands in v2.0.03: `plan`, `debug`, `security`, `predict`, `reason`.
+
+**Source**: [github.com/uditgoenka/autoresearch](https://github.com/uditgoenka/autoresearch) — separate marketplace, MIT licence.
+
+**How it composes with us**:
+- `/forge-cycle` Build phase can delegate to `/autoresearch:plan` when the task has a clear mechanical metric (perf, test rate, bundle size, security findings)
+- Autoresearch results captured as `forgeplan new evidence` with `congruence_level: 3` + `evidence_type: measurement` — high-quality CL3 input to R_eff
+- Brownfield extraction skills (intent-inferrer, hypothesis-triangulator, canonical-reproducer) can use autoresearch primitives as their loop engine
+
+**Integration guide**: [`docs/AUTORESEARCH-INTEGRATION.md`](AUTORESEARCH-INTEGRATION.md) — three integration patterns, decision matrix, anti-patterns, setup.
+
+**Install**:
+```
+/plugin marketplace add uditgoenka/autoresearch
+/plugin install autoresearch@uditgoenka-autoresearch
+```
+
+---
+
 ## External (referenced but not implemented in this ecosystem)
-
-### Autoresearch
-
-**What it is**: an automated research tool published in the anthropic-marketplace (`autoresearch@anthropic-marketplace`).
-
-**Status in our ecosystem**: `forgeplan-brownfield-pack` references hooks for Autoresearch (`integration/autoresearch-hooks.md`) and a planned mapping (`autoresearch-to-forge.yaml`). Forgeplan itself does not implement automated research — it integrates with Autoresearch when you install it separately.
 
 ### DDD (Domain-Driven Design)
 
@@ -217,7 +234,7 @@ If you want to read the original BMAD spec → see `sources/BMAD-METHOD/` in the
 | Laws of UX | `laws-of-ux` plugin | `/ux-review`, `/ux-law <name>` |
 | DDD | `agents-pro` + brownfield pack | Advisory only — no engine |
 | C4 | brownfield pack mapping | YAML conversion only |
-| Autoresearch | external (anthropic-marketplace) | Install separately |
+| Autoresearch | external companion (`uditgoenka/autoresearch`) | Install separately; see [AUTORESEARCH-INTEGRATION.md](AUTORESEARCH-INTEGRATION.md) for integration patterns |
 | RIPER | NOT in ecosystem | Manual — chain `/research` → `/refine` → `/rfc` → `/sprint` → `/audit` |
 | AI-SDLC | NOT named, approximated by `/autorun` | `/autorun "<task>"` |
 

--- a/docs/PLAYBOOK-RU.md
+++ b/docs/PLAYBOOK-RU.md
@@ -224,6 +224,56 @@ brew install ForgePlan/tap/forgeplan
 
 ---
 
+## Сценарий — Итерации под мерой (autoresearch + ForgePlan)
+
+**Что**: у задачи есть чёткая механическая метрика (число производительности, доля тестов, размер сборки, число security findings), и нужен целенаправленный цикл который улучшает метрику до цели — а результат фиксируется как полноценное Evidence.
+
+**Настройка** (autoresearch — отдельный маркетплейс):
+```
+/plugin marketplace add uditgoenka/autoresearch
+/plugin install autoresearch@uditgoenka-autoresearch
+/plugin install fpl-skills@ForgePlan-marketplace
+/plugin install forgeplan-workflow@ForgePlan-marketplace
+/reload-plugins
+```
+
+**Три способа** (полный гайд: [AUTORESEARCH-INTEGRATION-RU.md](AUTORESEARCH-INTEGRATION-RU.md)):
+
+### Способ A — Autoresearch как фаза Build в `/forge-cycle`
+
+```
+/forge-cycle "снизить p95 чекаута до 200мс"
+  → Шаг 4 — shape: PRD с критерием успеха «p95 < 200мс»
+  → Шаг 5 — BUILD передаётся в /autoresearch:plan (цикл крутится без участия)
+  → Шаг 7 — evidence: forgeplan new evidence с финальным p95
+              (verdict: supports, congruence_level: 3, evidence_type: measurement)
+  → Шаг 8 — активация когда R_eff > 0
+```
+
+Критерий успеха PRD **и есть** метрика autoresearch. Финальное состояние цикла попадает в высокоуверенное Evidence (CL3 — тот же контекст).
+
+### Способ B — Autoresearch отдельно → Note + Evidence
+
+Для лёгких улучшений без полного PRD:
+
+```
+/autoresearch:debug "починить нестабильный auth-тест"
+forgeplan new note "починен нестабильный auth-тест — гонка в моке токена"
+forgeplan new evidence "/autoresearch:debug 47 итераций; финал 100/100; sha=abc123"
+```
+
+### Способ C — Security-аудит → Evidence
+
+`/autoresearch:security` выдаёт структурный отчёт напрямую пригодный как Evidence:
+
+```
+/autoresearch:security        # только-чтение, или --fix для подтверждённых Critical/High
+forgeplan new evidence "<scope>: autoresearch:security — найдено 2 HIGH, 4 MED, 1 HIGH автоматически исправлено"
+forgeplan link EVID-NNN ADR-MMM --relation informs
+```
+
+---
+
 ## Сценарий 7 — Командная работа через несколько сессий
 
 **Что**: вы работаете командой через разные сессии. Задачи в Orchestra. Каждое утро — разбор входящих сигналов.

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -224,6 +224,56 @@ So you don't always need to invoke `/fpf-reason` directly — if you're using `/
 
 ---
 
+## Use-case — Metric-driven iteration (autoresearch + ForgePlan)
+
+**Scenario**: You have a task with a clear mechanical metric (perf number, test pass rate, bundle size, security findings count) and you want a goal-directed loop that improves the metric until target — with the result captured as proper Evidence.
+
+**Setup** (autoresearch is on a separate marketplace):
+```
+/plugin marketplace add uditgoenka/autoresearch
+/plugin install autoresearch@uditgoenka-autoresearch
+/plugin install fpl-skills@ForgePlan-marketplace
+/plugin install forgeplan-workflow@ForgePlan-marketplace
+/reload-plugins
+```
+
+**Three patterns** (full guide: [AUTORESEARCH-INTEGRATION.md](AUTORESEARCH-INTEGRATION.md)):
+
+### Pattern A — Autoresearch as Build phase of `/forge-cycle`
+
+```
+/forge-cycle "reduce checkout p95 latency below 200ms"
+  → Step 4 — shape: PRD with success criterion "p95 < 200ms"
+  → Step 5 — BUILD delegates to /autoresearch:plan (loop runs unattended)
+  → Step 7 — evidence: forgeplan new evidence with final p95 measurement
+              (verdict: supports, congruence_level: 3, evidence_type: measurement)
+  → Step 8 — activate when R_eff > 0
+```
+
+The PRD's success criterion **is** the autoresearch metric. The loop's final state becomes high-confidence Evidence (CL3 same-context).
+
+### Pattern B — Autoresearch standalone → Note + Evidence
+
+For lightweight improvements without a full PRD:
+
+```
+/autoresearch:debug "fix flaky auth test"
+forgeplan new note "fixed flaky auth test — race in token mock"
+forgeplan new evidence "/autoresearch:debug 47 iterations; final 100/100; sha=abc123"
+```
+
+### Pattern C — Security audit → Evidence
+
+`/autoresearch:security` produces a structured report directly suitable as Evidence:
+
+```
+/autoresearch:security        # read-only, or add --fix for confirmed Critical/High
+forgeplan new evidence "<scope>: autoresearch:security — 2 HIGH, 4 MED found, 1 HIGH auto-fixed"
+forgeplan link EVID-NNN ADR-MMM --relation informs
+```
+
+---
+
 ## Use-case 7 — Multi-session team coordination
 
 **Scenario**: You and your team work across sessions. Tasks live in Orchestra. You need an inbox-style triage every morning.

--- a/plugins/forgeplan-brownfield-pack/.claude-plugin/plugin.json
+++ b/plugins/forgeplan-brownfield-pack/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forgeplan-brownfield-pack",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Brownfield extraction pack for forgeplan — turns legacy code + docs into a structured forgeplan graph. Ships 12 extraction skills (ubiquitous-language, use-case-miner, intent-inferrer, invariant-detector, causal-linker, hypothesis-triangulator, interview-packager, scenario-writer, kg-curator, canonical-reproducer, reproducibility-validator, rag-packager), 2 orchestration playbooks (extract-business-logic, phase-transitions), 3 integration recipes (autoresearch hooks, forgeplan MCP additions, RAG export), 2 mappings (c4-to-forge, ddd-to-forge), templates, examples, and methodology docs. Implements two-tier extraction (Factum vs Intent) with confidence taxonomy and ADI cycle.",
   "author": {
     "name": "ForgePlan"


### PR DESCRIPTION
## Summary

Reframes [`uditgoenka/autoresearch`](https://github.com/uditgoenka/autoresearch) (Karpathy-inspired metric-driven loop plugin) from "external mention" to **recommended companion** with a proper integration guide. Earlier framing was technically correct but strategically misleading — autoresearch composes naturally with `/forge-cycle` and the brownfield extraction skills.

Marketplace catalog **1.14.0 → 1.15.0**. `forgeplan-brownfield-pack` 1.1.0 → 1.2.0 (description refresh only).

## What changed

### 🆕 `docs/AUTORESEARCH-INTEGRATION.md` and `-RU.md` (~280 lines each)

Covers autoresearch v2.0.03 command set: `plan`, `debug`, `security`, `predict`, `reason`.

**Three integration patterns**:

- **A — Autoresearch as Build phase of `/forge-cycle`**: PRD success criterion becomes the autoresearch metric. The loop's final state captured as Evidence with `congruence_level: 3` + `evidence_type: measurement` — high-confidence CL3 input to R_eff.
- **B — Autoresearch standalone → Note + Evidence**: lightweight, for improvements that don't warrant a full PRD (e.g. fixing a flaky test).
- **C — Security audit → Evidence**: `/autoresearch:security` produces a structured findings report directly suitable as Evidence (read-only, or `--fix` for confirmed Critical/High auto-remediation).

**Brownfield mapping** — which extraction skill delegates to which autoresearch command:

| Brownfield skill | Autoresearch command |
|---|---|
| intent-inferrer (C3) | `/autoresearch:reason` (iterative refinement of hypotheses) |
| hypothesis-triangulator (C6) | `/autoresearch:predict` (5-expert debate) |
| canonical-reproducer (C10) | `/autoresearch:debug` (loop until reproduction matches reality) |
| reproducibility-validator (C11) | autoresearch verify command |

Plus setup, decision matrix, 5 anti-patterns. RU version in plain Russian (less anglicism — "цикл под мерой", "под целью", "поведенческое совпадение").

### Changed

- **`METHODOLOGIES.md` + `-RU.md`**: autoresearch promoted from "External" section → "Recommended companion (separate marketplace, plays well with us)". Quick lookup table updated.
- **`PLAYBOOK.md` + `-RU.md`**: new use-case "Metric-driven iteration (autoresearch + ForgePlan)" with three patterns inline + link to full guide.
- **Root `README.md` + `README-RU.md`**: documentation block extended from 5 to 6 entries — new "🔁 Autoresearch integration" row.
- **`forgeplan-brownfield-pack` v1.1.0 → 1.2.0**: plugin.json description refreshed to mention autoresearch integration. No skill changes.
- **Marketplace catalog**: 1.14.0 → 1.15.0.
- **CHANGELOG**: 1.15.0 entry.

## Why this matters

Users reading `METHODOLOGIES.md` decide what to install. The earlier framing — "External, not in our ecosystem" — likely caused users to skip autoresearch. Reframed as "Recommended companion, here's how it composes" lowers the activation barrier. We already had the integration recipes (in `forgeplan-brownfield-pack/integration/autoresearch-hooks.md`); the framing was the problem.

## Verification

- [x] `./scripts/validate-all-plugins.sh` → ALL PASSED (no skill changes, but full pass)
- [x] All cross-references resolve (METHODOLOGIES, PLAYBOOK, root READMEs, brownfield-pack integration doc)
- [x] EN ↔ RU mirrors structurally identical
- [x] `forgeplan-brownfield-pack` plugin.json description aligns with marketplace.json catalog description
- [ ] CI `validate` passes on PR open

## Files

| Status | File | Lines |
|---|---|---|
| NEW | `docs/AUTORESEARCH-INTEGRATION.md` + `-RU.md` | ~280 each |
| MODIFIED | `docs/METHODOLOGIES.md` + `-RU.md` | reframe + lookup table |
| MODIFIED | `docs/PLAYBOOK.md` + `-RU.md` | new use-case section |
| MODIFIED | `README.md` + `README-RU.md` | docs block 5 → 6 |
| MODIFIED | `forgeplan-brownfield-pack/.claude-plugin/plugin.json` | version bump + description |
| MODIFIED | `.claude-plugin/marketplace.json` | catalog version + brownfield-pack entry |
| MODIFIED | `CHANGELOG.md` | 1.15.0 entry |

🤖 Generated with [Claude Code](https://claude.com/claude-code)