### PR TITLE
docs(brownfield-pack): v1.3.1 — sync docs with v1.18.0 mappings

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.18.0"
+    "version": "1.18.1"
   },
   "plugins": [
     {
@@ -141,7 +141,7 @@
       "name": "forgeplan-brownfield-pack",
       "source": "./plugins/forgeplan-brownfield-pack",
       "description": "Brownfield extraction pack: 12 extraction skills + 2 playbooks + 3 integrations + 5 mappings (c4, ddd, madr, obsidian, autoresearch) + templates + examples. Two-tier extraction (Factum vs Intent) with confidence taxonomy and ADI cycle. Turns legacy code + docs into a structured forgeplan graph. Documents integration with autoresearch (uditgoenka/autoresearch) for metric-driven extraction loops.",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "author": {
         "name": "ForgePlan"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the ForgePlan Marketplace will be documented in this file
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.1] - 2026-05-08
+
+Documentation sync for v1.18.0 — brings README/METHODOLOGIES/USAGE-GUIDE/ARCHITECTURE/AUTORESEARCH-INTEGRATION docs in line with the new mappings shipped in v1.18.0. No code or mapping changes.
+
+### Changed
+- `forgeplan-brownfield-pack` v1.3.0 → **1.3.1** (patch — docs only):
+  - `README.md` and `README-RU.md`: section "2 mappings" → "5 mappings"; lists all five (c4, ddd, madr, obsidian, autoresearch) with one-line descriptions each.
+- `docs/METHODOLOGIES.md` and `-RU.md`: added per-methodology sections for **MADR** and **Obsidian** (alongside existing DDD and C4 entries). Quick lookup table extended with rows for MADR, Obsidian, plus an updated Autoresearch row mentioning the new ingest mapping.
+- `docs/USAGE-GUIDE.md` and `-RU.md`: brownfield-pack section description now lists all five mappings by name instead of generic "Obsidian, MADR, ad-hoc markdown".
+- `docs/ARCHITECTURE.md` and `-RU.md`: brownfield-pack capability row updated from "Mappings + playbooks for migrating legacy docs (Obsidian, MADR)" to "5 mappings (c4, ddd, madr, obsidian, autoresearch) + 12 extraction skills + 2 playbooks".
+- `docs/AUTORESEARCH-INTEGRATION.md` and `-RU.md`: "See also" section now distinguishes the two directions — `autoresearch-hooks.md` (outbound: skill → autoresearch command) and `autoresearch-to-forge.yaml` (inbound: autoresearch outputs → forge artifacts).
+- `marketplace.json`: catalog 1.18.0 → **1.18.1**; brownfield-pack entry 1.3.0 → 1.3.1.
+
+### Notes
+This patch closes the documentation gap from v1.18.0 — the mappings YAMLs were shipped, but the user-facing docs that point at them weren't updated in the same PR. No new files; only edits to existing docs.
+
 ## [1.18.0] - 2026-05-08
 
 Three new brownfield ingestion mappings: MADR, Obsidian vaults, and autoresearch outputs. The `forgeplan-brownfield-pack` plugin now covers five upstream formats end-to-end (c4, ddd, madr, obsidian, autoresearch).

--- a/docs/ARCHITECTURE-RU.md
+++ b/docs/ARCHITECTURE-RU.md
@@ -167,7 +167,7 @@ Orchestra: Task "OAuth" Status=Review, Phase=Evidence
 | UX | laws-of-ux | `ux-reviewer` агент + `/ux-review` + auto-hint hook при правке frontend-файлов. |
 | Агенты | agents-core / agents-domain / agents-pro / agents-github | Специализированные сабагенты, которые `/audit`, `/sprint` и др. композят при необходимости. |
 | Универсальный тулкит (legacy) | dev-toolkit | Soft-deprecated, superseded by fpl-skills. Используй только если CLI forgeplan недоступен. |
-| Brownfield ингест | forgeplan-brownfield-pack | Mappings + playbooks для миграции legacy-доков (Obsidian, MADR) в forgeplan-граф. |
+| Brownfield ингест | forgeplan-brownfield-pack | 5 карт соответствия (c4, ddd, madr, obsidian, autoresearch) + 12 скиллов извлечения + 2 playbooks для миграции legacy-кода и доков в forgeplan-граф. |
 
 Команда установки: `/plugin install <plugin-name>@ForgePlan-marketplace`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -167,7 +167,7 @@ Orchestra: Task "OAuth" Status=Review, Phase=Evidence
 | UX | laws-of-ux | `ux-reviewer` agent + `/ux-review` + auto-hint hook on frontend file edits. |
 | Agents | agents-core / agents-domain / agents-pro / agents-github | Specialised subagents that `/audit`, `/sprint`, etc. compose when relevant. |
 | Universal toolkit (legacy) | dev-toolkit | Soft-deprecated, superseded by fpl-skills. Use only if forgeplan CLI is unavailable. |
-| Brownfield ingest | forgeplan-brownfield-pack | Mappings + playbooks for migrating legacy docs (Obsidian, MADR) into a forgeplan graph. |
+| Brownfield ingest | forgeplan-brownfield-pack | 5 mappings (c4, ddd, madr, obsidian, autoresearch) + 12 extraction skills + 2 playbooks for migrating legacy code + docs into a forgeplan graph. |
 
 Install command: `/plugin install <plugin-name>@ForgePlan-marketplace`.
 

--- a/docs/AUTORESEARCH-INTEGRATION-RU.md
+++ b/docs/AUTORESEARCH-INTEGRATION-RU.md
@@ -173,4 +173,5 @@ forgeplan --version          # CLI forgeplan
 - Оригинал Карпатого — [github.com/karpathy/autoresearch](https://github.com/karpathy/autoresearch)
 - [METHODOLOGIES-RU.md](METHODOLOGIES-RU.md) — autoresearch как recommended companion
 - [PLAYBOOK-RU.md](PLAYBOOK-RU.md) — сценарий «итерации под мерой»
-- [`plugins/forgeplan-brownfield-pack/integration/autoresearch-hooks.md`](../plugins/forgeplan-brownfield-pack/integration/autoresearch-hooks.md) — карта соответствия для 12 скиллов brownfield
+- [`plugins/forgeplan-brownfield-pack/integration/autoresearch-hooks.md`](../plugins/forgeplan-brownfield-pack/integration/autoresearch-hooks.md) — **исходящее** направление: карта соответствия для 12 скиллов brownfield (скилл → команда + режим autoresearch)
+- [`plugins/forgeplan-brownfield-pack/mappings/autoresearch-to-forge.yaml`](../plugins/forgeplan-brownfield-pack/mappings/autoresearch-to-forge.yaml) — **входящее** направление: выводы autoresearch (журналы + per-mode артефакты в `.autoresearch/`) → kind-ы артефактов forgeplan. Companion к файлу hooks выше.

--- a/docs/AUTORESEARCH-INTEGRATION.md
+++ b/docs/AUTORESEARCH-INTEGRATION.md
@@ -173,4 +173,5 @@ forgeplan --version          # forgeplan CLI
 - Karpathy's original — [github.com/karpathy/autoresearch](https://github.com/karpathy/autoresearch)
 - [METHODOLOGIES.md](METHODOLOGIES.md) — autoresearch listed as recommended companion
 - [PLAYBOOK.md](PLAYBOOK.md) — use-case "metric-driven iteration"
-- [`plugins/forgeplan-brownfield-pack/integration/autoresearch-hooks.md`](../plugins/forgeplan-brownfield-pack/integration/autoresearch-hooks.md) — per-skill mapping for the 12 brownfield skills
+- [`plugins/forgeplan-brownfield-pack/integration/autoresearch-hooks.md`](../plugins/forgeplan-brownfield-pack/integration/autoresearch-hooks.md) — **outbound** direction: per-skill mapping for the 12 brownfield skills (skill → autoresearch command + mode)
+- [`plugins/forgeplan-brownfield-pack/mappings/autoresearch-to-forge.yaml`](../plugins/forgeplan-brownfield-pack/mappings/autoresearch-to-forge.yaml) — **inbound** direction: autoresearch outputs (journals + per-mode artifacts in `.autoresearch/`) → forge artifact kinds. Companion to the hooks file above.

--- a/docs/METHODOLOGIES-RU.md
+++ b/docs/METHODOLOGIES-RU.md
@@ -185,6 +185,20 @@
 
 **Статус**: как у DDD — есть только карта `c4-to-forge.yaml` в `forgeplan-brownfield-pack` (переводит C4-документы в артефакты forgeplan). Своего C4-агента или скилла моделирования нет.
 
+### MADR (Markdown Architectural Decision Records)
+
+**Что это**: формат markdown-шаблона для ADR ([adr.github.io/madr](https://adr.github.io/madr/)).
+
+**Статус**: только ингест. Карта `madr-to-forge.yaml` в `forgeplan-brownfield-pack` конвертирует MADR 3.x/4.x ADR-файлы (в `docs/adr/`, `docs/decisions/` и т.д.) в forgeplan `adr` — с нормализацией статусов (proposed → draft, accepted → active, rejected → deprecated, superseded → superseded) и извлечением ссылок supersedes/superseded by.
+
+Для новых ADR используй `forgeplan new adr` (DDR-шаблон для Deep+).
+
+### Obsidian (импорт волта)
+
+**Что это**: markdown-first инструмент управления знаниями ([obsidian.md](https://obsidian.md/)). Волт использует `[[wikilinks]]`, `#теги`, frontmatter и иерархии папок (PARA, Johnny.Decimal, Zettelkasten).
+
+**Статус**: только ингест. Карта `obsidian-to-forge.yaml` в `forgeplan-brownfield-pack` обходит Obsidian-волт (определяется по маркеру `.obsidian/`) и ингестит ноты как Note/Epic/PRD/ADR/Hypothesis по 4-уровневому приоритету сигналов: frontmatter `kind:` → тег (`#prd`, `#adr`, ...) → паттерн папки → fallback в Note. MOC-файлы превращаются в Epic; project-ноты в PRD; теггированные decision-ноты в ADR (с делегацией в `madr-to-forge` если структура MADR-shaped).
+
 ---
 
 ## Не в этой экосистеме (упоминается, но не в forgeplan и не в маркетплейсе)
@@ -234,7 +248,9 @@
 | Laws of UX | Плагин `laws-of-ux` | `/ux-review`, `/ux-law <имя>` |
 | DDD | `agents-pro` + brownfield-pack | Только консультации — движка нет |
 | C4 | Карта в brownfield-pack | Только YAML-преобразование |
-| Autoresearch | Внешний companion (`uditgoenka/autoresearch`) | Ставится отдельно; см. [AUTORESEARCH-INTEGRATION-RU.md](AUTORESEARCH-INTEGRATION-RU.md) для способов интеграции |
+| MADR | Карта в brownfield-pack | Только ингест через `madr-to-forge.yaml` |
+| Obsidian | Карта в brownfield-pack | Только ингест через `obsidian-to-forge.yaml` |
+| Autoresearch | Внешний companion (`uditgoenka/autoresearch`) | Ставится отдельно; ингест через `autoresearch-to-forge.yaml`. См. [AUTORESEARCH-INTEGRATION-RU.md](AUTORESEARCH-INTEGRATION-RU.md). |
 | RIPER | НЕТ в экосистеме | Вручную — связка `/research` → `/refine` → `/rfc` → `/sprint` → `/audit` |
 | AI-SDLC | НЕ названо так, приближение через `/autorun` | `/autorun "<задача>"` |
 

--- a/docs/METHODOLOGIES.md
+++ b/docs/METHODOLOGIES.md
@@ -185,6 +185,20 @@ If you want full DDD modelling — combine the agent + brownfield pack + your ow
 
 **Status**: similar to DDD — we ship `c4-to-forge.yaml` mapping in `forgeplan-brownfield-pack` (translates C4 docs into forgeplan artifacts) but no C4-specific agent or modelling skill.
 
+### MADR (Markdown Architectural Decision Records)
+
+**What it is**: a markdown ADR template format ([adr.github.io/madr](https://adr.github.io/madr/)).
+
+**Status**: ingest-only. `madr-to-forge.yaml` mapping in `forgeplan-brownfield-pack` converts MADR 3.x/4.x ADR files (in `docs/adr/`, `docs/decisions/`, etc.) into forgeplan `adr` artifacts, with status normalization (proposed → draft, accepted → active, rejected → deprecated, superseded → superseded) and supersession-link extraction.
+
+For new ADRs, use `forgeplan new adr` (DDR template for Deep+).
+
+### Obsidian (vault import)
+
+**What it is**: a markdown-first knowledge management tool ([obsidian.md](https://obsidian.md/)). Vaults use `[[wikilinks]]`, `#tags`, frontmatter, and folder hierarchies (PARA, Johnny.Decimal, Zettelkasten).
+
+**Status**: ingest-only. `obsidian-to-forge.yaml` mapping in `forgeplan-brownfield-pack` walks an Obsidian vault (detected by `.obsidian/` directory marker) and ingests notes as Note/Epic/PRD/ADR/Hypothesis based on a 4-tier signal priority: frontmatter `kind:` → tag (`#prd`, `#adr`, ...) → folder pattern → default to Note. MOC files map to Epic; Project notes to PRD; tagged decision notes to ADR (delegating to `madr-to-forge` if MADR-shaped).
+
 ---
 
 ## Not in this ecosystem (mentioned but not part of forgeplan or marketplace)
@@ -234,7 +248,9 @@ If you want to read the original BMAD spec → see `sources/BMAD-METHOD/` in the
 | Laws of UX | `laws-of-ux` plugin | `/ux-review`, `/ux-law <name>` |
 | DDD | `agents-pro` + brownfield pack | Advisory only — no engine |
 | C4 | brownfield pack mapping | YAML conversion only |
-| Autoresearch | external companion (`uditgoenka/autoresearch`) | Install separately; see [AUTORESEARCH-INTEGRATION.md](AUTORESEARCH-INTEGRATION.md) for integration patterns |
+| MADR | brownfield pack mapping | `madr-to-forge.yaml` ingest only |
+| Obsidian | brownfield pack mapping | `obsidian-to-forge.yaml` ingest only |
+| Autoresearch | external companion (`uditgoenka/autoresearch`) | Install separately; ingest via `autoresearch-to-forge.yaml`. See [AUTORESEARCH-INTEGRATION.md](AUTORESEARCH-INTEGRATION.md). |
 | RIPER | NOT in ecosystem | Manual — chain `/research` → `/refine` → `/rfc` → `/sprint` → `/audit` |
 | AI-SDLC | NOT named, approximated by `/autorun` | `/autorun "<task>"` |
 

--- a/docs/USAGE-GUIDE-RU.md
+++ b/docs/USAGE-GUIDE-RU.md
@@ -256,7 +256,7 @@ Worked example (`добавить аутентификацию` end-to-end) — 
 
 ### `forgeplan-brownfield-pack` — Legacy ингест
 
-Mappings + playbooks для brownfield миграции (Obsidian, MADR, ad-hoc markdown → forgeplan граф). Композит `c4-architecture`, `autoresearch`, `ddd-expert`, `feature-dev`. См. [plugins/forgeplan-brownfield-pack/README-RU.md](../plugins/forgeplan-brownfield-pack/README-RU.md).
+12 скиллов извлечения + 2 playbooks + 5 карт соответствия (`c4-to-forge`, `ddd-to-forge`, `madr-to-forge`, `obsidian-to-forge`, `autoresearch-to-forge`) → граф forgeplan. Композит `c4-architecture`, `autoresearch`, `ddd-expert`, `feature-dev`. См. [plugins/forgeplan-brownfield-pack/README-RU.md](../plugins/forgeplan-brownfield-pack/README-RU.md).
 
 **Требует**: CLI forgeplan v0.25+.
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -256,7 +256,7 @@ Structured reasoning for decompose / evaluate / reason / lookup. 224 FPF spec se
 
 ### `forgeplan-brownfield-pack` — Legacy ingest
 
-Mappings + playbooks for brownfield migration (Obsidian, MADR, ad-hoc markdown → forgeplan graph). Composes `c4-architecture`, `autoresearch`, `ddd-expert`, `feature-dev`. See [plugins/forgeplan-brownfield-pack/README.md](../plugins/forgeplan-brownfield-pack/README.md).
+12 extraction skills + 2 playbooks + 5 mappings (`c4-to-forge`, `ddd-to-forge`, `madr-to-forge`, `obsidian-to-forge`, `autoresearch-to-forge`) → forgeplan graph. Composes `c4-architecture`, `autoresearch`, `ddd-expert`, `feature-dev`. See [plugins/forgeplan-brownfield-pack/README.md](../plugins/forgeplan-brownfield-pack/README.md).
 
 **Requires**: forgeplan CLI v0.25+.
 

--- a/plugins/forgeplan-brownfield-pack/.claude-plugin/plugin.json
+++ b/plugins/forgeplan-brownfield-pack/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forgeplan-brownfield-pack",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Brownfield extraction pack for forgeplan — turns legacy code + docs into a structured forgeplan graph. Ships 12 extraction skills (ubiquitous-language, use-case-miner, intent-inferrer, invariant-detector, causal-linker, hypothesis-triangulator, interview-packager, scenario-writer, kg-curator, canonical-reproducer, reproducibility-validator, rag-packager), 2 orchestration playbooks (extract-business-logic, phase-transitions), 3 integration recipes (autoresearch hooks, forgeplan MCP additions, RAG export), 5 mappings (c4-to-forge, ddd-to-forge, madr-to-forge, obsidian-to-forge, autoresearch-to-forge), templates, examples, and methodology docs. Implements two-tier extraction (Factum vs Intent) with confidence taxonomy and ADI cycle.",
   "author": {
     "name": "ForgePlan"

--- a/plugins/forgeplan-brownfield-pack/README-RU.md
+++ b/plugins/forgeplan-brownfield-pack/README-RU.md
@@ -46,10 +46,15 @@
 - `forgeplan-mcp-additions.md` — дополнения forgeplan MCP под специфические brownfield-операции
 - `rag-export-format.md` — формат вывода для RAG packager
 
-### 2 карты соответствия (`mappings/`)
+### 5 карт соответствия (`mappings/`)
 
-- `c4-to-forge.yaml` — C4 Context/Container/Component → Epic + PRD + Notes в forgeplan (проверена CL3 на репозитории Forgeplan, 2026-04-20)
-- `ddd-to-forge.yaml` — карта ограниченных контекстов DDD → Epic + PRD + Spec
+Все пять используют schema-v1.0; каждая создаёт артефакты forgeplan с секцией `## Sources` для трассировки.
+
+- `c4-to-forge.yaml` — C4 Context/Container/Component → Epic + PRD + Notes (проверена CL3 на репозитории Forgeplan, 2026-04-20)
+- `ddd-to-forge.yaml` — карта ограниченных контекстов DDD → Epic + PRD + Spec (Spike-3, 2026-04-21)
+- `madr-to-forge.yaml` — MADR 3.x/4.x markdown ADR → forgeplan `adr` (1:1) с нормализацией статусов и извлечением ссылок supersedes/superseded by
+- `obsidian-to-forge.yaml` — Obsidian-волт (маркер `.obsidian/`) → Note/Epic/PRD/ADR/Hypothesis с 4-уровневым приоритетом сигналов (frontmatter → тег → папка → fallback) и ленивым резолвом wikilinks
+- `autoresearch-to-forge.yaml` — выводы autoresearch v2.x (7 режимов: glossary/use-case/invariant/intent/triangulate/gherkin/canonical) → соответствующие kind-ы forgeplan. Companion (обратное направление) к `integration/autoresearch-hooks.md`.
 
 ### Шаблоны и примеры
 

--- a/plugins/forgeplan-brownfield-pack/README.md
+++ b/plugins/forgeplan-brownfield-pack/README.md
@@ -46,10 +46,15 @@ A Claude Code marketplace pack for **brownfield extraction**: take inherited cod
 - `forgeplan-mcp-additions.md` — additions to forgeplan MCP for brownfield-specific operations
 - `rag-export-format.md` — output format for the RAG packager
 
-### 2 mappings (`mappings/`)
+### 5 mappings (`mappings/`)
+
+All five follow schema-v1.0; each emits forge artifacts with a `## Sources` section for traceability.
 
 - `c4-to-forge.yaml` — C4 Context/Container/Component → forgeplan Epic + PRDs + Notes (validated CL3 on Forgeplan repo, 2026-04-20)
-- `ddd-to-forge.yaml` — DDD bounded-context map → Epic + PRDs + Spec
+- `ddd-to-forge.yaml` — DDD bounded-context map → Epic + PRDs + Spec (Spike-3, 2026-04-21)
+- `madr-to-forge.yaml` — MADR 3.x/4.x ADR markdown → forgeplan `adr` (1:1) with status normalization and supersession-link extraction
+- `obsidian-to-forge.yaml` — Obsidian vault (`.obsidian/` marker) → Note/Epic/PRD/ADR/Hypothesis with 4-tier signal priority (frontmatter → tag → folder → default) and lazy wikilink resolution
+- `autoresearch-to-forge.yaml` — autoresearch v2.x outputs (7 modes: glossary/use-case/invariant/intent/triangulate/gherkin/canonical) → matching forge kinds. Companion (inverse direction) of `integration/autoresearch-hooks.md`.
 
 ### Templates and examples
 


### PR DESCRIPTION
## Summary

Closes the documentation gap from PR #46 (v1.18.0). The mappings YAMLs were shipped but several user-facing docs that point at them still said "2 mappings" and only listed `c4-to-forge` + `ddd-to-forge`.

## Files changed (13)

| File | Change |
|---|---|
| `plugins/forgeplan-brownfield-pack/README.md` + `-RU.md` | Section header "2 mappings" → "5 mappings"; lists all five (c4, ddd, madr, obsidian, autoresearch) with one-line descriptions |
| `docs/METHODOLOGIES.md` + `-RU.md` | New per-methodology sections for **MADR** and **Obsidian** (alongside DDD and C4). Quick lookup table extended with rows for MADR, Obsidian, plus updated Autoresearch row mentioning the inbound mapping |
| `docs/USAGE-GUIDE.md` + `-RU.md` | brownfield-pack section description now lists all five mappings by name |
| `docs/ARCHITECTURE.md` + `-RU.md` | Capability row updated from "Mappings + playbooks for migrating legacy docs (Obsidian, MADR)" to "5 mappings + 12 extraction skills + 2 playbooks" |
| `docs/AUTORESEARCH-INTEGRATION.md` + `-RU.md` | "See also" distinguishes outbound (`autoresearch-hooks.md`: skill → autoresearch command) vs inbound (`autoresearch-to-forge.yaml`: outputs → forge artifacts) directions |
| `plugin.json` | brownfield-pack 1.3.0 → 1.3.1 |
| `marketplace.json` | catalog 1.18.0 → 1.18.1; brownfield-pack entry 1.3.0 → 1.3.1 |
| `CHANGELOG.md` | 1.18.1 entry |

## Verification

- ✅ `./scripts/validate-all-plugins.sh` — ALL PASSED
- ✅ All EN/RU pairs updated symmetrically
- ✅ No mapping YAMLs / no skill content touched — pure docs

## Test plan

- [x] Validation script passes
- [x] Versions bumped (patch) consistently across plugin.json + marketplace.json + CHANGELOG
- [x] Both English and Russian docs updated in lockstep
- [x] No links broken (existing internal links preserved; new ones point at files already on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)