### PR TITLE
feat(fpl-skills): v1.6.0 — wire forgeplan dispatch + claim loop in /sprint + /autorun

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.18.2"
+    "version": "1.19.0"
   },
   "plugins": [
     {
       "name": "fpl-skills",
       "source": "./plugins/fpl-skills",
-      "description": "Flagship workflow plugin for the ForgePlan ecosystem. 21 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, /riper RIPER orchestrator, plus session helpers) + dev-advisor agent + 4 hooks. Every workflow skill is forgeplan-aware. Full feature parity with the legacy dev-toolkit plus 18 additional skills built on forgeplan's artifact lifecycle.",
-      "version": "1.5.0",
+      "description": "Flagship workflow plugin for the ForgePlan ecosystem. 21 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, /riper RIPER orchestrator, plus session helpers) + dev-advisor agent + 4 hooks. Every workflow skill is forgeplan-aware. /sprint and /autorun wire the PRD-057 dispatcher and per-teammate forgeplan claim/evidence loop for artifact-driven sprints. Full feature parity with the legacy dev-toolkit plus 18 additional skills built on forgeplan's artifact lifecycle.",
+      "version": "1.6.0",
       "author": {
         "name": "ForgePlan"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to the ForgePlan Marketplace will be documented in this file
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.0] - 2026-05-08
+
+`/sprint` and `/autorun` now wire the **forgeplan dispatch + claim + evidence loop** for artifact-driven sprints. Tasks taken from forgeplan as artifacts (PRD-NNN/RFC-NNN/SPEC-NNN), parallel-safe grouping computed by PRD-057 dispatcher, soft-claim per teammate, evidence emitted per artifact at wave-close.
+
+This is **option A** from the agent-team integration roadmap — prose-only patch, no new MCP tools, no new code. Uses existing forgeplan CLI capabilities (`dispatch`, `claim`, `new evidence`) wired into skill prose so teammates pull tasks from the artifact graph instead of operating in a vacuum.
+
+### Added
+- `fpl-skills` v1.5.0 → **1.6.0** (minor — new behavior in two skills, fully backward-compatible):
+  - `/sprint` SKILL.md gains three new sub-steps:
+    - **§4a-bis "Forgeplan dispatch (artifact-driven sprints)"** — when wave plan tasks reference forgeplan IDs, calls `forgeplan dispatch -n {agents} --json` for a parallel-safe grouping with Jaccard file-overlap detection (threshold 0.3, PRD-057). Used as a second-opinion check on the human-built wave plan; surfaces conflicts in a 3-row decision table (agree → go, conservative → go, disagree → stop and re-check ownership).
+    - **§4b.g "Forgeplan-aware teammate prompt addendum"** — every teammate working on an artifact runs `forgeplan claim {artifact-id} --agent {kebab-name}` before starting (PRD-057 soft signal). Skipped if no artifact ID in task.
+    - **§4b-bis "Per-artifact evidence emission"** — at wave-close, team-lead emits `forgeplan new evidence` + `forgeplan link --relation informs` per completed artifact (one evidence per artifact, not per teammate, not per wave — because a single artifact may span multiple teammates and waves).
+  - `/sprint` "Forgeplan integration" section restructured: "Before / During / After" — During row mentions dispatch + claim flow; existing pre/post recommendations preserved.
+  - `/autorun` SKILL.md autopilot directive extended with FORGEPLAN-AWARE block — surfaces the dispatch/claim/evidence wiring to delegated skills so they don't have to re-discover it.
+  - `/autorun` "Forgeplan integration (clarified)" table row 2 (forgeplan CLI without forgeplan-workflow) updated to mention dispatch + claim per-teammate when task is artifact-driven.
+
+### Changed
+- `marketplace.json`: catalog 1.18.2 → **1.19.0** (minor — fpl-skills feature add); fpl-skills entry 1.5.0 → 1.6.0; description mentions PRD-057 dispatcher and claim/evidence loop.
+- `plugin.json` (fpl-skills): version 1.5.0 → 1.6.0.
+
+### Notes
+**Backward compatibility**: skills detect artifact-driven mode by presence of forgeplan IDs in task descriptions. Chat-driven sprints (no IDs) take the existing path unchanged — no claim, no evidence per artifact, no dispatch. Existing `/sprint` invocations continue to work identically.
+
+**No new MCP tools added** — uses existing `forgeplan dispatch`/`claim`/`new evidence` CLI subcommands (forgeplan ships an MCP server via `forgeplan serve --stdio`; that path is option B for a future patch and is out of scope here).
+
+**Soft-claim trade-off**: `forgeplan claim` is a soft signal, not a hard lock. Two parallel sessions claiming the same artifact will both succeed locally; conflict detection happens at the artifact graph level, not at claim-time. Acceptable for current single-orchestrator use; if multi-orchestrator races become real, upstream forgeplan would add TTL + lease-renewal to claim.
+
 ## [1.18.2] - 2026-05-08
 
 User-reported bug: `/plugin marketplace update forgeplan-marketplace` (lowercase) fails because Claude Code is case-sensitive and the canonical name in `marketplace.json` is `ForgePlan-marketplace` (PascalCase). Two top-level READMEs printed the broken lowercase form.

--- a/plugins/fpl-skills/.claude-plugin/plugin.json
+++ b/plugins/fpl-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fpl-skills",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Flagship workflow plugin for the ForgePlan ecosystem. 21 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, /riper RIPER orchestrator, plus session helpers) + dev-advisor agent + 4 hooks. Every workflow skill is forgeplan-aware. Full feature parity with the legacy dev-toolkit plus 18 additional skills built on forgeplan's artifact lifecycle.",
   "author": {
     "name": "ForgePlan"

--- a/plugins/fpl-skills/skills/autorun/SKILL.md
+++ b/plugins/fpl-skills/skills/autorun/SKILL.md
@@ -108,6 +108,12 @@ AUTOPILOT MODE — green light from user, do NOT pause for approval.
 Skip every "Proceed?" / "Continue to next wave?" / "Запускаем?" prompt — assume YES.
 Resolve blockers via ADI (Abduct → Induct → Deduce), 3 rounds max per blocker.
 Only stop on red-line actions (see /autorun red lines). Surface state and exit cleanly when red line hit.
+
+FORGEPLAN-AWARE — if forgeplan CLI is on $PATH and the task has artifact IDs:
+- /sprint will use `forgeplan dispatch -n N --json` for parallel-safe wave plan (4a-bis).
+- Each teammate runs `forgeplan claim <ID> --agent <name>` before starting (4b.g).
+- Team-lead emits `forgeplan new evidence` per completed artifact at wave-close (4b-bis).
+- See sprint SKILL.md sections 4a-bis / 4b.g / 4b-bis for the wired pattern.
 ```
 
 ---
@@ -208,7 +214,7 @@ The probe block at the start of this skill (step 2 — Detect environment) alrea
 | Detected | What `/autorun` does |
 |---|---|
 | `forgeplan-workflow` plugin installed | **Delegates to `/forge-cycle "<task>"`** — full route → shape → build → evidence → activate. No pauses. |
-| `forgeplan` CLI but no `forgeplan-workflow` | Runs `research → sprint → audit → report` and **inserts manual `forgeplan` calls between phases** (route → new prd → new evidence → activate). All non-interactive. |
+| `forgeplan` CLI but no `forgeplan-workflow` | Runs `research → sprint → audit → report` and **inserts manual `forgeplan` calls between phases** (route → new prd → new evidence → activate). All non-interactive. When the task is artifact-driven, `/sprint` automatically uses `forgeplan dispatch` for parallel-safe wave grouping and `forgeplan claim` per teammate (sprint SKILL.md §4a-bis / 4b.g). |
 | Neither | Runs the standard pipeline. Prints a single warning at the start: "no forgeplan integration; artifact graph will not be updated". |
 
 ### Want full automation?

--- a/plugins/fpl-skills/skills/sprint/SKILL.md
+++ b/plugins/fpl-skills/skills/sprint/SKILL.md
@@ -298,6 +298,25 @@ Options:
 4. teammates = all the work
 ```
 
+### 4a-bis. Forgeplan dispatch (artifact-driven sprints)
+
+If the wave plan is **artifact-driven** — each task references a forgeplan ID (PRD-NNN, RFC-NNN, SPEC-NNN, etc.) — wire the dispatcher and claim-loop in. If the plan is purely chat-driven (no artifact IDs), skip this sub-step and proceed to 4b.
+
+```bash
+# Probe and dispatch — once, before Wave 1 spawn.
+command -v forgeplan && forgeplan dispatch -n {agents-per-wave} --json
+```
+
+`forgeplan dispatch` returns a parallel-safe grouping (PRD-057 dispatcher with Jaccard file-overlap detection at threshold 0.3). Use it as a **second opinion** on your wave plan:
+
+| Dispatch says | Your plan says | Action |
+|---|---|---|
+| Group A: [PRD-001, PRD-003] | Same wave | ✅ go |
+| Group A: [PRD-001, PRD-003] | Different waves | OK — your split is more conservative; go |
+| Group A: [PRD-001, PRD-003] | Same wave, but PRD-001 and PRD-003 share files in your file-ownership table | ⚠️ stop — your file map disagrees with Jaccard. Re-check the ownership table before spawning |
+
+Pass each agent the artifact ID they own — see 4b teammate prompt addendum below.
+
 ### 4b. Team-lead prompt
 
 ```
@@ -327,6 +346,11 @@ For each Wave (sequential):
    d) Requirements
    e) "Follow CLAUDE.md project rules"
    f) "Report back: files created/modified, LOC, issues"
+   g) Forgeplan-aware (only if task references an artifact ID like PRD-NNN/RFC-NNN/SPEC-NNN):
+      - BEFORE starting work: run `forgeplan claim {artifact-id} --agent {kebab-name}`
+        — soft signal "I'm working on this" (PRD-057). Skip if claim already held by self.
+      - AFTER completing: report the artifact ID + LOC summary so team-lead can
+        emit `forgeplan new evidence` post-wave (see step 4b-bis below).
 
 3. WAIT for all wave agents to complete.
 
@@ -348,6 +372,20 @@ After ALL waves:
 4. Shutdown teammates.
 5. Signal completion.
 ```
+
+### 4b-bis. Per-artifact evidence emission (artifact-driven sprints)
+
+If the sprint is artifact-driven (per 4a-bis), team-lead emits **one evidence per completed artifact** at wave-close — not per teammate, not per wave.
+
+```bash
+# After each artifact is complete (all teammates working on it reported done):
+forgeplan new evidence "{artifact-id}: {what shipped} — {tests/smoke status}"
+forgeplan link EVID-MMM {artifact-id} --relation informs
+```
+
+Why per-artifact and not per-teammate: a single artifact may be built by 2-3 teammates across waves (Wave 1: scaffolding + Wave 2: integration). Evidence describes the *artifact's* state, not who pushed which line.
+
+For chat-driven sprints (no artifact IDs), skip — emit one summary evidence at sprint-end via the existing post-sprint section below.
 
 ### 4c. Dynamic teammates
 
@@ -460,7 +498,7 @@ Emit the **Sprint Complete** report — format in [`references/OUTPUT-FORMATS.md
 
 ## Forgeplan integration
 
-If the `forgeplan` CLI is on `$PATH` (probe with `command -v forgeplan`), this skill is **forgeplan-aware** — it recommends the right CLI calls but does not invoke them itself, so you stay in control of artifact lifecycle.
+If the `forgeplan` CLI is on `$PATH` (probe with `command -v forgeplan`), this skill is **forgeplan-aware**. The **dispatch + claim + evidence loop** is wired into Step 4 (4a-bis, 4b.g, 4b-bis) for artifact-driven sprints; the recommendations below are for human-orchestrated runs.
 
 ### Before `/sprint <task>`
 
@@ -473,10 +511,21 @@ forgeplan validate PRD-NNN         # gate before sprint
 forgeplan reason PRD-NNN           # ADI 3+ hypotheses (Deep+: required)
 ```
 
+### During `/sprint` (artifact-driven mode — see 4a-bis)
+
+```bash
+forgeplan dispatch -n {agents-per-wave} --json   # parallel-safe grouping (PRD-057)
+# Per teammate, in their spawn prompt:
+forgeplan claim {artifact-id} --agent {kebab-name}   # soft signal "I'm working on this"
+# Per artifact at wave-close, by team-lead:
+forgeplan new evidence "{artifact-id}: ..."
+forgeplan link EVID-MMM {artifact-id} --relation informs
+```
+
 ### After `/sprint` completes
 
 ```bash
-forgeplan new evidence "<task>: tests pass / smoke OK / N waves merged"
+forgeplan new evidence "<task>: tests pass / smoke OK / N waves merged"   # for chat-driven sprints, or sprint-level summary
 forgeplan link EVID-MMM PRD-NNN --relation informs
 forgeplan score PRD-NNN            # R_eff > 0?
 forgeplan activate PRD-NNN         # draft → active


### PR DESCRIPTION
## Summary

**Option A** from the agent-team integration roadmap. Prose-only patch — `/sprint` and `/autorun` now wire the existing `forgeplan` CLI (`dispatch`, `claim`, `new evidence`) so teammates pull tasks from the artifact graph instead of operating in a vacuum.

No new MCP tools, no new code in forgeplan — uses what PRD-057 (dispatcher) already ships.

## What changes

### `/sprint` SKILL.md — three new sub-sections

| Section | What | When it fires |
|---|---|---|
| **4a-bis "Forgeplan dispatch"** | Calls `forgeplan dispatch -n {agents-per-wave} --json` for parallel-safe grouping with Jaccard file-overlap detection (threshold 0.3). Used as a second-opinion check on the human-built wave plan. 3-row decision table: agree → go, conservative → go, disagree → stop and re-check ownership. | Wave plan has artifact IDs |
| **4b.g** | Teammate prompt addendum: every teammate working on an artifact runs `forgeplan claim {artifact-id} --agent {kebab-name}` before starting. Skipped if no artifact ID. | Per-teammate spawn |
| **4b-bis "Per-artifact evidence emission"** | Team-lead emits `forgeplan new evidence` + `forgeplan link --relation informs` per completed artifact at wave-close (one evidence per artifact, not per teammate, not per wave). | Wave-close, artifact-driven mode |

Existing "Forgeplan integration" section at end of file restructured: "Before / During / After" — During row now lists the dispatch + claim flow.

### `/autorun` SKILL.md — two minor edits

- **Autopilot directive** extended with `FORGEPLAN-AWARE` block — surfaces the dispatch/claim/evidence wiring to delegated skills.
- **"Forgeplan integration (clarified)" table** row 2 (forgeplan CLI without forgeplan-workflow) — updated to mention `dispatch` + `claim` per-teammate when task is artifact-driven.

## Backward compatibility

Skills detect **artifact-driven mode** by presence of forgeplan IDs (`PRD-NNN`/`RFC-NNN`/`SPEC-NNN`) in task descriptions. Chat-driven sprints take the existing path unchanged — no `claim`, no per-artifact evidence, no `dispatch` call.

Existing `/sprint` invocations behave identically.

## Verification

- ✅ `./scripts/validate-all-plugins.sh` — ALL PASSED
- ✅ Both skills' SKILL.md remain forgeplan-aware probe-first (`command -v forgeplan`) — runs without forgeplan CLI installed
- ✅ Diff is minimal — 89 insertions across 5 files (2 SKILL.md + 2 manifests + CHANGELOG)

## Test plan

- [x] Validation script passes
- [x] No new MCP tools (option A scope respected)
- [x] Backward-compatible — chat-driven sprints unchanged
- [x] Versions bumped (fpl-skills 1.5.0 → 1.6.0 minor; catalog 1.18.2 → 1.19.0 minor)
- [x] CHANGELOG entry explains scope, trade-offs, and what's NOT in scope (option B / MCP wiring)

## Trade-off (documented in CHANGELOG)

`forgeplan claim` is a **soft signal**, not a hard lock. Two parallel sessions claiming the same artifact will both succeed locally; conflict detection happens at the graph level, not at claim-time. Acceptable for current single-orchestrator use; if multi-orchestrator races become real in production, upstream forgeplan would need to add TTL + lease-renewal to claim — that's not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)