### PR TITLE
fix(docs): v1.18.2 — correct marketplace name case in README update command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.18.1"
+    "version": "1.18.2"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the ForgePlan Marketplace will be documented in this file
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.2] - 2026-05-08
+
+User-reported bug: `/plugin marketplace update forgeplan-marketplace` (lowercase) fails because Claude Code is case-sensitive and the canonical name in `marketplace.json` is `ForgePlan-marketplace` (PascalCase). Two top-level READMEs printed the broken lowercase form.
+
+### Fixed
+- `README.md`: update command line 310 — `forgeplan-marketplace` → `ForgePlan-marketplace`.
+- `README-RU.md`: update command line 284 — same fix.
+- `marketplace.json`: catalog 1.18.1 → **1.18.2**.
+
+### Notes
+`docs/USAGE-GUIDE.md` and `-RU.md` already documented the case-sensitivity correctly (with explicit "Wrong: forgeplan-marketplace / Right: ForgePlan-marketplace" examples) — those were intentional and not touched. Plugin install commands across all docs already use the correct `@ForgePlan-marketplace` form (148+ occurrences, none broken).
+
+The marketplace name in your local registry is set when you run `/plugin marketplace add ForgePlan/marketplace` — so the canonical name is what GitHub reports for the marketplace.json `"name"` field. PascalCase F + P, lowercase rest. No version bump for plugins; this is a docs-only patch.
+
 ## [1.18.1] - 2026-05-08
 
 Documentation sync for v1.18.0 — brings README/METHODOLOGIES/USAGE-GUIDE/ARCHITECTURE/AUTORESEARCH-INTEGRATION docs in line with the new mappings shipped in v1.18.0. No code or mapping changes.

--- a/README-RU.md
+++ b/README-RU.md
@@ -281,7 +281,7 @@ Standalone-репо **автоматически зеркалируются** и
 Получить последние версии плагинов:
 
 ```bash
-/plugin marketplace update forgeplan-marketplace
+/plugin marketplace update ForgePlan-marketplace
 ```
 
 ## Участие в разработке

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ These standalone repos are **auto-mirrored** from the marketplace — same conte
 Get the latest plugins:
 
 ```bash
-/plugin marketplace update forgeplan-marketplace
+/plugin marketplace update ForgePlan-marketplace
 ```
 
 ## Contributing


### PR DESCRIPTION
## Summary

**User-reported bug**: `/plugin marketplace update forgeplan-marketplace` (lowercase) fails because Claude Code is case-sensitive and the canonical marketplace name in `marketplace.json` is `ForgePlan-marketplace` (PascalCase F + P).

Two top-level READMEs printed the broken lowercase form. Fixed.

## What changed

| File | Line | Before | After |
|---|---|---|---|
| `README.md` | 310 | `/plugin marketplace update forgeplan-marketplace` | `/plugin marketplace update ForgePlan-marketplace` |
| `README-RU.md` | 284 | same lowercase | same fix |
| `marketplace.json` | — | catalog 1.18.1 | catalog **1.18.2** |
| `CHANGELOG.md` | — | — | 1.18.2 entry explaining the bug + scope |

## What was NOT changed (intentionally)

- **`docs/USAGE-GUIDE.md` + `-RU.md`** lines 301-307: these already document case-sensitivity correctly with explicit `# Wrong: forgeplan-marketplace` / `# Right: ForgePlan-marketplace` examples. The lowercase appears in a "Wrong" block on purpose — leaving alone.
- **148+ plugin install commands** across all docs (`@ForgePlan-marketplace` form) — already correct everywhere.

## Verification

- ✅ `./scripts/validate-all-plugins.sh` — ALL PASSED.
- ✅ `grep -rn 'forgeplan-marketplace' --include="*.md" --include="*.json"` — only matches inside `docs/USAGE-GUIDE*` (intentional Wrong/Right) and bare dirname uses (`cd forgeplan-marketplace` — that's the actual directory name, lowercase). No more broken update commands.
- ✅ Diff is minimal — 2 single-line README fixes + version bump + CHANGELOG entry.

## Test plan

- [x] Validation script passes
- [x] Both English and Russian READMEs fixed
- [x] No false positives in remaining docs (USAGE-GUIDE intentional, dirname uses are correct)
- [x] Patch version bump (docs-only — convention per CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)