### PR TITLE
fix(fpl-skills): v1.5.1 — /do and /autorun explicitly create forgeplan artifacts inline

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.17.0"
+    "version": "1.17.1"
   },
   "plugins": [
     {
       "name": "fpl-skills",
       "source": "./plugins/fpl-skills",
       "description": "Flagship workflow plugin for the ForgePlan ecosystem. 21 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, /riper RIPER orchestrator, plus session helpers) + dev-advisor agent + 4 hooks. Every workflow skill is forgeplan-aware. Full feature parity with the legacy dev-toolkit plus 18 additional skills built on forgeplan's artifact lifecycle.",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "author": {
         "name": "ForgePlan"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to the ForgePlan Marketplace will be documented in this file
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.1] - 2026-05-08
+
+Fixes a real-world report from a developer using the marketplace: `/do` "refused to create artifacts for a big task". Investigation showed the gap was in skill prose — Pipeline Templates listed only the skill chain (research → sprint → audit) without the **forgeplan artifact lifecycle steps**. The "Forgeplan integration" section at the bottom of each skill described the right behaviour, but it was easy to miss.
+
+This patch makes artifact creation **inline and explicit** in the templates themselves.
+
+### Changed
+- `fpl-skills` v1.5.0 → **1.5.1** (patch — bug fix in skill prose):
+  - **`/do`** Pipeline Templates rewritten:
+    - Top of Workflow now has an `[!IMPORTANT]` block stating: "Forgeplan artifact lifecycle is part of `/do`'s job. If forgeplan CLI is present, this skill creates artifacts at each phase and announces each creation explicitly."
+    - **Template C (feature implementation)** — added Step 0 (Forgeplan probe), Step 2 (Shape — `forgeplan new prd` + validate + reason), Step 7 (Evidence with structured fields), Step 8 (Activate). Before: 7 steps, no forgeplan calls. After: 11 steps with explicit artifact lifecycle.
+    - **Template D (audit)** — added Step 0 (probe + resolve linked PRD/ADR), Step 4 (Evidence with verdict + CL3 + evidence_type=code_review).
+    - **Template E (bug investigation)** — added Step 0 (probe), Step 2 (Problem card), Step 6 (Evidence + close Problem).
+  - **`/autorun`** Workflow section rewritten:
+    - Top has matching `[!IMPORTANT]` block.
+    - "Run the pipeline" subsection (Step 3) now shows the **8-step pipeline with forgeplan calls** at each stage (Probe → Health → Route → Shape → Build → Audit → Evidence → Activate → Report) instead of the prior 3-bullet skill chain.
+    - For research-only / review-only / status tasks: explicit fallback (drop steps 3-7, optionally still create a Note).
+
+### Notes
+**This is a documentation/prose fix, not a code change.** Skills are markdown — what they "do" is what their SKILL.md describes. The previous prose described the right behaviour in a footer; agents reading the skill might apply it or skip it depending on attention. Putting the artifact steps inline in the pipeline templates makes them load-bearing.
+
+The developer's expectation ("`/do` should do everything itself") is now matched: when forgeplan CLI is available, `/do` creates PRDs, evidence, and activates artifacts at the right phases. If the CLI is absent, a clear warning is logged at the start.
+
 ## [1.17.0] - 2026-05-08
 
 Final piece of the methodology coverage trio: `/riper` orchestrator + AI-SDLC mapping doc + upstream methodologies bibliography.

--- a/docs/DEVELOPER-JOURNEY-RU.md
+++ b/docs/DEVELOPER-JOURNEY-RU.md
@@ -323,14 +323,18 @@ Step 8: Activate        → `forgeplan activate` когда R_eff > 0
                         → готовит conventional commit с `Refs: PRD-NNN`
 ```
 
-### Когда `/forge-cycle` vs `/sprint` vs `/autorun`
+### Когда `/forge-cycle` vs `/sprint` vs `/autorun` vs `/do`
 
-| Команда | Плагин | Лучше всего для |
-|---|---|---|
-| `/forge-cycle` | forgeplan-workflow | «Прогони методологию end-to-end по одной задаче» — единый entry point, полный lifecycle. |
-| `/sprint` | fpl-skills | Wave-based execution с file ownership и per-wave teammates. Используй когда уже сам route/shape сделал. |
-| `/autorun` | fpl-skills | Ночной / unattended. Auto-делегирует в `/forge-cycle` если установлен `forgeplan-workflow`; иначе работает standalone. |
-| `/do` | fpl-skills | Интерактивный вариант `/autorun` — пауза на границах фаз для review. |
+Все четыре оркестрируют один и тот же lifecycle артефактов forgeplan (PRD → сборка → Evidence → активация). Разница — в **терминологии**, **интерактивности** и **требованиях к плагинам**:
+
+| Команда | Плагин | Паузы? | Создаёт артефакты? | Лучше всего для |
+|---|---|---|---|---|
+| `/forge-cycle` | forgeplan-workflow | На каждом шаге | ✅ Да | «Прогони методологию end-to-end» — единый entry point, полный lifecycle, родная терминология фаз |
+| `/autorun` | fpl-skills | Нет (автопилот) | ✅ Да (встроенные вызовы forgeplan если CLI есть, или делегирует в `/forge-cycle` если установлен `forgeplan-workflow`) | Ночной / unattended прогон |
+| `/do` | fpl-skills | На каждой фазе | ✅ Да (тот же lifecycle что и `/autorun`, с явными объявлениями каждого артефакта) | Когда хочется отревьюить каждую фазу до её исполнения; тот же lifecycle что у `/autorun` но интерактивно |
+| `/sprint` | fpl-skills | На утверждении плана | 🟡 Только если сам вызовешь `forgeplan new prd` до / `forgeplan new evidence` после | Wave-based execution когда route/shape уже сделал вручную |
+
+**Замечание**: `/autorun` и `/do` обновлены в v1.5.1 — создание артефактов теперь **явное и встроенное** в их pipeline-шаблоны (раньше было легко пропустить). Если обновлялся со старой версии — переустанови: `/plugin install fpl-skills@ForgePlan-marketplace`.
 
 ### Setup checklist для `/forge-cycle`
 

--- a/docs/DEVELOPER-JOURNEY.md
+++ b/docs/DEVELOPER-JOURNEY.md
@@ -323,14 +323,18 @@ Step 8: Activate        → `forgeplan activate` once R_eff > 0
                         → prepares the conventional commit with `Refs: PRD-NNN`
 ```
 
-### When to use `/forge-cycle` vs `/sprint` vs `/autorun`
+### When to use `/forge-cycle` vs `/sprint` vs `/autorun` vs `/do`
 
-| Command | Plugin | Best for |
-|---|---|---|
-| `/forge-cycle` | forgeplan-workflow | "Run the methodology end-to-end on this one task" — single entry point, full lifecycle. |
-| `/sprint` | fpl-skills | Wave-based execution with file ownership and per-wave teammates. Use when you've already routed/shaped manually. |
-| `/autorun` | fpl-skills | Overnight / unattended. Auto-delegates to `/forge-cycle` if `forgeplan-workflow` is installed; otherwise runs standalone. |
-| `/do` | fpl-skills | Interactive variant of `/autorun` — pauses at phase boundaries for review. |
+All four orchestrate the same forgeplan artifact lifecycle (PRD → build → Evidence → activate). They differ in **vocabulary**, **interactivity**, and **plugin requirements**:
+
+| Command | Plugin | Pauses? | Creates artifacts? | Best for |
+|---|---|---|---|---|
+| `/forge-cycle` | forgeplan-workflow | At each step | ✅ Yes | "Run the methodology end-to-end on this one task" — single entry point, full lifecycle, native phase names |
+| `/autorun` | fpl-skills | No (autopilot) | ✅ Yes (inline forgeplan calls if CLI present, or delegates to `/forge-cycle` if `forgeplan-workflow` installed) | Overnight / unattended runs |
+| `/do` | fpl-skills | At each phase | ✅ Yes (same artifact lifecycle as `/autorun`, with explicit announcements per artifact) | Reviewing each phase before it runs; same lifecycle as `/autorun` but interactive |
+| `/sprint` | fpl-skills | At plan approval | 🟡 Only if you call `forgeplan new prd` yourself before / `forgeplan new evidence` after | Wave-based execution when you've already routed/shaped manually |
+
+**Note**: `/autorun` and `/do` were updated in v1.5.1 to make artifact creation **inline and explicit** in their pipeline templates (was easy to miss before). If you upgraded from an older version, re-install: `/plugin install fpl-skills@ForgePlan-marketplace`.
 
 ### Setup checklist for `/forge-cycle`
 

--- a/docs/PLAYBOOK-RU.md
+++ b/docs/PLAYBOOK-RU.md
@@ -120,6 +120,12 @@ brew install ForgePlan/tap/forgeplan
 
 Красные линии (push в main, запись секретов, развёртывание в продакшен) **останавливают автопилот** и просят явное одобрение.
 
+**Без `forgeplan-workflow` (только CLI `forgeplan`)**:
+
+`/autorun` (и `/do`) всё равно создают артефакт-lifecycle inline — вызывают `forgeplan health` / `forgeplan route` / `forgeplan new prd` / `forgeplan new evidence` / `forgeplan activate` между фазами стандартного конвейера (research → sprint → audit). Те же артефакты, меньше предварительной оркестрации. **Не считай что `/do` или `/autorun` пропускают создание артефактов при отсутствии `forgeplan-workflow`** — нет, начиная с v1.5.1 не пропускают.
+
+Если CLI `forgeplan` тоже отсутствует — оба скилла предупреждают в начале («нет forgeplan-интеграции; конвейер без lifecycle артефактов») и работают только как цепочка скиллов.
+
 ---
 
 ## Сценарий 4 — Унаследованный проект (brownfield)

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -99,7 +99,7 @@ After `/shape`:
 /autorun "implement <task>"
 ```
 
-**What happens under the hood**:
+**What happens under the hood (with `forgeplan-workflow` installed — recommended)**:
 ```
 /autorun
   ├── detects forgeplan-workflow installed
@@ -119,6 +119,12 @@ After `/shape`:
 ```
 
 Red lines (push to main, secrets writes, deploys) **stop autopilot** and ask for explicit approval.
+
+**Without `forgeplan-workflow` (only `forgeplan` CLI installed)**:
+
+`/autorun` (and `/do`) still create the artifact lifecycle inline — they call `forgeplan health` / `forgeplan route` / `forgeplan new prd` / `forgeplan new evidence` / `forgeplan activate` between phases of the standard pipeline (research → sprint → audit). Same artifacts, fewer pre-orchestration features. **Do NOT assume `/do` or `/autorun` skips artifact creation when `forgeplan-workflow` isn't installed** — they don't, since v1.5.1.
+
+If `forgeplan` CLI is also absent — both skills warn at the start ("no forgeplan integration; pipeline runs without artifact lifecycle") and run the skill chain only.
 
 ---
 

--- a/docs/USAGE-GUIDE-RU.md
+++ b/docs/USAGE-GUIDE-RU.md
@@ -96,8 +96,8 @@ End-to-end развёртка: `forgeplan init`, MCP wiring, CLAUDE.md, docs/age
 | `/sprint <фича>` | Wave-based execution со строгим file ownership; auto-detect Tactical/Standard/Deep. |
 | `/audit` | Multi-expert ревью (≥4 ревьюера — logic, architecture, types, security; +ux-reviewer если установлен). |
 | `/diagnose <баг>` | Дисциплинированный 6-фазный debug loop. Фаза 1 («построй feedback loop») — это весь скилл. |
-| `/autorun <задача>` | Автопилот-оркестратор — research → sprint → audit → report end-to-end, без пауз на approval. |
-| `/do <задача>` | Интерактивная версия `/autorun` (пауза на каждом шаге). |
+| `/autorun <задача>` | Автопилот-оркестратор — полный конвейер end-to-end с **lifecycle артефактов forgeplan**: probe → health → route → shape (PRD, RFC, ADR для Deep) → build (research → sprint → audit) → evidence → activate. Без пауз. Если установлен `forgeplan-workflow` — делегирует в `/forge-cycle`; если CLI `forgeplan` отсутствует — работает без артефактов и предупреждает в начале. |
+| `/do <задача>` | Интерактивная версия `/autorun` — тот же lifecycle артефактов (PRD, Evidence, Activate по фазам), но **пауза на approval перед каждой фазой**. Явно объявляет каждое создание артефакта. Использовать когда хочется ревьюить каждый артефакт-шаг до его выполнения. |
 | `/build` | Исполнение готового IMPLEMENTATION-PLAN.md из research-отчёта (wave-by-wave). |
 | `/setup` | Интерактивный wizard — пишет `docs/agents/{issue-tracker,build-config,paths,domain}.md`. |
 | `/bootstrap` | Универсальный CLAUDE.md template (stack-detected) в текущий проект. |

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -96,8 +96,8 @@ Mirror of root [README.md](../README.md) "Where to Start?" matrix, with cross-li
 | `/sprint <feature>` | Wave-based execution with strict file ownership; auto-detects Tactical/Standard/Deep depth. |
 | `/audit` | Multi-expert review (≥4 reviewers — logic, architecture, types, security; +ux-reviewer if installed). |
 | `/diagnose <bug>` | 6-phase disciplined debug loop. Phase 1 ("build a feedback loop") is the entire skill. |
-| `/autorun <task>` | Autopilot orchestrator — research → sprint → audit → report end-to-end, no approval pauses. |
-| `/do <task>` | Interactive variant of `/autorun` (pauses for approval at each step). |
+| `/autorun <task>` | Autopilot orchestrator — full pipeline end-to-end with **forgeplan artifact lifecycle**: probe → health → route → shape (PRD, RFC, ADR if Deep) → build (research → sprint → audit) → evidence → activate. No approval pauses. If `forgeplan-workflow` installed, delegates to `/forge-cycle`; if `forgeplan` CLI is absent, runs without artifacts and warns at start. |
+| `/do <task>` | Interactive variant of `/autorun` — same artifact lifecycle (PRD, Evidence, Activate per phase) but **pauses for approval at each phase**. Announces each artifact creation explicitly. Use when you want to review each artifact step before it happens. |
 | `/build` | Execute an existing IMPLEMENTATION-PLAN.md from a research report (wave-by-wave). |
 | `/setup` | Interactive wizard — writes `docs/agents/{issue-tracker,build-config,paths,domain}.md`. |
 | `/bootstrap` | Drops the universal CLAUDE.md template (stack-detected) into the current project. |

--- a/plugins/fpl-skills/.claude-plugin/plugin.json
+++ b/plugins/fpl-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fpl-skills",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Flagship workflow plugin for the ForgePlan ecosystem. 21 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, /riper RIPER orchestrator, plus session helpers) + dev-advisor agent + 4 hooks. Every workflow skill is forgeplan-aware. Full feature parity with the legacy dev-toolkit plus 18 additional skills built on forgeplan's artifact lifecycle.",
   "author": {
     "name": "ForgePlan"

--- a/plugins/fpl-skills/skills/autorun/SKILL.md
+++ b/plugins/fpl-skills/skills/autorun/SKILL.md
@@ -64,18 +64,65 @@ Decisions:
 
 ## Workflow
 
+> [!IMPORTANT]
+> **Forgeplan artifact lifecycle is part of `/autorun`'s job.** If `forgeplan` CLI is on `$PATH`, this skill **creates artifacts at each phase** of the pipeline (PRD before build, Evidence after audit, activate at the end). If `forgeplan-workflow` is also installed, the whole pipeline delegates to `/forge-cycle` (functionally equivalent, with native phase names). If `forgeplan` is absent, artifact creation is skipped and a single warning is logged in the final report ("ran without artifact lifecycle").
+>
+> **Don't assume `/autorun` silently skips artifact creation.** It doesn't. The pipeline below shows where each forgeplan call lands.
+
 ### 1. Read context
 `@docs/agents/*.md` are auto-loaded by frontmatter imports. Check `CONTEXT.md` and recent `git log` for any in-flight intent.
 
 ### 2. Classify the task
 Same categories as [`do`](../do/SKILL.md): research / docs / feature / review / bug / refactor / status. Pick template silently — do NOT show plan to user, do NOT ask for approval.
 
-### 3. Run the pipeline
-Delegate to the right skill(s). Pass the **autopilot directive** (see below) in every spawn prompt so the called skill skips its own approval steps.
+### 3. Run the pipeline (artifact-aware by default)
 
-If the task is a feature/refactor: `research` → `sprint` (with `team`) → `audit` → report.
-If the task is research only: `research` → report.
-If the task is review only: `audit` → report.
+For **feature** / **refactor** / **bug** tasks (the most common autorun cases), the full pipeline with forgeplan integration:
+
+```
+0. Probe       command -v forgeplan; ls forgeplan-workflow plugin
+               If forgeplan-workflow installed: delegate whole flow to /forge-cycle
+               If forgeplan CLI only: continue with inline calls below
+               If neither: log warning, continue without artifact lifecycle
+
+1. Health      forgeplan health    (surface blind spots before starting)
+
+2. Route       forgeplan route "<task>"   (decide depth: Tactical/Standard/Deep)
+
+3. Shape       For Standard+:
+                 forgeplan new prd "<title>"
+                 fill MUST sections from research output
+                 forgeplan validate PRD-NNN
+               For Deep:
+                 forgeplan reason PRD-NNN          (3+ ADI hypotheses, mandatory)
+                 forgeplan new rfc "<approach>"    (link based_on PRD-NNN)
+                 forgeplan new adr "<key decision>" (if architectural)
+
+4. Build       /research → /sprint with /team → ADI on blockers
+               (skill chain as before)
+
+5. Audit       /audit (4-6 reviewers in parallel)
+
+6. Evidence    forgeplan new evidence "<task>: tests pass / smoke OK"
+               Set Structured Fields:
+                 verdict: supports
+                 congruence_level: 3
+                 evidence_type: test_result OR code_review
+               forgeplan link EVID-MMM PRD-NNN --relation informs
+               forgeplan score PRD-NNN          (R_eff > 0?)
+
+7. Activate    forgeplan activate PRD-NNN       (only if R_eff > 0; else stop with reason)
+
+8. Report      Use `forge-report` skill if available; otherwise inline template
+```
+
+For **research only** / **review only** / **status** tasks — drop steps 3-7 (no implementation, no PRD needed). Optionally still create a Note for research findings:
+
+```
+forgeplan new note "<takeaway from research/audit>"
+```
+
+If `forgeplan-workflow` plugin is installed, **steps 0-3 and 6-8 are handled by `/forge-cycle`** automatically — `/autorun` calls `/forge-cycle "<task>"` once, lets it orchestrate the artifact lifecycle, and treats steps 4-5 as the Build phase delegated back to `/sprint` and `/audit`.
 
 ### 4. File ownership + blockedBy
 

--- a/plugins/fpl-skills/skills/do/SKILL.md
+++ b/plugins/fpl-skills/skills/do/SKILL.md
@@ -43,6 +43,13 @@ auto-detect through project files (glob, `package.json`, etc.).
 
 ## Workflow
 
+> [!IMPORTANT]
+> **Forgeplan artifact lifecycle is part of `/do`'s job.** If `forgeplan` CLI is on `$PATH`, this skill **creates artifacts at each phase** of the pipeline (PRD before build, Evidence after audit, activate at the end) and announces each artifact creation explicitly. If the CLI is absent, artifact creation is skipped and you're warned at the start of Phase 3 ("no forgeplan integration; pipeline will run without artifact lifecycle").
+>
+> If `forgeplan-workflow` plugin is also installed, `/do` delegates the whole pipeline to `/forge-cycle` (which is the same orchestration with forgeplan's native phase names).
+>
+> **`/do` is not just a skill chain — it's a skill chain plus artifact lifecycle.** Don't expect it to silently skip artifact creation when forgeplan is available. If you don't want artifacts, call the individual skill directly (`/sprint`, `/audit` etc.).
+
 ### Phase 1: UNDERSTAND — classification
 
 Parse `$ARGUMENTS` into one or more categories:
@@ -166,39 +173,76 @@ Step 5: CLEANUP
 **For**: "add", "implement", "реализуй"
 
 ```
+Step 0: FORGEPLAN PROBE
+  → command -v forgeplan
+  → If found: forgeplan health (surface blind spots first)
+  → If found: forgeplan route "<task>" → decide depth (Tactical/Standard/Deep)
+  → If absent: warn "no artifact lifecycle; pipeline runs without forgeplan"
+
 Step 1: RESEARCH (like Template A, focused on implementation context)
   → What exists, what's needed, reference patterns
 
-Step 2: PLAN
+Step 2: SHAPE — create artifact (if forgeplan present and depth ≥ Standard)
+  → forgeplan new prd "<title>" → PRD-NNN draft
+  → ANNOUNCE: "Created PRD-NNN, filling MUST sections from research"
+  → Fill Problem, Goals, FR from research output
+  → forgeplan validate PRD-NNN (must be 0 errors)
+  → If Deep: forgeplan reason PRD-NNN (3+ ADI hypotheses, mandatory before activation)
+  → If Deep: forgeplan new rfc "<implementation>" + link based_on PRD-NNN
+
+Step 3: PLAN
   → Plan from research → via [`sprint`](../sprint/SKILL.md) Step 2
   → File ownership map
   → Task breakdown (5-6 per teammate)
   → Dependencies
+  → Reference PRD-NNN / RFC-NNN in the plan
 
-Step 3: APPROVAL CHECKPOINT
-  → Show plan
+Step 4: APPROVAL CHECKPOINT
+  → Show plan + which artifacts will be created/activated
   → Wait approval
 
-Step 4: WAVE-SPRINT execute
+Step 5: WAVE-SPRINT execute
   → [`sprint`](../sprint/SKILL.md) Step 4 — wave-by-wave
   → Backend, frontend, tests teammates with research context
 
-Step 5: VERIFY
+Step 6: VERIFY
   → typecheck, build, tests (project-specific commands)
 
-Step 6: DOC (optional, if the task included docs)
+Step 7: EVIDENCE — capture verification (if forgeplan present)
+  → forgeplan new evidence "<task>: tests pass, smoke OK, audit clean"
+  → ANNOUNCE: "Created EVID-MMM, linking to PRD-NNN"
+  → Set Structured Fields in evidence body:
+       verdict: supports
+       congruence_level: 3
+       evidence_type: test_result
+  → forgeplan link EVID-MMM PRD-NNN --relation informs
+  → forgeplan score PRD-NNN (R_eff > 0?)
+
+Step 8: ACTIVATE — close the lifecycle (if forgeplan present and R_eff > 0)
+  → forgeplan activate PRD-NNN (draft → active)
+  → ANNOUNCE: "PRD-NNN activated; cycle complete"
+
+Step 9: DOC (optional, if the task included docs)
   → Update TODO with [x]
   → memory_retain decisions
   → Update RFC (Implementation Log + Insights)
 
-Step 7: CLEANUP
+Step 10: CLEANUP
 ```
+
+If `forgeplan-workflow` plugin is installed, **steps 0, 2, 7, 8 are handled by `/forge-cycle`** — `/do` delegates the whole pipeline. Otherwise these steps run as `forgeplan` CLI calls inline.
 
 ### Template D: AUDIT (code review)
 
 **For**: "ревью", "review", "аудит"
 
 ```
+Step 0: FORGEPLAN PROBE
+  → command -v forgeplan
+  → If found AND PR/branch references an artifact (Refs: PRD-NNN):
+       resolve the linked PRD/ADR for context
+  → If absent: skip artifact link step
+
 Step 1: SCOPE
   → Determine review target (branch diff, files, PR)
   → git diff main...HEAD for branch
@@ -209,11 +253,21 @@ Step 2: AUDIT
 Step 3: SYNTHESIZE
   → Cross-validate, prioritize Critical > High > Medium > Low
 
-Step 4: DELIVER
-  → Present audit report
+Step 4: EVIDENCE — capture audit verdict (if forgeplan present)
+  → forgeplan new evidence "<scope>: audit by N reviewers — X HIGH, Y MED resolved/deferred"
+  → ANNOUNCE: "Created EVID-MMM, linking to PRD-NNN" (if a target artifact was found)
+  → Structured Fields:
+       verdict: supports / weakens (depending on findings)
+       congruence_level: 3
+       evidence_type: code_review
+  → If a target PRD/ADR was found: forgeplan link EVID-MMM PRD-NNN --relation informs
+  → forgeplan score (target artifact)  → R_eff updated
+
+Step 5: DELIVER
+  → Present audit report + reference to EVID-MMM
   → memory_retain key issues
 
-Step 5: CLEANUP
+Step 6: CLEANUP
 ```
 
 ### Template E: RESEARCH → BUG HUNT (bug investigation)
@@ -221,30 +275,51 @@ Step 5: CLEANUP
 **For**: "bug", "doesn't work", "investigate"
 
 ```
+Step 0: FORGEPLAN PROBE
+  → command -v forgeplan
+  → If found: surface any related Problem cards
+       forgeplan list --kind problem | grep <bug-keyword>
+
 Step 1: RESEARCH (focused on the bug area)
   → memory_recall known issues
   → Read KNOWN-ISSUES.md
   → Understand architecture around the bug
 
-Step 2: BUG HUNT TEAM
-  → Spawn 3-5 teammates, each with its own hypothesis:
+Step 2: PROBLEM (if forgeplan present and bug is non-trivial)
+  → forgeplan new problem "<bug as a problem card>"
+  → ANNOUNCE: "Created PROB-NNN to track this investigation"
+  → Body: symptom, frequency, impact, observed behaviour vs expected
+
+Step 3: BUG HUNT TEAM (with ADI cycle)
+  → Spawn 3-5 teammates, each with its own hypothesis (this IS abduction):
     · hypothesis-input: validation, parsing
     · hypothesis-state: race condition, mutation
     · hypothesis-config: env mismatch
     · hypothesis-timing: async, ordering
   → See [`team`](../team/SKILL.md), Recipe 3.
+  → Each teammate predicts (deduction) + checks (induction) — full ADI
 
-Step 3: SYNTHESIZE
+Step 4: SYNTHESIZE
   → Which hypothesis is confirmed? Root cause?
 
-Step 4: FIX (if simple)
+Step 5: FIX (if simple)
   → Apply fix, add test, verify
 
-Step 5: DOCUMENT
+Step 6: EVIDENCE — capture verification (if forgeplan present)
+  → forgeplan new evidence "<bug>: root cause = X; fix verified by <test/repro>"
+  → ANNOUNCE: "Created EVID-MMM, linking to PROB-NNN"
+  → Structured Fields:
+       verdict: supports
+       congruence_level: 3
+       evidence_type: measurement OR test_result
+  → forgeplan link EVID-MMM PROB-NNN --relation informs
+  → forgeplan deprecate PROB-NNN --reason "fixed in EVID-MMM" (closes the problem)
+
+Step 7: DOCUMENT
   → Update KNOWN-ISSUES.md
   → memory_retain root cause + fix
 
-Step 6: CLEANUP
+Step 8: CLEANUP
 ```
 
 ### Template F: LIGHTWEIGHT STATUS CHECK


### PR DESCRIPTION
## Summary

**Closes a real-world report from a developer using the marketplace**: *«/do refused to create artifacts for a big task. Or wasn't it planned that way?»*

Investigation showed the gap was in **skill prose**, not behavior. Pipeline Templates listed only the skill chain (research → sprint → audit) without the forgeplan artifact lifecycle steps. The "Forgeplan integration" section at the bottom of each skill described correct behaviour, but it was easy to miss — agents reading the skill might apply it or skip it depending on attention.

This patch makes artifact creation **inline and load-bearing** in the templates themselves.

`fpl-skills` v1.5.0 → **v1.5.1** (patch). Marketplace catalog **1.17.0 → 1.17.1**.

## What changed

### `/do` — Pipeline Templates rewritten

**Top of Workflow** now has an `[!IMPORTANT]` block stating clearly:
> Forgeplan artifact lifecycle is part of `/do`'s job. If `forgeplan` CLI is on `$PATH`, this skill **creates artifacts at each phase** of the pipeline (PRD before build, Evidence after audit, activate at the end) and announces each artifact creation explicitly. If the CLI is absent, artifact creation is skipped and you're warned at the start.

Templates rewritten:

| Template | Before | After |
|---|---|---|
| **C — feature implementation** | 7 steps, no forgeplan calls | 11 steps with explicit artifact lifecycle: probe → research → **shape (forgeplan new prd + validate + reason)** → plan → approval → build → verify → **evidence (with verdict + CL3 + evidence_type)** → **activate (PRD draft → active)** → doc → cleanup |
| **D — audit (code review)** | 5 steps, no Evidence | 6 steps: probe → scope → audit → synthesise → **evidence (verdict + link to PRD/ADR + score)** → deliver |
| **E — bug investigation** | 6 steps, no Problem/Evidence | 8 steps: probe → research → **problem (forgeplan new problem)** → ADI bug-hunt team → synthesise → fix → **evidence (verified fix + close Problem)** → document |

Each artifact-creating step **announces** what it's doing (`ANNOUNCE: "Created PRD-NNN, filling MUST sections from research"`) so the user sees the lifecycle visibly.

If `forgeplan-workflow` plugin is installed, the Shape/Evidence/Activate steps delegate to `/forge-cycle` instead of inline calls — same effect, native phase names.

### `/autorun` — Workflow Step 3 rewritten

**Top of Workflow** has matching `[!IMPORTANT]` block.

**Step 3 ("Run the pipeline")** previously listed:
```
research → sprint (with team) → audit → report
```

Now shows the **8-step pipeline** with forgeplan calls inline:
```
0. Probe       (forgeplan-workflow installed? CLI present?)
1. Health      forgeplan health
2. Route       forgeplan route "<task>"
3. Shape       forgeplan new prd + validate + reason (Deep+: + RFC + ADR)
4. Build       /research → /sprint with /team → ADI on blockers
5. Audit       /audit (4-6 reviewers)
6. Evidence    forgeplan new evidence (verdict + CL3 + evidence_type)
               forgeplan link + score
7. Activate    forgeplan activate (only if R_eff > 0)
8. Report      forge-report skill or inline template
```

For research-only / review-only / status tasks: explicit fallback (drop steps 3-7, optionally still create a Note for research findings).

If `forgeplan-workflow` is installed: steps 0-3 and 6-8 delegate to `/forge-cycle`; only steps 4-5 stay in `/autorun`.

## Why this is "documentation/prose fix, not code change"

Skills are markdown. **What they "do" is what their SKILL.md describes.** The previous prose described correct behaviour in a footer ("Forgeplan integration" section). Agents reading the skill might apply it or skip it depending on attention.

Putting artifact steps **inline in the pipeline templates** — as load-bearing parts of the flow — makes them impossible to miss. The artifact lifecycle becomes part of the pipeline, not a footnote.

## Verification

- [x] `./scripts/validate-all-plugins.sh fpl-skills` → ALL PASSED
- [x] Both SKILL.md files have correct frontmatter (no changes there)
- [x] No version conflicts (plugin.json + marketplace.json fpl-skills entry both 1.5.1)
- [x] Pipeline templates now have explicit artifact-creation steps with announcements
- [x] Fallback paths documented (CLI absent → skip + warn; forgeplan-workflow installed → delegate)
- [ ] CI `validate` passes on PR open

## Test plan (developer-facing)

After this PR merges and the user updates the plugin (`/plugin marketplace update ForgePlan-marketplace` + reinstall), invoke `/do "implement <feature>"` on a project that has forgeplan CLI installed:

- [ ] At Phase 3 PLAN, `/do` shows "I will create PRD-NNN, ..." in the plan
- [ ] After approval, `/do` actually runs `forgeplan new prd` and announces the result
- [ ] After audit, `/do` runs `forgeplan new evidence` with structured fields
- [ ] At the end, `forgeplan health` shows the new artifact as `active` (if R_eff > 0)

If forgeplan CLI is NOT installed:
- [ ] `/do` shows a clear warning at Phase 3 ("no forgeplan integration; pipeline runs without artifact lifecycle")
- [ ] No `forgeplan` calls fire (graceful skip)

## Files

| Status | File | Lines |
|---|---|---|
| MODIFIED | `plugins/fpl-skills/skills/do/SKILL.md` | +60 (templates C/D/E + Workflow header) |
| MODIFIED | `plugins/fpl-skills/skills/autorun/SKILL.md` | +35 (Workflow Step 3 rewrite) |
| MODIFIED | `plugins/fpl-skills/.claude-plugin/plugin.json` | version bump |
| MODIFIED | `.claude-plugin/marketplace.json` | catalog + fpl-skills entry version |
| MODIFIED | `CHANGELOG.md` | 1.17.1 entry |

🤖 Generated with [Claude Code](https://claude.com/claude-code)