### PR TITLE
feat(fpl-skills): v1.4.0 — /ddd-decompose + /c4-diagram interactive design skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.15.0"
+    "version": "1.16.0"
   },
   "plugins": [
     {
       "name": "fpl-skills",
       "source": "./plugins/fpl-skills",
       "description": "Flagship workflow plugin for the ForgePlan ecosystem. 17 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /migrate-from-dev-toolkit automation + session helpers) + dev-advisor agent + 4 hooks (safety, test reminder, forge-report auto-trigger). Full feature parity with the legacy dev-toolkit plus 14 additional skills built on forgeplan's artifact lifecycle.",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "author": {
         "name": "ForgePlan"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the ForgePlan Marketplace will be documented in this file
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.0] - 2026-05-08
+
+Two new interactive design skills — top-down complement to the existing brownfield-pack extraction skills (which work bottom-up from code).
+
+### Added
+- `fpl-skills` v1.3.0 → **1.4.0** (minor — two new interactive skills):
+  - **`/ddd-decompose`** (~280 lines) — interview-driven Domain-Driven Design decomposition. Walks through identifying bounded contexts, ubiquitous language per context, aggregates, domain events, integration map. Outputs context map (Markdown + Mermaid) plus, when forgeplan CLI is available, Epic + per-context PRDs + Spec for cross-context contracts. Pairs with `/fpf-decompose` (general decomposition without DDD framing) and the `ddd-domain-expert` agent in `agents-pro` (advisory).
+  - **`/c4-diagram`** (~280 lines) — interactive C4 architecture diagram generator. Walks through L1 Context (system + actors), L2 Container (runtime units inside system), L3 Component (per-container detail, optional), L4 Code (rare). Outputs Mermaid diagrams plus written context per level. Maps cleanly to forgeplan via `c4-to-forge.yaml` from `forgeplan-brownfield-pack` — top-down design vs the brownfield bottom-up ingestion path.
+
+### Changed
+- `plugin.json` (fpl-skills): skills array `18 → 20` entries (+ddd-decompose, +c4-diagram). Description updated. Version 1.3.0 → 1.4.0.
+- `marketplace.json`: catalog version 1.15.0 → **1.16.0**; fpl-skills entry version 1.3.0 → 1.4.0.
+- `docs/USAGE-GUIDE.md` and `-RU.md`: Quick Reference adds `/ddd-decompose` and `/c4-diagram` rows in the fpl-skills section.
+
+### Notes
+The two new skills close a real gap. We had:
+- Bottom-up (brownfield): `forgeplan-brownfield-pack` extraction skills work from existing code → produce DDD/C4-style artifacts
+- Mappings only (forgeplan integration): `c4-to-forge.yaml` and `ddd-to-forge.yaml` ingest existing diagrams/contexts
+- Advisory agent: `ddd-domain-expert` and `architect-reviewer` in `agents-pro`
+
+What was missing — **top-down interactive design**. A new system needs DDD/C4 decomposition through structured questions, not by analysing code that doesn't exist yet. `/ddd-decompose` and `/c4-diagram` fill this. The interview pattern is consistent with `/shape` and `/refine` (one focused question per turn, surface contradictions immediately, cap output to a draft).
+
 ## [1.15.0] - 2026-05-08
 
 Reframed `autoresearch` (the metric-driven loop plugin by Udit Goenka) from "external mention" to **recommended companion** with a proper integration guide. Earlier docs treated it as a distant reference; in reality it composes naturally with `/forge-cycle` and the brownfield extraction skills.

--- a/docs/USAGE-GUIDE-RU.md
+++ b/docs/USAGE-GUIDE-RU.md
@@ -88,6 +88,8 @@ End-to-end развёртка: `forgeplan init`, MCP wiring, CLAUDE.md, docs/age
 | `/briefing` | Обзор трекера — Orchestra/GitHub Issues/Linear/Jira или локальные TODO. |
 | `/research <тема>` | Глубокое многоагентное исследование (5 параллельно: code · docs · status · references · memory) → `research/reports/`. |
 | `/shape <идея>` | Интервью с нуля — превращает сырую идею в черновик PRD через 8-12 направленных вопросов. Передняя сторона жизненного цикла (пишет план ВМЕСТЕ с тобой). |
+| `/ddd-decompose` | Интервью-разложение по Domain-Driven Design — ограниченные контексты, единый язык, агрегаты, доменные события. Выдаёт карту контекстов (Markdown + Mermaid) плюс опционально Epic + PRD по контексту + Spec через forgeplan. |
+| `/c4-diagram` | Интерактивный генератор C4-диаграмм архитектуры — уровни Context, Container, Component на Mermaid. Связывается с forgeplan через c4-to-forge.yaml. |
 | `/refine <план>` | Интервью для уточнения существующего плана — терминология, противоречия, попутные ADR. Шлифует то что уже написано. |
 | `/rfc <action>` | Create/read/update RFC и ADR (каноничная структура, фазы). |
 | `/sprint <фича>` | Wave-based execution со строгим file ownership; auto-detect Tactical/Standard/Deep. |

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -88,6 +88,8 @@ Mirror of root [README.md](../README.md) "Where to Start?" matrix, with cross-li
 | `/briefing` | Tracker overview — Orchestra/GitHub Issues/Linear/Jira or local TODO files. |
 | `/research <topic>` | Deep multi-agent research (5 parallel: code · docs · status · references · memory) → `research/reports/`. |
 | `/shape <idea>` | Interview-from-scratch — turns a fuzzy idea into a draft PRD via 8-12 focused questions. Front-end of the lifecycle (write the plan WITH you). |
+| `/ddd-decompose` | Interview-driven Domain-Driven Design decomposition — bounded contexts, ubiquitous language, aggregates, domain events. Outputs context map (Markdown + Mermaid) plus optional Epic + per-context PRDs + Spec via forgeplan. |
+| `/c4-diagram` | Interactive C4 architecture diagram generator — Context, Container, Component levels with Mermaid. Maps to forgeplan via c4-to-forge.yaml. |
 | `/refine <plan>` | Interview-driven refinement of an existing plan — sharpens terminology, surfaces contradictions, lazy-creates ADRs. Polish what you already wrote. |
 | `/rfc <action>` | Create/read/update RFCs and ADRs (canonical structure, phase progress). |
 | `/sprint <feature>` | Wave-based execution with strict file ownership; auto-detects Tactical/Standard/Deep depth. |

--- a/plugins/fpl-skills/.claude-plugin/plugin.json
+++ b/plugins/fpl-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fpl-skills",
-  "version": "1.3.0",
-  "description": "Flagship workflow plugin for the ForgePlan ecosystem. 18 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, plus session helpers) + dev-advisor agent + 4 hooks (safety, test reminder, forge-report auto-trigger). Every workflow skill is forgeplan-aware. Full feature parity with the legacy dev-toolkit plus 15 additional skills built on forgeplan's artifact lifecycle.",
+  "version": "1.4.0",
+  "description": "Flagship workflow plugin for the ForgePlan ecosystem. 20 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, plus session helpers) + dev-advisor agent + 4 hooks. Every workflow skill is forgeplan-aware. Full feature parity with the legacy dev-toolkit plus 17 additional skills built on forgeplan's artifact lifecycle.",
   "author": {
     "name": "ForgePlan"
   },
@@ -44,6 +44,8 @@
       "bootstrap",
       "briefing",
       "build",
+      "c4-diagram",
+      "ddd-decompose",
       "diagnose",
       "do",
       "forge-report",

--- a/plugins/fpl-skills/skills/c4-diagram/SKILL.md
+++ b/plugins/fpl-skills/skills/c4-diagram/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: c4-diagram
+description: Interactive C4 architecture diagram generator. Walks through the four C4 levels (Context, Container, Component, Code) via guided questions and produces Mermaid diagrams plus a context document. Pairs with /ddd-decompose (which produces a domain context map) — /c4-diagram adds the deployment / runtime structure layer. Maps cleanly to forgeplan via c4-to-forge.yaml in forgeplan-brownfield-pack. Triggers (EN/RU) — "c4 diagram", "architecture diagram", "context container component", "архитектурная диаграмма", "c4 нарисуй", "/c4-diagram".
+disable-model-invocation: true
+allowed-tools: Read Write Edit Bash(test *) Bash(forgeplan *) Bash(command *) Bash(grep *) Bash(ls *) Bash(mkdir *)
+---
+
+# c4-diagram — C4 architecture diagrams via guided interview
+
+Walk through Simon Brown's C4 model — **Context → Container → Component → Code** — by asking the user the right questions at each level and producing Mermaid diagrams plus a written context document. Each diagram is one zoom level of the system, and you stop at the level that adds value (most teams stop at Component; Code level is rarely worth the effort).
+
+This skill **draws the system with you** through structured questions. For one-shot architectural review (no drawing) — use `architect-reviewer` agent in `agents-pro`. For brownfield ingestion of existing C4 docs — use [`c4-to-forge.yaml`](../../../forgeplan-brownfield-pack/mappings/c4-to-forge.yaml) mapping.
+
+---
+
+## When to use
+
+- Onboarding a new system — need diagrams for documentation.
+- Designing a new system and want C4-style framing rather than ad-hoc diagrams.
+- Existing system with no diagrams, planning a refactor — capture the current state first.
+- User explicitly invokes `/c4-diagram` or asks "draw a C4 diagram", "architecture diagram", "архитектурная диаграмма".
+
+## When NOT to use
+
+- One-off architectural decision needing a diagram — embed Mermaid directly in the ADR via `forgeplan new adr`. C4 is overkill.
+- Domain modelling without deployment focus — use [`/ddd-decompose`](../ddd-decompose/SKILL.md) instead. C4 talks about runtime units; DDD talks about domain meanings. Pair them.
+- The system is too small for 4 levels — single service + frontend = Container level is enough; skip Component and Code.
+- Existing C4 docs you want to ingest — use the [`c4-to-forge.yaml`](../../../forgeplan-brownfield-pack/mappings/c4-to-forge.yaml) mapping in `forgeplan-brownfield-pack`.
+
+---
+
+## C4 in 30 seconds
+
+| Level | What it shows | Audience | Example |
+|---|---|---|---|
+| **L1 — Context** | The system as a single box with users + external systems around it | Anyone (CEO, PM, dev) | "Our SaaS, used by Customers, integrates with Stripe and SendGrid" |
+| **L2 — Container** | Deployment / runtime units inside the system | Developers, ops | "Web app (React), API (Go), Postgres, Redis, worker queue" |
+| **L3 — Component** | Components inside one container | Developers of that container | "API has Auth handler, Order handler, Catalog handler, ..." |
+| **L4 — Code** | Class/function structure inside one component | Developers diving into one component | UML / package diagrams (rarely drawn — the IDE shows this) |
+
+**Rule of thumb**: ship Context + Container always. Ship Component when a container has 5+ logical pieces. Ship Code only when explaining a tricky algorithm.
+
+---
+
+## Process
+
+### 1. Orient
+
+```bash
+pwd
+test -d .forgeplan && echo "forgeplan workspace" || echo "no forgeplan"
+command -v forgeplan
+test -d docs/architecture && echo "docs/architecture exists" || mkdir -p docs/architecture/c4
+test -f CLAUDE.md && echo "claude md present"
+```
+
+Outputs go to `docs/architecture/c4/` with one file per level (`c1-context.md`, `c2-containers.md`, `c3-components-<container>.md`). If forgeplan is available, an Epic + per-level PRDs/Notes also get created.
+
+### 2. Establish the system identity
+
+Open with one question:
+
+> "What's the name of the system you want to diagram, and in one sentence — what does it do?"
+
+Use the answer to name files (`my-system-c1-context.md` etc.) and to populate the central box of the L1 diagram.
+
+### 3. Build L1 — Context diagram
+
+Ask, in order:
+
+```
+1. Who are the human user types? List them by role (Customer, Admin, Support agent, Auditor).
+2. What other systems does your system talk to? (Stripe, SendGrid, Salesforce, internal services)
+3. What's the direction of each interaction? (your system calls them, they call you, both)
+4. What's the protocol? (REST, GraphQL, webhook, queue, file drop)
+```
+
+Render:
+
+```mermaid
+flowchart TB
+    Customer["Customer<br/><i>Person</i>"]
+    Admin["Admin<br/><i>Person</i>"]
+
+    System["<b>My SaaS</b><br/><i>Software System</i><br/>Lets customers manage subscriptions and pay"]
+
+    Stripe["Stripe<br/><i>External System</i>"]
+    SendGrid["SendGrid<br/><i>External System</i>"]
+
+    Customer -->|uses| System
+    Admin -->|administers| System
+    System -->|charges| Stripe
+    System -->|sends emails| SendGrid
+    Stripe -->|webhooks| System
+```
+
+Save as `docs/architecture/c4/c1-context.md` with the diagram + a 5-10 line written context describing each box and arrow.
+
+### 4. Build L2 — Container diagram
+
+Ask:
+
+```
+1. What runtime units are inside the system? (frontend, backend services, databases, queues, workers)
+2. For each — what tech / language / framework?
+3. How do they talk to each other? (HTTP, gRPC, queue, shared DB)
+4. What are the operational characteristics? (always-on, batch, scheduled)
+```
+
+Render:
+
+```mermaid
+flowchart LR
+    subgraph "My SaaS"
+        Web["Web App<br/><i>React + TS</i><br/>SPA UI"]
+        API["API<br/><i>Go service</i><br/>HTTP/REST"]
+        Worker["Background Worker<br/><i>Go service</i><br/>Async jobs"]
+        DB[("Postgres<br/><i>Database</i><br/>Transactional data")]
+        Cache[("Redis<br/><i>Cache + Queue</i>")]
+    end
+
+    User["Customer"] -->|HTTPS| Web
+    Web -->|REST| API
+    API -->|SQL| DB
+    API -->|enqueue| Cache
+    Worker -->|dequeue| Cache
+    Worker -->|SQL| DB
+```
+
+Save as `docs/architecture/c4/c2-containers.md` with a written description of each container's responsibility.
+
+### 5. Build L3 — Component diagram (per container, optional)
+
+Ask the user which container they want to zoom into. Then:
+
+```
+1. What logical components live inside <container>?
+2. What does each component own (data, behaviour, integration)?
+3. How do they collaborate? (function call, internal queue, shared state)
+4. Which components talk to other containers / external systems?
+```
+
+Render the L3 for that container only. Save as `docs/architecture/c4/c3-components-<container>.md`.
+
+Repeat for any container the user wants to detail. Most teams stop at the API container; sometimes the Worker too.
+
+### 6. L4 — Code (skip by default)
+
+Ask: "Is there a specific component where the internal class/function structure is tricky enough to draw?"
+
+If yes — produce a UML-style class/function diagram. If no (the typical answer) — note in the Component diagram doc that L4 isn't drawn and the IDE serves as the source of truth.
+
+### 7. Forgeplan integration
+
+If `forgeplan` is on `$PATH`, write the diagrams as forgeplan artifacts using the [`c4-to-forge.yaml`](../../../forgeplan-brownfield-pack/mappings/c4-to-forge.yaml) mapping:
+
+| C4 level | Forgeplan artifact |
+|---|---|
+| L1 — Context | Epic (groups everything) + Note (the L1 doc) |
+| L2 — Container | PRD per container, all linked to the Epic |
+| L3 — Component | RFC per detailed container |
+| L4 — Code | (rare) RFC or Spec |
+
+```bash
+forgeplan new epic "<system> architecture (C4)"
+forgeplan new note "<system> — L1 Context diagram + system landscape"
+forgeplan link NOTE-NNN EPIC-MMM --relation based_on
+
+# Per container
+for c in <list of containers>; do
+  forgeplan new prd "<system> — <container> container"
+  forgeplan link PRD-NNN EPIC-MMM --relation based_on
+done
+
+# For each detailed container (L3)
+for c in <list of detailed>; do
+  forgeplan new rfc "<system> — <container> components"
+  forgeplan link RFC-NNN PRD-CONTAINER --relation based_on
+done
+```
+
+If `forgeplan` is missing — leave the markdown files in `docs/architecture/c4/` as the source.
+
+### 8. Hand-off
+
+```
+✓ L1 Context     docs/architecture/c4/c1-context.md      (or NOTE-NNN if forgeplan)
+✓ L2 Container   docs/architecture/c4/c2-containers.md   (or PRD-NNN per container)
+✓ L3 Component   docs/architecture/c4/c3-components-<X>.md (only for containers you detailed)
+- L4 Code        skipped (typical)
+
+Next steps:
+  • /ddd-decompose to add the domain context map (DDD complements C4)
+  • /refine each PRD to lock terminology and surface contradictions
+  • /forge-cycle "<implement <container>>" to build one container end-to-end
+```
+
+---
+
+## Forgeplan integration
+
+The output diagrams + docs map to forgeplan via [`c4-to-forge.yaml`](../../../forgeplan-brownfield-pack/mappings/c4-to-forge.yaml). Step 7 above wires this automatically when `forgeplan` CLI is available.
+
+For Deep+ scope (irreversible architecture decisions surfaced during the interview):
+
+```bash
+forgeplan new adr "<system> — <key architecture decision>"
+# Body: Context, Decision, Alternatives Considered, Consequences
+forgeplan link ADR-NNN EPIC-<system> --relation informs
+forgeplan reason ADR-NNN          # ADI 3+ hypotheses on the architecture choice
+```
+
+### Want this orchestrated for you?
+
+`/forge-cycle "design <system> architecture"` (in [`forgeplan-workflow`](../../../forgeplan-workflow/README.md)) can run the full lifecycle. The C4 diagrams produced by this skill become the Shape-phase content; Build phase implements one container at a time.
+
+---
+
+## Companion skills
+
+- [`/ddd-decompose`](../ddd-decompose/SKILL.md) — domain-side decomposition. Run before `/c4-diagram` if domain meanings drive the container split. Run after if container split was driven by deployment/operational concerns.
+- [`/refine`](../refine/SKILL.md) — refine an existing C4 doc, surface contradictions.
+- `architect-reviewer` agent (in `agents-pro`) — advisory review of an existing C4 set without drawing.
+- [`c4-to-forge.yaml`](../../../forgeplan-brownfield-pack/mappings/c4-to-forge.yaml) — ingestion mapping for existing C4 docs (brownfield).
+
+---
+
+## Anti-patterns
+
+- ❌ **Drawing all 4 levels for a small system.** Code level is rarely worth it; Component only when a container has 5+ pieces.
+- ❌ **Mixing levels in one diagram.** L1 should NOT show containers. L2 should NOT show external systems' internals.
+- ❌ **Using boxes inside boxes for hierarchy on L2.** That's L3 territory. Stay flat per level.
+- ❌ **Asking the user "what's a Container in C4?".** Explain by example: "Frontend SPA, API, database — those are containers."
+- ❌ **Naming conventions inconsistent across diagrams.** `Auth Service` in L1 should be `Auth Service` in L2 too, not `auth-svc`.
+- ❌ **Skipping the description text.** A Mermaid diagram alone isn't enough; the 5-10 lines describing each box and arrow add the meaning the diagram can't carry.
+
+---
+
+## Mermaid notation conventions
+
+- Person: `["Name<br/><i>Person</i>"]`
+- Software system: `["Name<br/><i>Software System</i><br/>One-line description"]`
+- External system: `["Name<br/><i>External System</i>"]`
+- Container: `["Name<br/><i>Tech / framework</i><br/>One-line responsibility"]`
+- Database: `[("Name<br/><i>Database</i>")]`
+- Queue/Cache: `[("Name<br/><i>Queue / Cache</i>")]`
+
+Arrows labelled with **action + protocol**: `-->|sends emails via SMTP|`, `-->|HTTPS REST|`, `-->|enqueue job|`.
+
+---
+
+## Companion mapping
+
+If you have **existing C4 documentation** (Markdown, Structurizr DSL output) and want to ingest into forgeplan rather than redraw — use [`c4-to-forge.yaml`](../../../forgeplan-brownfield-pack/mappings/c4-to-forge.yaml) from `forgeplan-brownfield-pack`. That's the bottom-up path; `/c4-diagram` is the top-down (interview) path. Different starting points, same artifact graph at the end.

--- a/plugins/fpl-skills/skills/ddd-decompose/SKILL.md
+++ b/plugins/fpl-skills/skills/ddd-decompose/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: ddd-decompose
+description: Interview-driven Domain-Driven Design decomposition skill. Walks through identifying bounded contexts, aggregates, ubiquitous language, and domain events for a system or new feature. Outputs a DDD context map (Markdown + Mermaid) plus optional forgeplan artifacts (Epic + per-context PRDs + Spec). Pairs with /fpf-decompose (general decomposition) — use /ddd-decompose when DDD framing matters (multi-team boundaries, complex business domains). Triggers (EN/RU) — "ddd decompose", "bounded contexts", "ubiquitous language", "domain model", "разложи по DDD", "ограниченные контексты", "доменная модель", "/ddd-decompose".
+disable-model-invocation: true
+allowed-tools: Read Write Edit Bash(test *) Bash(forgeplan *) Bash(command *) Bash(grep *) Bash(ls *) Bash(mkdir *)
+---
+
+# ddd-decompose — Domain-Driven Design via guided interview
+
+Walk a developer through DDD decomposition: bounded contexts → ubiquitous language per context → aggregates → domain events → context map. Outputs Markdown + Mermaid. If `forgeplan` CLI is available, also writes Epic + per-context PRDs + Spec to wire the decomposition into the artifact graph.
+
+This skill is the **interactive companion** to the `ddd-domain-expert` agent in `agents-pro`. The agent gives advisory analysis on existing code; this skill **builds the model with you** through structured questions.
+
+---
+
+## When to use
+
+- Designing a new system with multiple teams or services involved.
+- Refactoring a monolith and need to decide where the seams should be.
+- Onboarding a brownfield codebase and want a DDD-style mental map.
+- User explicitly invokes `/ddd-decompose` or asks "decompose this with DDD", "разложи по DDD", "ограниченные контексты".
+
+## When NOT to use
+
+- General system decomposition without DDD framing — use [`/fpf-decompose`](../../../fpf/skills/fpf-knowledge/SKILL.md) (broader, less ceremony).
+- A single-team CRUD app — DDD ceremony is overkill; just write a PRD.
+- Brownfield code where DDD is the goal — pair with [`forgeplan-brownfield-pack`](../../../forgeplan-brownfield-pack/skills/ubiquitous-language/SKILL.md) extraction skills which work bottom-up from code.
+- Pure architecture diagrams without domain modelling — use [`/c4-diagram`](../c4-diagram/SKILL.md).
+
+---
+
+## Process
+
+### 1. Orient
+
+```bash
+pwd
+test -d .forgeplan && echo "forgeplan workspace" || echo "no forgeplan"
+command -v forgeplan
+test -f CLAUDE.md && echo "claude md present"
+test -d docs/architecture && echo "docs/architecture exists" || echo "no docs/architecture"
+```
+
+If `forgeplan` is available — outputs go into the artifact graph. Otherwise — Markdown files under `docs/architecture/ddd/`.
+
+### 2. Establish the system context
+
+Open with one question:
+
+> "What's the system we're decomposing? In one sentence — what does it do, and who uses it?"
+
+Reflect the answer back, then derive **system actors** (humans and other systems that interact with it). This becomes the outer boundary of the context map.
+
+### 3. Identify bounded contexts
+
+Ask, one context at a time:
+
+```
+1. What's a major area of behaviour or business capability inside the system?
+2. What language do people use to talk about it? (specific terms, not abstractions)
+3. Who owns it? (team, person, "shared" if no clear owner)
+4. What does it explicitly NOT handle? (boundary by negation)
+5. What does it depend on, what depends on it?
+```
+
+Stop adding contexts when the user can't think of new ones or when the existing list covers the system. Typical: 3-7 contexts. Fewer = monolith with no real seams. More = over-decomposition or true platform-scale.
+
+For each context, capture:
+
+| Field | Example |
+|---|---|
+| Name | `Catalog`, `Cart`, `Checkout`, `Fulfillment`, `Identity` |
+| Responsibility | `Product data, search, categories` |
+| Owners | `Product team` |
+| Outbound | `→ Cart (product lookup), → Search Engine` |
+| Inbound | `← Fulfillment (stock updates)` |
+| NOT in scope | `Pricing decisions (those live in Cart)` |
+
+### 4. Build the ubiquitous language per context
+
+For each context, ask:
+
+> "List the 3-5 terms you'd use to describe what happens in <context>. Define them in your own words. Are any of them used differently in another context?"
+
+The last question is the **synonym/translator** signal. If `Order` means one thing in Cart and another in Fulfillment — that's a translator boundary. Capture both definitions, mark as a translation.
+
+Output per context:
+
+```markdown
+## Context: Catalog
+
+**Ubiquitous language**:
+- **Product** — a SKU offered for sale. Has price, description, category. _Note: distinct from `LineItem` in Cart, which adds quantity and discount._
+- **Category** — taxonomic grouping for browsing.
+- **Variant** — color/size/etc. of the same Product.
+
+**Cross-context translations**:
+| Term | Outside meaning | Inside meaning |
+|---|---|---|
+| Order | (Cart context) | reservation slip |
+```
+
+### 5. Find the aggregates inside each context
+
+Ask:
+
+> "Inside <context>, what's the **smallest thing** you need to keep consistent in a single transaction? Name it as a noun."
+
+Aggregates are the consistency boundary. Examples: `Order` (with its line items), `Account` (with balance + transactions), `Subscription` (with plan + billing cycle).
+
+For each aggregate:
+
+| Field | Example |
+|---|---|
+| Aggregate root | `Order` |
+| Internal entities | `LineItem`, `ShippingAddress`, `Discount` |
+| Invariants | "total = sum(line_items.price * qty) - discount", "status transitions: created → paid → shipped → delivered" |
+| Events emitted | `OrderCreated`, `OrderPaid`, `OrderShipped` |
+
+### 6. Map domain events between contexts
+
+Ask:
+
+> "When <event in context A> happens, what should other contexts know? What's the cleanest way for them to find out — direct call, queue, eventual consistency?"
+
+This builds the **integration map**:
+
+```
+Cart  ─── CartCheckedOut ──→ Checkout  (sync, REST)
+Checkout ── OrderPlaced ──→ Fulfillment, Notifications  (async, queue)
+Fulfillment ── ShipmentDispatched ──→ Notifications  (async, queue)
+```
+
+### 7. Render the context map
+
+Generate a Mermaid C4-Container-style diagram:
+
+```mermaid
+flowchart LR
+    subgraph "Catalog (Product team)"
+        Catalog[(Product / Category / Variant)]
+    end
+    subgraph "Cart (Commerce team)"
+        Cart[(LineItem / Discount)]
+    end
+    subgraph "Checkout (Commerce team)"
+        Checkout[(Order / Payment)]
+    end
+    subgraph "Fulfillment (Ops team)"
+        Fulfillment[(Shipment / Delivery)]
+    end
+
+    Cart -->|product lookup| Catalog
+    Cart -->|CartCheckedOut, sync REST| Checkout
+    Checkout -->|OrderPlaced, async queue| Fulfillment
+```
+
+Save to `docs/architecture/ddd/context-map.md` (or include in the forgeplan artifact below).
+
+### 8. Forgeplan integration (if CLI available)
+
+If `forgeplan` is on `$PATH`:
+
+```bash
+# Top-level Epic groups all contexts
+forgeplan new epic "<system name> domain decomposition"
+# One PRD per bounded context
+for ctx in <list of contexts>; do
+  forgeplan new prd "<system> — <ctx> bounded context"
+  # Body: filled from interview answers in step 3-5
+  forgeplan link PRD-<ctx> EPIC-<system> --relation based_on
+done
+# Specs for cross-context contracts
+forgeplan new spec "<system> — domain events catalogue"
+forgeplan link SPEC-<events> EPIC-<system> --relation implements
+```
+
+If `forgeplan` is missing — just write the Markdown files under `docs/architecture/ddd/`.
+
+### 9. Hand-off
+
+Show the user where artefacts went and what's next:
+
+```
+✓ Context map     docs/architecture/ddd/context-map.md (or EPIC-NNN if forgeplan)
+✓ Per-context     docs/architecture/ddd/<context>.md   (or PRD-NNN per context)
+✓ Domain events   docs/architecture/ddd/events.md      (or SPEC-NNN)
+
+Next steps:
+  • /refine each PRD to surface contradictions and lock terminology
+  • /c4-diagram to add Container/Component diagrams complementing the DDD map
+  • /forge-cycle "<implement first context>" to start building one context end-to-end
+```
+
+---
+
+## Forgeplan integration
+
+If the `forgeplan` CLI is on `$PATH`, the decomposition produces Epic + PRDs + Spec naturally (step 8). For Deep+ depth (cross-team, multi-context system):
+
+```bash
+forgeplan reason EPIC-NNN          # ADI 3+ hypotheses on the boundary choices
+forgeplan validate EPIC-NNN        # confirm MUST sections present
+```
+
+DDR-style ADR for the **why** behind specific boundary decisions:
+
+```bash
+forgeplan new adr "<system> — bounded context boundaries: <key decision>"
+# Body: Context (why this came up), Decision, Alternatives Considered, Consequences, Invariants
+forgeplan link ADR-NNN EPIC-NNN --relation informs
+```
+
+### Want this orchestrated for you?
+
+`/forge-cycle "decompose <system>"` (in [`forgeplan-workflow`](../../../forgeplan-workflow/README.md)) can run the full lifecycle around a DDD decomposition — `/ddd-decompose` becomes the Shape phase content for an Epic.
+
+---
+
+## Companion skills
+
+- [`/c4-diagram`](../c4-diagram/SKILL.md) — Context/Container/Component diagrams as a complement to the DDD map. Use after DDD decomposition to add deployment-level structure.
+- [`/fpf-decompose`](../../../fpf/skills/fpf-knowledge/SKILL.md) — general FPF decomposition without DDD-specific framing. Use when DDD vocabulary doesn't fit (e.g. internal tooling, single-team app).
+- [`/refine`](../refine/SKILL.md) — interview-style refinement of an existing decomposition. Use after `/ddd-decompose` to lock terminology.
+- Brownfield extraction skills ([`ubiquitous-language`](../../../forgeplan-brownfield-pack/skills/ubiquitous-language/SKILL.md), `intent-inferrer`, `causal-linker`) — bottom-up from existing code instead of top-down interview.
+
+`ddd-domain-expert` agent (in `agents-pro`) — for advisory review of an existing DDD decomposition, or for domain-modelling questions where you want a senior advisor's input.
+
+---
+
+## Anti-patterns
+
+- ❌ **Decomposing into 10+ contexts on first pass.** Over-decomposition is harder to walk back than under-decomposition. Start with 3-5; add more only when the existing ones genuinely don't cover something.
+- ❌ **One context per database table.** Tables ≠ aggregates ≠ contexts. A context can have many tables; a table can serve many contexts.
+- ❌ **Skipping the ubiquitous language step.** Without language, the boundaries drift. The whole point of DDD is the shared vocabulary.
+- ❌ **Asking "what's a bounded context?" theoretically.** Stay concrete: ask about the system the user is decomposing, not the methodology.
+- ❌ **Drawing the context map before identifying the contexts.** Diagram last, after step 6 (events). Otherwise you'll redraw it three times.
+- ❌ **Ignoring synonyms.** `Order` in Cart vs Checkout is a translator, not a sloppy naming. Capture it.
+
+---
+
+## Examples
+
+See [`forgeplan-brownfield-pack/examples/`](../../../forgeplan-brownfield-pack/examples/) for sample DDD decompositions extracted from the TripSales project (`tripsales-glossary-sample.md`, `tripsales-use-case-sample.md`). Those came bottom-up via brownfield extraction; `/ddd-decompose` produces the same artifact shapes top-down via interview.


### PR DESCRIPTION
## Summary

Two new interview-driven design skills closing the **top-down design gap**. We had brownfield extraction (bottom-up from code) and mappings (ingest existing diagrams) but no interactive way to **build** DDD models or C4 diagrams through structured questions.

`fpl-skills` v1.3.0 → **v1.4.0** (minor — two new skills). Marketplace catalog **1.15.0 → 1.16.0**.

## What's new

### `/ddd-decompose` (~280 lines)

Domain-Driven Design via guided interview. Walks through:

1. **System context** — what does the system do, who uses it
2. **Bounded contexts** — major behaviour areas, with owners + boundaries by negation (typical: 3-7 contexts)
3. **Ubiquitous language** per context — terms + cross-context translators (where same word means different things)
4. **Aggregates** — smallest consistency boundary per context (with invariants + emitted events)
5. **Domain events** — async vs sync interactions between contexts
6. **Context map** — Mermaid rendering
7. **Forgeplan integration** — Epic groups everything, PRD per context, Spec for events catalogue

Pairs with:
- `/fpf-decompose` (general decomposition without DDD framing)
- `ddd-domain-expert` agent in `agents-pro` (advisory, not interactive)
- Brownfield extraction skills (`ubiquitous-language`, `intent-inferrer`) — bottom-up from existing code

### `/c4-diagram` (~280 lines)

C4 architecture diagrams (Simon Brown's model) via guided interview. Per-level question script:

- **L1 Context** — system as a single box, with humans and external systems around it
- **L2 Container** — runtime units inside the system (frontend, services, DB, queue, worker)
- **L3 Component** — per-container detail (run only for containers with 5+ pieces)
- **L4 Code** — rare; UML for tricky algorithms only

Outputs Mermaid diagrams + written context per level. Maps to forgeplan via [`c4-to-forge.yaml`](../plugins/forgeplan-brownfield-pack/mappings/c4-to-forge.yaml) — top-down design vs the bottom-up ingestion path that mapping enables.

Mermaid notation conventions documented in the skill: Person, Software System, External System, Container, Database, Queue/Cache — all with consistent badge styling.

## Why this matters

Existing tools covered:
- **Bottom-up** (brownfield): extraction skills work from code → produce DDD/C4-style artifacts ✅
- **Mappings**: `c4-to-forge.yaml` and `ddd-to-forge.yaml` ingest existing diagrams ✅
- **Advisory**: `ddd-domain-expert` and `architect-reviewer` in `agents-pro` ✅
- **Top-down interactive design**: ❌ ← this PR fills it

For new systems, you decompose through structured questions, not by analysing code that doesn't exist yet. The interview pattern (one focused question per turn, surface contradictions immediately, cap output to a draft) matches `/shape` and `/refine` — same discipline applied at design time.

## Verification

- [x] `./scripts/validate-all-plugins.sh fpl-skills` → ALL PASSED
- [x] Both SKILL.md files have valid Claude Code frontmatter (`name`, `description`, `disable-model-invocation`, `allowed-tools`)
- [x] `plugin.json` skills array reflects the 20 skills (was 18)
- [x] No command collisions (skills only)
- [x] Cross-references to fpf, brownfield-pack, agents-pro all resolve
- [ ] CI `validate` passes on PR open

## Files

| Status | File | Lines |
|---|---|---|
| NEW | `plugins/fpl-skills/skills/ddd-decompose/SKILL.md` | ~280 |
| NEW | `plugins/fpl-skills/skills/c4-diagram/SKILL.md` | ~280 |
| MODIFIED | `plugins/fpl-skills/.claude-plugin/plugin.json` | skill array + version + description |
| MODIFIED | `.claude-plugin/marketplace.json` | catalog + entry version |
| MODIFIED | `docs/USAGE-GUIDE.md` + `-RU.md` | Quick Reference rows |
| MODIFIED | `CHANGELOG.md` | 1.16.0 entry |

🤖 Generated with [Claude Code](https://claude.com/claude-code)