### PR TITLE
feat(fpl-skills): v1.7.0 — forgeplan operating contract enforcement (PRD-018)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.19.0"
+    "version": "1.20.0"
   },
   "plugins": [
     {
       "name": "fpl-skills",
       "source": "./plugins/fpl-skills",
-      "description": "Flagship workflow plugin for the ForgePlan ecosystem. 21 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, /riper RIPER orchestrator, plus session helpers) + dev-advisor agent + 4 hooks. Every workflow skill is forgeplan-aware. /sprint and /autorun wire the PRD-057 dispatcher and per-teammate forgeplan claim/evidence loop for artifact-driven sprints. Full feature parity with the legacy dev-toolkit plus 18 additional skills built on forgeplan's artifact lifecycle.",
-      "version": "1.6.0",
+      "description": "Flagship workflow plugin for the ForgePlan ecosystem. 21 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, /riper RIPER orchestrator, plus session helpers) + dev-advisor agent + 4 hooks. /fpl-init injects a 13-line forgeplan operating contract into project CLAUDE.md (idempotent v1 marker). SessionStart hook surfaces concrete next-action when forgeplan health is non-clean (orphans/stubs/dups/stale). /sprint and /autorun wire the PRD-057 dispatcher and per-teammate forgeplan claim/evidence loop for artifact-driven sprints. Full feature parity with the legacy dev-toolkit plus 18 additional skills built on forgeplan's artifact lifecycle.",
+      "version": "1.7.0",
       "author": {
         "name": "ForgePlan"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to the ForgePlan Marketplace will be documented in this file
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.0] - 2026-05-08
+
+**Forgeplan operating contract enforcement** — closes the gap where skills described forgeplan integration but didn't enforce it across sessions. Refs PRD-018 (planned and validated via `/forge-cycle` autonomous run).
+
+The frustration this fixes: agents read SKILL.md only when a skill triggers; between skill invocations they fall back to general heuristics and skip artifact-graph operations (`forgeplan search`, `new evidence`, `link`, `activate`). User had to manually remind every session. Now the contract lives in CLAUDE.md (auto-loaded into every session context) plus the SessionStart hook surfaces concrete next-action when health is non-clean.
+
+### Added
+- `fpl-skills` v1.6.0 → **1.7.0** (minor — two new behaviours, both forgeplan-CLI-gated, fully backward-compatible):
+  - **`/fpl-init` step 7-bis: operating contract injection into project CLAUDE.md**
+    - When `/fpl-init` runs in a project with forgeplan CLI on `$PATH`, it offers (one yes/no prompt, defaults to yes per step-3 plan approval) to append a 13-line `## Forgeplan operating contract` section to project CLAUDE.md.
+    - Section structure: **Before** (`forgeplan search` + `list -s draft`) → **During** (multi-agent: `claim` + `dispatch`) → **After** (`new evidence` + `link` + `score` + `activate`). Plus a forward-compat note about preferring `mcp__forgeplan__*` tools when available.
+    - Idempotent via marker `<!-- forgeplan-operating-contract:v1 -->`. Re-running `/fpl-init` detects the marker and skips re-injection silently.
+    - Step 11 (Report) gains an "Operating contract" line.
+  - **SessionStart hook: `forgeplan health --json` next-action surfacing**
+    - `plugins/fpl-skills/hooks/scripts/session-start.sh` now runs `timeout 2 forgeplan health --json` (gracefully degrading on absence/error) and surfaces a 2-line next-action when the artifact graph is non-clean (orphans, stubs, possible-duplicates, or stale evidence).
+    - Output format: `⚠ forgeplan health: <N orphans / N stubs (id-list) / N possible-dup pairs / N stale evidence> — close before new work` + `→ <first concrete CLI from forgeplan's own next_actions array>`.
+    - Healthy projects print no extra line. CLI absent → no extra line. Python3 used for JSON parsing (already a hook dependency); 2-second timeout caps the cost.
+
+### Changed
+- `marketplace.json`: catalog 1.19.0 → **1.20.0**; fpl-skills entry 1.6.0 → 1.7.0; description updated to mention contract injection + hook.
+- `plugin.json` (fpl-skills): version 1.6.0 → 1.7.0.
+
+### Notes
+**Why CLAUDE.md and not skill prose**: skill descriptions live in SKILL.md and load only when their skill triggers. Between triggers, agents work from system context where skill rules don't reach. CLAUDE.md is auto-loaded into every session by Claude Code — the contract sits in the always-on context. This is the strongest enforcement lever the marketplace can pull without changing forgeplan-core.
+
+**Forward-compat to option B (MCP wiring)**: contract mentions `mcp__forgeplan__*` tools as preferred when available. When option B lands (separate PR — `.mcp.json` config + `mcp__forgeplan__*` callsites in skills), no contract change needed.
+
+**Out of scope (deferred)**:
+- Refactoring all 22 forgeplan-aware skills to share a single `FORGEPLAN-PROBE.md` reference (option C from prior discussion). With contract in CLAUDE.md, the per-skill probe-section refactor has diminishing returns.
+- Auto-detecting forgeplan and injecting without asking. The contract injection requires explicit user yes — agent autonomy stops at modifying user-owned files.
+
+### PRD-018 — Acceptance criteria status
+
+- [x] AC-1: `/fpl-init` in fresh repo offers contract injection — implemented via step 7-bis prose.
+- [x] AC-2: Contract section appears in CLAUDE.md with the four-phase template — verified template in skill prose.
+- [x] AC-3: Re-running `/fpl-init` skips on marker presence — idempotency guard documented.
+- [x] AC-4: SessionStart in repo with stubs prints concrete warning + tip — parser tested with simulated non-clean JSON.
+- [x] AC-5: SessionStart in repo without forgeplan CLI prints baseline only — `command -v forgeplan` guard.
+- [x] AC-6: `./scripts/validate-all-plugins.sh` passes — verified pre-commit.
+
 ## [1.19.0] - 2026-05-08
 
 `/sprint` and `/autorun` now wire the **forgeplan dispatch + claim + evidence loop** for artifact-driven sprints. Tasks taken from forgeplan as artifacts (PRD-NNN/RFC-NNN/SPEC-NNN), parallel-safe grouping computed by PRD-057 dispatcher, soft-claim per teammate, evidence emitted per artifact at wave-close.

--- a/plugins/fpl-skills/.claude-plugin/plugin.json
+++ b/plugins/fpl-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fpl-skills",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Flagship workflow plugin for the ForgePlan ecosystem. 21 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, /riper RIPER orchestrator, plus session helpers) + dev-advisor agent + 4 hooks. Every workflow skill is forgeplan-aware. Full feature parity with the legacy dev-toolkit plus 18 additional skills built on forgeplan's artifact lifecycle.",
   "author": {
     "name": "ForgePlan"

--- a/plugins/fpl-skills/hooks/scripts/session-start.sh
+++ b/plugins/fpl-skills/hooks/scripts/session-start.sh
@@ -41,4 +41,48 @@ else
   echo "   Quick start: /restore (recover context) · /briefing (today's tasks) · /research <topic>"
 fi
 
+# ─── forgeplan health next-action surfacing ───────────────────────────────
+# When forgeplan is present and the artifact graph is non-clean (orphans,
+# stubs, dups, or stale), print one concrete next-action line. Fail silently
+# on any error — the hook must never block session start.
+if [ "$HAS_FORGEPLAN_DIR" = "yes" ] && command -v forgeplan >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
+  HEALTH_JSON=$(timeout 2 forgeplan health --json 2>/dev/null || echo "")
+  if [ -n "$HEALTH_JSON" ]; then
+    NEXT_ACTION=$(printf '%s' "$HEALTH_JSON" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    if d.get("verdict") == "healthy":
+        sys.exit(0)
+    parts = []
+    orphans = d.get("orphans") or []
+    if orphans:
+        suffix = "s" if len(orphans) != 1 else ""
+        parts.append(str(len(orphans)) + " orphan" + suffix)
+    stubs = d.get("active_stubs") or []
+    if stubs:
+        ids = [s["id"] for s in stubs[:3]]
+        more = "..." if len(stubs) > 3 else ""
+        parts.append(str(len(stubs)) + " stub(s) (" + ", ".join(ids) + more + ")")
+    dups = d.get("possible_duplicates") or []
+    if dups:
+        parts.append(str(len(dups)) + " possible-dup pair(s)")
+    stale = d.get("stale_count", 0) or 0
+    if stale > 0:
+        parts.append(str(stale) + " stale evidence")
+    if parts:
+        print("   ⚠ forgeplan health: " + " / ".join(parts) + " — close before new work")
+        nxt = d.get("next_actions") or []
+        if nxt:
+            line = nxt[0]
+            if "`" in line:
+                line = line.split("`")[1]
+            print("   → " + line[:90])
+except Exception:
+    pass
+' 2>/dev/null)
+    [ -n "$NEXT_ACTION" ] && printf '%s\n' "$NEXT_ACTION"
+  fi
+fi
+
 exit 0

--- a/plugins/fpl-skills/skills/fpl-init/SKILL.md
+++ b/plugins/fpl-skills/skills/fpl-init/SKILL.md
@@ -269,6 +269,41 @@ scratch" because the template seems too verbose. The verbosity is the
 point — the U-curve attention model needs primacy/recency zones to be
 populated. A thin file silently strips guard rails.
 
+### 7-bis. Inject forgeplan operating contract into CLAUDE.md
+
+If forgeplan CLI is on `$PATH` (probed in step 2), append the **operating contract** to CLAUDE.md. This makes forgeplan-aware behaviour the default for every session in the project — without it, agents revert to general heuristics and skip artifact-graph operations under context pressure (the failure mode this section fixes).
+
+**Idempotency check** — read CLAUDE.md and look for the version marker `<!-- forgeplan-operating-contract:v1 -->`. If present, skip silently and continue to step 8. If absent, ask the user once:
+
+```
+Inject the 13-line forgeplan operating contract into CLAUDE.md? It tells future
+agents to use forgeplan as source-of-truth on every non-trivial task — search
+before creating, claim before working, evidence after finishing. [y/n]
+```
+
+Default to `y` (per the step-3 plan approval). If user says no — skip; do not warn again.
+
+If yes — append (NOT replace) the following block to `./CLAUDE.md`:
+
+```markdown
+<!-- forgeplan-operating-contract:v1 -->
+## Forgeplan operating contract (this project)
+
+Forgeplan is the source of truth for artifacts in this project. On every non-trivial task you MUST:
+
+**Before** — `forgeplan search "<topic>"` then `forgeplan list -s draft`. Find related artifacts before creating new ones (avoid duplicates; reuse existing).
+**During** (multi-agent / artifact-driven) — `forgeplan claim <ID> --agent <name>` per teammate before they start; `forgeplan dispatch -n N --json` for parallel-safe wave grouping.
+**After** — `forgeplan new evidence "<summary>"` + `forgeplan link EVID-MMM <ARTIFACT-ID> --relation informs` + `forgeplan score <ARTIFACT-ID>` + `forgeplan activate <ARTIFACT-ID>` if R_eff > 0.
+
+Prefer `mcp__forgeplan__*` tools over shell when forgeplan MCP is wired in `.mcp.json`. If `command -v forgeplan` fails, warn once at session start and proceed without artifact ops.
+
+This is enforcement, not recommendation. Skipping leaves the artifact graph empty — `forgeplan health` will flag orphans / missing evidence / stale stubs.
+```
+
+The marker `<!-- forgeplan-operating-contract:v1 -->` is **load-bearing**: re-running `/fpl-init` keys off this marker to avoid double-appending. If the contract evolves to v2, change the marker and add a migration note rather than mutating the v1 block in place.
+
+**Verify**: `grep -q 'forgeplan-operating-contract:v1' CLAUDE.md` returns 0. Echo "✓ operating contract injected" or "✓ contract already present, skipped" depending on path taken.
+
 ### 8. Run `/setup` flow
 
 If `docs/agents/` is missing, invoke the setup wizard inline. Per
@@ -339,6 +374,7 @@ Final summary in a single block:
 ✓ .mcp.json                wired (forgeplan + N existing servers preserved)
 ✓ .claude/settings.json    safety hook added       (or "skipped per user")
 ✓ CLAUDE.md                created from template   (or "appended")
+✓ Operating contract       injected into CLAUDE.md (or "already present" / "skipped per user")
 ✓ docs/agents/             configured (4 files)
 ✓ CONTEXT.md               created starter         (or "skipped — exists")
 
@@ -365,6 +401,7 @@ If any step in the plan failed — replace its ✓ with ✗ and show the error.
 
 - Detect what's already in place (step 1) and skip those branches.
 - Never overwrite existing `CLAUDE.md` content (always append).
+- Operating contract injection (step 7-bis) keys off marker `<!-- forgeplan-operating-contract:v1 -->` — re-runs detect and skip without prompting.
 - Never overwrite existing `.mcp.json` entries (always merge).
 - Never overwrite existing `docs/agents/*.md` (`/setup` re-prompts).
 


### PR DESCRIPTION
## Summary

**Closes the enforcement gap**: skills described forgeplan integration in their own SKILL.md files but didn't make it stick across sessions. Agents read skill body only when the skill triggers; between triggers they fall back to general heuristics and skip artifact-graph operations (`forgeplan search`, `new evidence`, `link`, `activate`). User had to manually remind every session.

Now: a 13-line operating contract sits in project CLAUDE.md (auto-loaded into every session context), and the SessionStart hook surfaces a concrete next-action when `forgeplan health` is non-clean.

Routed via `/forge-cycle` autonomous run — Route → Shape → Build → Evidence → Activate. PRD-018 created, validated (PASS, 5 links), AC-1..AC-6 all met.

## What changes

### 1. `/fpl-init` step 7-bis: operating contract injection

After step 7 (CLAUDE.md created/appended) and before step 8 (`/setup` for docs/agents), `/fpl-init` offers to append the contract:

```markdown
<!-- forgeplan-operating-contract:v1 -->
## Forgeplan operating contract (this project)

Forgeplan is the source of truth for artifacts in this project. On every non-trivial task you MUST:

**Before** — `forgeplan search "<topic>"` then `forgeplan list -s draft`.
**During** (multi-agent / artifact-driven) — `forgeplan claim <ID> --agent <name>`; `forgeplan dispatch -n N --json`.
**After** — `forgeplan new evidence` + `forgeplan link --relation informs` + `forgeplan score` + `forgeplan activate` if R_eff > 0.

Prefer `mcp__forgeplan__*` tools when forgeplan MCP is wired in `.mcp.json`.

This is enforcement, not recommendation.
```

- **Idempotent** via marker `<!-- forgeplan-operating-contract:v1 -->`. Re-running `/fpl-init` detects and skips silently.
- **Opt-in** — one yes/no prompt (default yes per step-3 plan approval).
- **Forward-compat** to option B (MCP wiring): contract already mentions `mcp__forgeplan__*` preference; no contract change needed when MCP wiring lands.

### 2. SessionStart hook: forgeplan health next-action

`plugins/fpl-skills/hooks/scripts/session-start.sh` now runs `timeout 2 forgeplan health --json`, parses with python3 (already a hook dependency), and prints:

```
🛠  fpl-skills active — .forgeplan/ (53 artifacts) · CLAUDE.md present · branch: X
   ⚠ forgeplan health: 2 orphans / 3 stub(s) (PRD-007, PRD-008, PRD-009) — close before new work
   → forgeplan supersede PRD-007 --by <NEW>
```

Healthy projects: no extra line. CLI absent: no extra line. 2-second timeout caps the hook cost.

## Verification

- ✅ `./scripts/validate-all-plugins.sh` — ALL PASSED.
- ✅ Hook smoke-test on healthy project — prints baseline only, no health line.
- ✅ Hook parser tested on simulated non-clean JSON — prints expected 2-line warning.
- ✅ /fpl-init step ordering: 1. orient → 2. probe forgeplan → 3. plan → 4. forgeplan init → 5. .mcp.json → 6. .claude/settings.json → 7. CLAUDE.md → **7-bis. operating contract** → 8. setup → 9. recommend → 10. verify → 11. report.
- ✅ PRD-018 graph: PRD-018 → ADR-001 (informs), PRD-002 (informs), PRD-013 (informs), PRD-017 (refines), NOTE-003 (informs).

## Test plan

- [x] Validation script passes
- [x] Hook outputs correct on healthy project
- [x] Hook parser handles all four health-flag types (orphans / stubs / dups / stale)
- [x] /fpl-init idempotency marker `<!-- forgeplan-operating-contract:v1 -->` documented
- [x] Backward-compatible — both behaviours forgeplan-CLI-gated, gracefully degrade
- [x] CHANGELOG explains scope, AC status, what's NOT in scope (option B / 22-skill probe-section refactor)
- [x] Versions bumped (fpl-skills 1.6.0 → 1.7.0 minor; catalog 1.19.0 → 1.20.0 minor)

## What's NOT in scope (deferred)

- **Option B (MCP wiring)** — `mcp/forgeplan.mcp.json` config + `mcp__forgeplan__*` callsites in skills. Separate PR.
- **22-skill probe-section refactor (option C)** — with contract in CLAUDE.md, per-skill probe-prose has diminishing returns.
- **Auto-injection without asking** — agent autonomy stops at modifying user-owned files. Explicit yes is correct.

Refs: PRD-018

🤖 Generated with [Claude Code](https://claude.com/claude-code)