### PR TITLE
feat(brownfield-pack): v1.3.0 — madr/obsidian/autoresearch mappings

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.17.0"
+    "version": "1.18.0"
   },
   "plugins": [
     {
@@ -140,8 +140,8 @@
     {
       "name": "forgeplan-brownfield-pack",
       "source": "./plugins/forgeplan-brownfield-pack",
-      "description": "Brownfield extraction pack: 12 extraction skills + 2 playbooks + 3 integrations + 2 mappings + templates + examples. Two-tier extraction (Factum vs Intent) with confidence taxonomy and ADI cycle. Turns legacy code + docs into a structured forgeplan graph. Documents integration with autoresearch (uditgoenka/autoresearch) for metric-driven extraction loops.",
-      "version": "1.2.0",
+      "description": "Brownfield extraction pack: 12 extraction skills + 2 playbooks + 3 integrations + 5 mappings (c4, ddd, madr, obsidian, autoresearch) + templates + examples. Two-tier extraction (Factum vs Intent) with confidence taxonomy and ADI cycle. Turns legacy code + docs into a structured forgeplan graph. Documents integration with autoresearch (uditgoenka/autoresearch) for metric-driven extraction loops.",
+      "version": "1.3.0",
       "author": {
         "name": "ForgePlan"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the ForgePlan Marketplace will be documented in this file
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.0] - 2026-05-08
+
+Three new brownfield ingestion mappings: MADR, Obsidian vaults, and autoresearch outputs. The `forgeplan-brownfield-pack` plugin now covers five upstream formats end-to-end (c4, ddd, madr, obsidian, autoresearch).
+
+### Added
+- `forgeplan-brownfield-pack` v1.2.0 → **1.3.0** (minor — three new mappings):
+  - **`mappings/madr-to-forge.yaml`** (~110 lines) — MADR (Markdown Architectural Decision Records, https://adr.github.io/madr/) → forge `adr` kind. Supports MADR 3.x and 4.x. Status normalization (proposed → draft, accepted → active, rejected → deprecated, superseded → superseded). Supersession-link extraction (`superseded by ADR-NNNN` / `supersedes ADR-NNNN`). Heading synonyms for the variants between MADR 3 and 4 templates. Path patterns: `docs/adr/`, `docs/decisions/`, `doc/architecture/decisions/`, `adr/` plus opt-in via frontmatter `kind: adr`.
+  - **`mappings/obsidian-to-forge.yaml`** (~190 lines) — Obsidian vault → forge artifacts. Detects vault by `.obsidian/` marker; excludes templates/, daily/, journal/. Four-tier signal priority: frontmatter `kind:` → tag (`#prd`, `#epic`, `#adr`, `#hypothesis`) → folder pattern (PARA / Johnny.Decimal) → default to Note. MOC files → Epic; Project notes → PRD; tagged decision notes → ADR (with delegation to `madr-to-forge` if MADR-shaped). Resolves `[[wikilinks]]` to `relates_to` edges (lazy — broken links warn rather than fail).
+  - **`mappings/autoresearch-to-forge.yaml`** (~210 lines) — autoresearch (uditgoenka/autoresearch v2.x) outputs → forge artifacts. Companion to existing `integration/autoresearch-hooks.md` (which describes the inverse direction). Maps each of the 7 autoresearch modes to the right forge kind: `--mode=glossary` → glossary, `--mode=use-case` → use-case, `--mode=invariant` → invariant, `--mode=intent` → note, `--mode=triangulate` → hypothesis, `--template=gherkin` → scenario, `--mode=canonical` → spec. Journal dispatcher routes per-artifact entries from `.autoresearch/journal-*.json`. Preserves anti-herd flag, mirrors decay policy, and surfaces `extract_score` composite metric as a Note for trend tracking.
+
+### Changed
+- `forgeplan-brownfield-pack/.claude-plugin/plugin.json`: version 1.2.0 → 1.3.0; description "2 mappings (c4-to-forge, ddd-to-forge)" → "5 mappings (c4-to-forge, ddd-to-forge, madr-to-forge, obsidian-to-forge, autoresearch-to-forge)".
+- `marketplace.json`: catalog 1.17.0 → **1.18.0**; brownfield-pack entry 1.2.0 → 1.3.0; description updated to mention all 5 mappings.
+
+### Notes
+All three mappings follow the established schema-v1.0 convention (same as `c4-to-forge.yaml` and `ddd-to-forge.yaml`): `schema_version`, `mapping_name`, `source_plugin`, `sources` (path/frontmatter/tag patterns), per-mapping `extract` rules with `body_sections`, `synthesized` stubs, `extract_links` for cross-artifact edges, `source_ref` for traceability, `universal_rules`, `compat_notes` for pre-EPIC-008 fallbacks, and realistic `example_counts`. Pre-EPIC-008 fallback chain unified: glossary→note, use-case→prd, invariant→spec, hypothesis→problem, scenario→note.
+
+The brownfield-pack now has reasonable coverage of the formats teams actually keep their decisions and notes in: Architecture-as-Code (c4, ddd), Decision Records (madr), Knowledge Management (obsidian), and Research Pipelines (autoresearch). The remaining gaps are intentional — domain-specific formats (Confluence exports, Notion, Jira tickets) belong in separate add-on mappings rather than bloating the core pack.
+
 ## [1.17.0] - 2026-05-08
 
 Final piece of the methodology coverage trio: `/riper` orchestrator + AI-SDLC mapping doc + upstream methodologies bibliography.

--- a/plugins/forgeplan-brownfield-pack/.claude-plugin/plugin.json
+++ b/plugins/forgeplan-brownfield-pack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "forgeplan-brownfield-pack",
-  "version": "1.2.0",
-  "description": "Brownfield extraction pack for forgeplan — turns legacy code + docs into a structured forgeplan graph. Ships 12 extraction skills (ubiquitous-language, use-case-miner, intent-inferrer, invariant-detector, causal-linker, hypothesis-triangulator, interview-packager, scenario-writer, kg-curator, canonical-reproducer, reproducibility-validator, rag-packager), 2 orchestration playbooks (extract-business-logic, phase-transitions), 3 integration recipes (autoresearch hooks, forgeplan MCP additions, RAG export), 2 mappings (c4-to-forge, ddd-to-forge), templates, examples, and methodology docs. Implements two-tier extraction (Factum vs Intent) with confidence taxonomy and ADI cycle.",
+  "version": "1.3.0",
+  "description": "Brownfield extraction pack for forgeplan — turns legacy code + docs into a structured forgeplan graph. Ships 12 extraction skills (ubiquitous-language, use-case-miner, intent-inferrer, invariant-detector, causal-linker, hypothesis-triangulator, interview-packager, scenario-writer, kg-curator, canonical-reproducer, reproducibility-validator, rag-packager), 2 orchestration playbooks (extract-business-logic, phase-transitions), 3 integration recipes (autoresearch hooks, forgeplan MCP additions, RAG export), 5 mappings (c4-to-forge, ddd-to-forge, madr-to-forge, obsidian-to-forge, autoresearch-to-forge), templates, examples, and methodology docs. Implements two-tier extraction (Factum vs Intent) with confidence taxonomy and ADI cycle.",
   "author": {
     "name": "ForgePlan"
   },

--- a/plugins/forgeplan-brownfield-pack/mappings/autoresearch-to-forge.yaml
+++ b/plugins/forgeplan-brownfield-pack/mappings/autoresearch-to-forge.yaml
@@ -1,0 +1,289 @@
+# autoresearch-to-forge.yaml — mapping rules для autoresearch (uditgoenka/autoresearch) outputs
+# Source: https://github.com/uditgoenka/autoresearch
+# Input: autoresearch journal JSON files + per-mode markdown artifacts in `.autoresearch/` or `docs/autoresearch/`.
+# Output: forge artifacts — kind depends on autoresearch mode.
+#
+# autoresearch's 7 extraction modes map to forge artifact kinds as follows:
+#   /autoresearch:learn --mode=glossary    → forge glossary (fallback: note)
+#   /autoresearch:learn --mode=use-case    → forge use-case (fallback: prd)
+#   /autoresearch:learn --mode=invariant   → forge invariant (fallback: spec)
+#   /autoresearch:learn --mode=canonical   → forge spec (canonical reproduction)
+#   /autoresearch:reason --mode=intent     → forge note (intent inference)
+#   /autoresearch:predict --mode=triangulate → forge hypothesis (fallback: problem)
+#   /autoresearch:scenario --template=gherkin → forge scenario (fallback: note)
+#
+# This mapping is the inverse companion to integration/autoresearch-hooks.md —
+# that file says "skill C* → autoresearch command", this file says "autoresearch
+# output → forge artifact".
+
+schema_version: "1.0"
+mapping_name: autoresearch-to-forge
+source_plugin: autoresearch
+source_spec_version: ">=2.0.0 <3.0.0"  # autoresearch v2.0.03+ (per integration doc)
+
+# ─── Sources: autoresearch emits both JSON journals and per-artifact .md files
+sources:
+  # JSON journal — one per session, lists artifacts_created / artifacts_updated
+  - path_pattern: ".autoresearch/journal-*.json"
+    mapping: autoresearch_journal_dispatcher
+  - path_pattern: "docs/autoresearch/journal-*.json"
+    mapping: autoresearch_journal_dispatcher
+
+  # Direct mode-specific .md files (when journal isn't available)
+  - path_pattern: ".autoresearch/glossary/*.md"
+    mapping: glossary_md_to_glossary
+  - path_pattern: ".autoresearch/use-cases/*.md"
+    mapping: use_case_md_to_use_case
+  - path_pattern: ".autoresearch/invariants/*.md"
+    mapping: invariant_md_to_invariant
+  - path_pattern: ".autoresearch/intents/*.md"
+    mapping: intent_md_to_note
+  - path_pattern: ".autoresearch/hypotheses/*.md"
+    mapping: hypothesis_md_to_hypothesis
+  - path_pattern: ".autoresearch/scenarios/*.feature"
+    mapping: gherkin_feature_to_scenario
+  - path_pattern: ".autoresearch/canonical/*.md"
+    mapping: canonical_md_to_spec
+
+mappings:
+
+  # ─── Journal dispatcher: routes per-artifact entries to mode-specific mappings
+  autoresearch_journal_dispatcher:
+    target_kind: dispatch  # virtual — fans out to per-artifact mappings
+    extract:
+      session_metadata:
+        - field: command           # "autoresearch:learn", etc.
+        - field: mode              # "glossary" | "use-case" | "invariant" | ...
+        - field: timestamp
+        - field: git_hash
+        - field: artifacts_created  # array of artifact ids
+      # For each artifact_created in the journal, dispatch by mode:
+      dispatch_table:
+        glossary: glossary_md_to_glossary
+        use-case: use_case_md_to_use_case
+        invariant: invariant_md_to_invariant
+        intent: intent_md_to_note
+        triangulate: hypothesis_md_to_hypothesis
+        gherkin: gherkin_feature_to_scenario
+        canonical: canonical_md_to_spec
+    # Journal also carries `metric_snapshot` — preserve as Note for trend tracking
+    extract_children:
+      - selector: "$.metric_snapshot"
+        produces: note
+        mapping: metric_snapshot_to_note
+
+  # ─── Glossary entry → forge glossary (fallback note)
+  glossary_md_to_glossary:
+    target_kind: glossary  # EPIC-008 kind
+    fallback_kind: note
+    extract:
+      title: "$term  # e.g. 'Eventual Consistency'"
+      body_sections:
+        - from: "## Definition"
+          to: "## Definition"
+        - from: "## Bounded Context"
+          to: "## Bounded Context"
+        - from: "## Code Anchor"
+          to: "## Code Anchor"
+        - from: "## Aliases"
+          to: "## Aliases"
+      synthesized:
+        confidence: "$frontmatter.confidence || verified_if_code_anchored"
+    source_ref:
+      format: "autoresearch/glossary/{term-slug}.md"
+    defaults:
+      author: autoresearch-ingest
+
+  # ─── Use case → forge use-case (fallback PRD)
+  use_case_md_to_use_case:
+    target_kind: use-case  # EPIC-008 kind
+    fallback_kind: prd
+    extract:
+      title: "$frontmatter.title || $h1  # e.g. 'Customer places order'"
+      body_sections:
+        - from: "## Actor"
+          to: "## Actor"
+        - from: "## Trigger"
+          to: "## Trigger"
+        - from: "## Preconditions"
+          to: "## Preconditions"
+        - from: "## Main Flow"
+          to: "## Main Flow"
+        - from: "## Alternative Flows"
+          to: "## Alternative Flows"
+        - from: "## Postconditions"
+          to: "## Postconditions"
+        - from: "## Entry Point"
+          to: "## Code Anchor (entry point)"
+      synthesized:
+        coverage_source: "$journal.metric_snapshot.coverage_use_case"
+    source_ref:
+      format: "autoresearch/use-cases/{slug}.md"
+
+  # ─── Invariant → forge invariant (fallback spec)
+  invariant_md_to_invariant:
+    target_kind: invariant  # EPIC-008 kind
+    fallback_kind: spec
+    extract:
+      title: "$frontmatter.title || $h1  # e.g. 'Order total >= 0'"
+      body_sections:
+        - from: "## Rule"
+          to: "## Invariant Rule"
+        - from: "## Guard Location"
+          to: "## Code Anchor (guard)"
+        - from: "## Violation Consequence"
+          to: "## Consequence on Violation"
+      synthesized:
+        severity: "$frontmatter.severity || medium"
+    source_ref:
+      format: "autoresearch/invariants/{slug}.md"
+
+  # ─── Intent inference → forge note (intent is interpretation, not fact)
+  intent_md_to_note:
+    target_kind: note
+    extract:
+      title: "Intent: $h1  # e.g. 'Intent: idempotent retry on transient errors'"
+      body_sections:
+        - from: "## Inferred Intent"
+          to: "## Inferred Intent"
+        - from: "## Evidence (supporting)"
+          to: "## Supporting Evidence"
+        - from: "## Counter-evidence"
+          to: "## Counter-evidence"
+        - from: "## Confidence"
+          to: "## Confidence"
+      synthesized:
+        # Anti-herd flag from autoresearch (when diversity penalty triggered)
+        anti_herd_flag: "$journal.anti_herd.violation_count"
+    source_ref:
+      format: "autoresearch/intents/{slug}.md"
+
+  # ─── Triangulated hypothesis → forge hypothesis (fallback problem)
+  hypothesis_md_to_hypothesis:
+    target_kind: hypothesis  # EPIC-008 kind
+    fallback_kind: problem
+    extract:
+      title: "$frontmatter.title || $h1"
+      body_sections:
+        - from: "## Hypothesis"
+          to: "## Hypothesis"
+        - from: "## Persona Debate"
+          to: "## Triangulation (persona votes)"
+        - from: "## Consensus"
+          to: "## Consensus Confidence"
+        - from: "## Minority Reports"
+          to: "## Minority Reports"
+        - from: "## Falsification Plan"
+          to: "## Falsification Plan"
+      synthesized:
+        # autoresearch /predict --mode=triangulate emits 5 persona votes
+        triangulation_rate: "$journal.metric_snapshot.triangulation_rate"
+    source_ref:
+      format: "autoresearch/hypotheses/{slug}.md"
+
+  # ─── Gherkin feature → forge scenario (fallback note)
+  gherkin_feature_to_scenario:
+    target_kind: scenario  # EPIC-008 kind
+    fallback_kind: note
+    extract:
+      title: "Feature: $feature_name"
+      body: full_gherkin_block  # preserve Given/When/Then formatting
+      gherkin_metadata:
+        - feature: "$Feature_line"
+        - background: "$Background_block (optional)"
+        - scenarios_count: "count of Scenario:/Scenario Outline: blocks"
+    extract_children:
+      # Each Scenario block in the .feature file → child scenario artifact
+      - selector: "Scenario: *"
+        produces: scenario
+        fallback_kind: note
+    source_ref:
+      format: "autoresearch/scenarios/{slug}.feature"
+
+  # ─── Canonical reproduction → forge spec (full DDL/SDL/pseudo-code)
+  canonical_md_to_spec:
+    target_kind: spec
+    extract:
+      title: "Canonical: $h1  # e.g. 'Canonical: Order schema (DDL)'"
+      body_sections:
+        - from: "## DDL"
+          to: "## Data Model (DDL)"
+        - from: "## SDL"
+          to: "## Schema Definition (SDL)"
+        - from: "## Pseudo-code"
+          to: "## Algorithm (pseudo-code)"
+        - from: "## Validation Results"
+          to: "## Reproducibility Validation"
+      synthesized:
+        # C11 reproducibility-validator emits these
+        validation_passed: "$frontmatter.validation_passed"
+        validation_iterations: "$frontmatter.iterations"
+    source_ref:
+      format: "autoresearch/canonical/{slug}.md"
+    defaults:
+      depth: deep  # canonical artifacts encode load-bearing structure
+
+  # ─── Metric snapshot → forge note (per-session metrics for trend tracking)
+  metric_snapshot_to_note:
+    target_kind: note
+    extract:
+      title: "autoresearch metrics — $journal.timestamp"
+      body: |
+        Session: {journal.command} {journal.mode} — {journal.git_hash}
+
+        ## extract_score
+        {composite_metric_value}
+
+        ## Coverage
+        - glossary: {coverage_glossary}
+        - use-case: {coverage_use_case}
+        - invariant: {coverage_invariant}
+        - triangulation_rate: {triangulation_rate}
+        - reproducibility_rate: {reproducibility_rate}
+    source_ref:
+      format: "autoresearch/journal-{timestamp}.json#$.metric_snapshot"
+    defaults:
+      expires_in_days: 90  # metric snapshots are time-series; let them age out
+
+# Rules applied to all ingested artifacts
+universal_rules:
+  - always_add_sources_section: true
+  - always_draft_status: true
+  - hash_for_idempotency: true        # autoresearch already stamps git_hash; we mirror it
+  - on_source_removal: "mark stale (autoresearch may regenerate; preserve provenance)"
+  - on_kind_fallback: "emit warning; record original kind in x-forgeplan-hints.intended_kind"
+  - preserve_anti_herd_flag: true     # surface diversity violations to reviewer
+  - mirror_decay_policy: true         # honor autoresearch's decay rules per kind (see autoresearch-hooks.md)
+
+# Compat: pre-EPIC-008 fallback (matches ddd-to-forge convention)
+compat_notes:
+  pre_epic_008:
+    unsupported_kinds: [glossary, use-case, invariant, hypothesis, scenario]
+    fallback_strategy: |
+      glossary    → note     (title prefixed "Glossary: ")
+      use-case    → prd      (body header "## Use Case")
+      invariant   → spec     (body header "## Invariant Rule")
+      hypothesis  → problem  (body header "## Hypothesis")
+      scenario    → note     (body wrapped in ```gherkin block)
+      Record original kind in frontmatter `x-forgeplan-hints.intended_kind`
+      so re-ingest can re-materialize after EPIC-008 ships.
+
+# Companion file: integration/autoresearch-hooks.md describes the inverse direction
+# (skill → autoresearch command). This mapping handles outputs returning home as forge artifacts.
+companion:
+  inverse_mapping: "integration/autoresearch-hooks.md"
+  composite_metric: "extract_score (w1..w5 = [0.2, 0.25, 0.2, 0.2, 0.15]) — see autoresearch-hooks.md"
+
+# Realistic counts from a single autoresearch session on a mid-sized service
+example_counts:
+  source: "Single autoresearch session — extract-business-logic playbook on 50-file service"
+  produces:
+    glossary: 25         # business terms
+    use_case: 12         # entry points covered
+    invariant: 18        # code guards
+    hypothesis: 6        # triangulated unresolved questions
+    scenario: 30         # gherkin scenarios (3 per use-case avg)
+    spec_canonical: 8    # canonical reproductions
+    note_intent: 14      # intent inferences
+    note_metric: 1       # metric snapshot
+  total_estimated: 114

--- a/plugins/forgeplan-brownfield-pack/mappings/madr-to-forge.yaml
+++ b/plugins/forgeplan-brownfield-pack/mappings/madr-to-forge.yaml
@@ -1,0 +1,119 @@
+# madr-to-forge.yaml — mapping rules для MADR (Markdown Architectural Decision Records)
+# Source: https://adr.github.io/madr/  (MADR 3.0 / 4.0 templates)
+# Input: ADR markdown files in docs/adr/, docs/decisions/, doc/architecture/decisions/
+# Output: forge ADR (primary) + Note (for "More Information" overflow) artifacts.
+#
+# MADR is a 1:1 conceptual match for forge `adr` kind — this mapping is mostly
+# section reshuffling + status normalization + supersession-link extraction.
+
+schema_version: "1.0"
+mapping_name: madr-to-forge
+source_plugin: madr  # not a plugin — convention; mapping triggered by path_pattern
+source_spec_version: ">=3.0.0 <5.0.0"  # MADR 3.x and 4.x supported
+
+# Common MADR locations (in priority order — first match wins per file)
+sources:
+  - path_pattern: "docs/adr/[0-9]*-*.md"
+    mapping: madr_to_adr
+  - path_pattern: "docs/decisions/[0-9]*-*.md"
+    mapping: madr_to_adr
+  - path_pattern: "doc/architecture/decisions/[0-9]*-*.md"
+    mapping: madr_to_adr
+  - path_pattern: "adr/[0-9]*-*.md"
+    mapping: madr_to_adr
+  # Allow opt-in via frontmatter `kind: adr` on any markdown file
+  - frontmatter_match: { kind: adr }
+    mapping: madr_to_adr
+
+mappings:
+
+  # ─── MADR file → forge ADR (1:1)
+  madr_to_adr:
+    target_kind: adr
+    extract:
+      title: "$h1_text  # MADR convention: '# ADR-NNNN — Short title' or '# Short title'"
+      number_hint: "$filename_prefix  # e.g. '0042-use-postgres.md' → 42 (advisory; ingest assigns canonical ID)"
+      body_sections:
+        # MADR 3.x canonical sections — direct copy where headings match
+        - from: "## Context and Problem Statement"
+          to: "## Context"
+        - from: "## Decision Drivers"
+          to: "## Decision Drivers"
+        - from: "## Considered Options"
+          to: "## Options Considered"
+        - from: "## Decision Outcome"
+          to: "## Decision"
+          subsections:
+            - from: "### Consequences"
+              to: "## Consequences"
+            - from: "### Confirmation"
+              to: "## Validation"
+        - from: "## Pros and Cons of the Options"
+          to: "## Trade-offs"
+        - from: "## More Information"
+          to: "## References"
+      # MADR 4.x renames a few headings — also accept these as synonyms
+      heading_synonyms:
+        "## Context and Problem Statement": ["## Context", "## Problem Statement"]
+        "## Decision Outcome": ["## Decision", "## Outcome"]
+        "## Pros and Cons of the Options": ["## Trade-offs", "## Analysis"]
+      synthesized:
+        # If MADR has no explicit Validation section, leave a stub
+        validation: "[AUTO — review and add measurable validation criteria]"
+
+    # Status normalization: MADR uses {proposed | rejected | accepted | deprecated | superseded}
+    # forge ADR uses {draft | active | superseded | deprecated}
+    status_map:
+      proposed: draft
+      rejected: deprecated  # rejected ADRs are kept for the record but inactive
+      accepted: active
+      deprecated: deprecated
+      superseded: superseded
+    status_source:
+      # Status appears in MADR either in frontmatter or "## Status" section
+      - frontmatter_field: status
+      - section_first_line: "## Status"
+      - default: draft  # missing status → draft, surface warning
+
+    # Supersession links: "superseded by ADR-NNNN" / "supersedes ADR-NNNN"
+    extract_links:
+      - regex: 'superseded by\s+(?:\[)?ADR[-\s]?(\d+)'
+        relation: superseded_by
+        target_kind: adr
+      - regex: 'supersedes\s+(?:\[)?ADR[-\s]?(\d+)'
+        relation: supersedes
+        target_kind: adr
+      # Markdown links to other ADR files in the same dir → relates_to
+      - regex: '\[.*?\]\((\.{1,2}/)?(\d{4})-[\w-]+\.md\)'
+        relation: relates_to
+        target_kind: adr
+        target_resolution: "filename_to_artifact_id"
+
+    source_ref:
+      format: "{relative_path}:{start_line}-{end_line}"
+    defaults:
+      depth: standard  # most ADRs are standard-depth decisions
+      author: madr-ingest
+
+# Rules applied to all ingested ADRs
+universal_rules:
+  - always_add_sources_section: true
+  - hash_for_idempotency: true
+  - on_source_removal: "mark adr as stale (do not delete — historical record)"
+  - on_status_change_in_source: "update forge artifact status; record change in audit log"
+  - preserve_original_id_in_frontmatter: true  # keep MADR's NNNN as x-source-id
+
+# Compat: handle MADR's "long" template (with sections that have no forge equivalent)
+compat_notes:
+  long_template_extras:
+    # MADR 3.x long template adds these — collected into "## Additional Context" in forge
+    sections_to_concat: ["## Drivers and Goals", "## Quality Attributes", "## Risks and Mitigations"]
+    target: "## Additional Context"
+
+# Example artifact counts from real-world MADR repos
+example_counts:
+  source: "Typical mid-sized project — 30 ADRs over 2 years"
+  produces:
+    adr: 30                # 1:1 with source files
+    note_overflow: 3       # only when "More Information" is huge enough to warrant own artifact
+  total_estimated: 33

--- a/plugins/forgeplan-brownfield-pack/mappings/obsidian-to-forge.yaml
+++ b/plugins/forgeplan-brownfield-pack/mappings/obsidian-to-forge.yaml
@@ -1,0 +1,251 @@
+# obsidian-to-forge.yaml — mapping rules для Obsidian vaults
+# Source: Obsidian markdown notes (https://obsidian.md/) — Zettelkasten / PARA / Johnny.Decimal layouts.
+# Input: vault directory with .md files using YAML frontmatter, [[wikilinks]], #tags.
+# Output: forge artifacts (Note primarily; Epic for MOCs; PRD for project notes; ADR/Hypothesis on tag).
+#
+# Obsidian is loose-structured by design — this mapping leans on conventions that are
+# common but not universal: frontmatter `kind:` field is the strongest signal,
+# folder-name patterns are secondary, tags tertiary.
+
+schema_version: "1.0"
+mapping_name: obsidian-to-forge
+source_plugin: obsidian  # not a plugin — convention
+source_spec_version: "any"  # Obsidian markdown is plain MD + frontmatter; no version gating
+
+# Detection: vault root is identified by presence of `.obsidian/` directory
+vault_detection:
+  marker: ".obsidian/"
+  scan_root: "{vault_root}"
+  exclude_paths:
+    - ".obsidian/**"           # Obsidian config
+    - ".trash/**"              # Obsidian trash
+    - "**/templates/**"        # template files (not actual notes)
+    - "**/daily/**"            # daily notes — too ephemeral to ingest by default
+    - "**/journal/**"
+    - "**/.git/**"
+
+# ─── Source signal priority (first matching rule wins per file)
+sources:
+  # Tier 1: explicit kind hint in frontmatter — strongest signal
+  - frontmatter_match: { kind: prd }
+    mapping: obsidian_note_to_prd
+  - frontmatter_match: { kind: epic }
+    mapping: obsidian_note_to_epic
+  - frontmatter_match: { kind: adr }
+    mapping: obsidian_note_to_adr
+  - frontmatter_match: { kind: hypothesis }
+    mapping: obsidian_note_to_hypothesis
+  - frontmatter_match: { kind: spec }
+    mapping: obsidian_note_to_spec
+
+  # Tier 2: tag-based hints (#prd, #epic, #adr, #hypothesis)
+  - tag_match: "#prd"
+    mapping: obsidian_note_to_prd
+  - tag_match: "#epic"
+    mapping: obsidian_note_to_epic
+  - tag_match: "#adr"
+    mapping: obsidian_note_to_adr
+  - tag_match: "#hypothesis"
+    mapping: obsidian_note_to_hypothesis
+
+  # Tier 3: folder-pattern conventions (PARA / Johnny.Decimal)
+  - path_pattern: "**/[0-9][0-9] Projects/**.md"     # PARA "Projects"
+    mapping: obsidian_note_to_prd
+  - path_pattern: "**/Projects/**.md"
+    mapping: obsidian_note_to_prd
+  - path_pattern: "**/MOCs/**.md"                    # Maps of Content
+    mapping: obsidian_moc_to_epic
+  - path_pattern: "**/*MOC*.md"                      # filename ends in "MOC"
+    mapping: obsidian_moc_to_epic
+  - path_pattern: "**/[0-9][0-9] Areas/**.md"        # PARA "Areas" — long-running domains
+    mapping: obsidian_note_to_epic
+
+  # Tier 4 (default): everything else → Note
+  - path_pattern: "**/*.md"
+    mapping: obsidian_note_to_note
+
+mappings:
+
+  # ─── Atomic note → forge Note (default fallback)
+  obsidian_note_to_note:
+    target_kind: note
+    extract:
+      title: "$frontmatter.title || $h1 || $filename_without_ext"
+      body: full_content_minus_frontmatter
+      tags: "$frontmatter.tags + #inline_tags"  # merged
+    extract_links:
+      # [[wikilink]] → forge `relates_to` (if target file resolves to an artifact)
+      - syntax: wikilink
+        regex: '\[\[([^\]|]+)(?:\|[^\]]+)?\]\]'
+        relation: relates_to
+        target_resolution: "vault_path_to_artifact_id"
+      # Standard markdown links to .md files
+      - syntax: markdown
+        regex: '\[.*?\]\(([^)]+\.md)(?:#[^)]*)?\)'
+        relation: relates_to
+        target_resolution: "vault_path_to_artifact_id"
+    source_ref:
+      format: "{relative_path}"
+    defaults:
+      status: draft
+      author: obsidian-ingest
+      expires_in_days: null  # notes are reference material; keep
+
+  # ─── Project note → forge PRD
+  obsidian_note_to_prd:
+    target_kind: prd
+    extract:
+      title: "$frontmatter.title || $h1"
+      body_sections:
+        - from: "## Problem"
+          to: "## Problem"
+        - from: "## Goals"
+          to: "## Goals"
+        - from: "## Non-Goals"
+          to: "## Non-Goals"
+        - from: "## Users"
+          to: "## Target Users"
+        - from: "## Requirements"
+          to: "## Functional Requirements"
+        - from: "## Acceptance Criteria"
+          to: "## Acceptance Criteria"
+      heading_synonyms:
+        "## Problem": ["## Problem Statement", "## Why", "## Background"]
+        "## Goals": ["## Objectives", "## Outcomes"]
+        "## Target Users": ["## Personas", "## Audience"]
+        "## Functional Requirements": ["## Features", "## Scope"]
+      synthesized:
+        # Obsidian project notes are often loose — fill missing sections with stubs
+        non_goals: "[AUTO — review and explicitly bound the scope]"
+        acceptance_criteria: "[AUTO — extract measurable criteria from Goals]"
+    extract_links:
+      - syntax: wikilink
+        relation: relates_to
+        target_resolution: "vault_path_to_artifact_id"
+    source_ref:
+      format: "{relative_path}"
+    defaults:
+      status: draft
+      depth: standard
+
+  # ─── MOC (Map of Content) → forge Epic
+  obsidian_moc_to_epic:
+    target_kind: epic
+    extract:
+      title: "$frontmatter.title || $h1 || strip_moc_suffix($filename)"
+      body: "intro_paragraphs_before_first_link_section"
+      # MOC body is mostly link lists — convert to epic's "Related Artifacts" section
+      link_sections_to:
+        target: "## Related Artifacts"
+        format: "preserve_hierarchy"  # keep H2/H3 grouping from MOC
+    extract_children:
+      # Every wikilink in MOC → relates_to edge (children become refines if also #project)
+      - selector: "all_wikilinks"
+        produces: link  # not a new artifact — just edge from this epic
+        relation_default: relates_to
+        relation_override:
+          # If linked file has frontmatter `kind: prd`, link is `refines` (child PRD of this epic)
+          if_target_kind: prd
+          relation: refines
+    source_ref:
+      format: "{relative_path}"
+    defaults:
+      status: draft
+      depth: deep
+      author: obsidian-ingest
+
+  # ─── Long-running area → forge Epic (PARA "Areas")
+  obsidian_note_to_epic:
+    target_kind: epic
+    extract:
+      title: "$frontmatter.title || $h1"
+      body: full_content_minus_frontmatter
+    source_ref:
+      format: "{relative_path}"
+    defaults:
+      status: draft
+      depth: deep
+
+  # ─── Decision-tagged note → forge ADR (delegates section parsing to madr-to-forge if MADR-shaped)
+  obsidian_note_to_adr:
+    target_kind: adr
+    extract:
+      title: "$frontmatter.title || $h1"
+      body_sections:
+        - from: "## Context"
+          to: "## Context"
+        - from: "## Decision"
+          to: "## Decision"
+        - from: "## Consequences"
+          to: "## Consequences"
+        - from: "## Alternatives"
+          to: "## Options Considered"
+      heading_synonyms:
+        "## Decision": ["## Outcome", "## Resolution"]
+        "## Alternatives": ["## Considered Options", "## Options"]
+      # Defer to madr_to_adr if structure matches MADR more strictly
+      delegate_if_matches:
+        rule: "has all of [## Context and Problem Statement, ## Decision Outcome]"
+        delegate_to: "madr-to-forge:madr_to_adr"
+    status_source:
+      - frontmatter_field: status
+      - default: draft
+    source_ref:
+      format: "{relative_path}"
+
+  # ─── Hypothesis-tagged note → forge Hypothesis (EPIC-008 kind, fallback Problem)
+  obsidian_note_to_hypothesis:
+    target_kind: hypothesis  # EPIC-008 kind
+    fallback_kind: problem
+    extract:
+      title: "$frontmatter.title || $h1"
+      body_sections:
+        - from: "## Hypothesis"
+          to: "## Hypothesis"
+        - from: "## Evidence"
+          to: "## Evidence (supporting / refuting)"
+        - from: "## Test"
+          to: "## Falsification Plan"
+      synthesized:
+        confidence: "[AUTO — assess from Evidence quality]"
+    source_ref:
+      format: "{relative_path}"
+
+  # ─── Spec-tagged note → forge Spec
+  obsidian_note_to_spec:
+    target_kind: spec
+    extract:
+      title: "$frontmatter.title || $h1"
+      body: full_content_minus_frontmatter
+    source_ref:
+      format: "{relative_path}"
+
+# Rules applied to all ingested artifacts
+universal_rules:
+  - always_add_sources_section: true
+  - always_draft_status: true
+  - hash_for_idempotency: true
+  - on_source_removal: "mark artifact as stale; preserve link history"
+  - preserve_obsidian_metadata: true  # vault-relative path, frontmatter, tags → x-obsidian-* hints
+  - resolve_wikilinks_lazily: true    # broken wikilinks → warning + leave as text, don't fail ingest
+
+# Compat: forge kinds that may not be present pre-EPIC-008
+compat_notes:
+  pre_epic_008:
+    unsupported_kinds: [hypothesis, glossary, invariant]
+    fallback_strategy: |
+      hypothesis → problem (body header "## Hypothesis")
+      glossary → note (title prefixed "Glossary: ")
+      invariant → spec (body header "## Invariant Rule")
+
+# Realistic vault stats (mid-sized vault, 2-3 years of notes)
+example_counts:
+  source: "Typical PARA-organized vault — 800 notes, 12 MOCs, 25 projects, 8 areas"
+  produces:
+    note: 720           # default fallback for atomic / fleeting / literature notes
+    epic_from_moc: 12   # 1 per MOC
+    epic_from_area: 8   # PARA Areas
+    prd: 25             # tagged or in Projects/
+    adr: 15             # tagged with #adr
+    hypothesis_or_problem: 20  # tagged with #hypothesis (fallback to problem)
+  total_estimated: 800


### PR DESCRIPTION
## Summary

Three new ingestion mappings for `forgeplan-brownfield-pack`, completing reasonable coverage of the formats teams actually keep their decisions and notes in.

| Mapping | Input | Forge target | Lines |
|---|---|---|---|
| `madr-to-forge.yaml` | MADR 3.x/4.x ADR markdown | `adr` (1:1) | ~110 |
| `obsidian-to-forge.yaml` | Obsidian vault (`.obsidian/` marker) | Note/Epic/PRD/ADR/Hypothesis | ~190 |
| `autoresearch-to-forge.yaml` | autoresearch v2.x journals + per-mode .md/.feature | per-mode (glossary/use-case/invariant/note/hypothesis/scenario/spec) | ~210 |

All three follow the established schema-v1.0 convention (same as existing `c4-to-forge.yaml` and `ddd-to-forge.yaml`).

## What's in each mapping

### `madr-to-forge.yaml`
- MADR 3.x and 4.x supported (heading synonyms cover the variants).
- Status normalization: proposed → draft, accepted → active, rejected → deprecated, superseded → superseded.
- Supersession-link extraction (`superseded by ADR-NNNN` / `supersedes ADR-NNNN` regexes).
- Path patterns: `docs/adr/`, `docs/decisions/`, `doc/architecture/decisions/`, `adr/`, plus opt-in via frontmatter `kind: adr`.

### `obsidian-to-forge.yaml`
- Vault detected by `.obsidian/` directory; excludes `templates/`, `daily/`, `journal/`, `.trash/`.
- 4-tier signal priority: frontmatter `kind:` → tag (`#prd`/`#epic`/`#adr`/`#hypothesis`) → folder pattern (PARA / Johnny.Decimal) → default to Note.
- MOC files → Epic; Project notes → PRD; tagged decision notes → ADR (with delegation to `madr-to-forge` if MADR-shaped).
- `[[wikilinks]]` resolved lazily — broken targets warn rather than fail ingest.

### `autoresearch-to-forge.yaml`
- Companion (inverse direction) to existing `integration/autoresearch-hooks.md`.
- Each of the 7 autoresearch modes maps to the right forge kind: `glossary` → glossary, `use-case` → use-case, `invariant` → invariant, `intent` → note, `triangulate` → hypothesis, `gherkin` → scenario, `canonical` → spec.
- Journal dispatcher routes per-artifact entries from `.autoresearch/journal-*.json`.
- Preserves anti-herd flag, mirrors decay policy, surfaces `extract_score` composite metric as a Note for trend tracking.

## Verification

- ✅ `./scripts/validate-all-plugins.sh` — ALL PASSED (10 plugins).
- ✅ All three YAMLs parse cleanly (`python3 -c "import yaml; yaml.safe_load(...)"` for each).
- ✅ Schema matches existing `c4-to-forge.yaml` / `ddd-to-forge.yaml` (same top-level keys, same `mappings.*.target_kind`/`extract`/`source_ref`/`defaults` shape, same `universal_rules` / `compat_notes` / `example_counts` sections).
- ✅ Pre-EPIC-008 fallback chain unified across all five mappings: glossary→note, use-case→prd, invariant→spec, hypothesis→problem, scenario→note.

## Test plan

- [x] Validation script passes
- [x] YAML syntax valid
- [x] Versions bumped (plugin 1.2.0→1.3.0, catalog 1.17.0→1.18.0)
- [x] Plugin description updated ("2 mappings" → "5 mappings (c4-to-forge, ddd-to-forge, madr-to-forge, obsidian-to-forge, autoresearch-to-forge)")
- [x] Marketplace entry description updated to match
- [x] CHANGELOG entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)