### PR TITLE
fix(fpl-skills): v1.7.1 — SessionStart hook fallback when GNU timeout missing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.20.0"
+    "version": "1.20.1"
   },
   "plugins": [
     {
       "name": "fpl-skills",
       "source": "./plugins/fpl-skills",
       "description": "Flagship workflow plugin for the ForgePlan ecosystem. 21 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, /riper RIPER orchestrator, plus session helpers) + dev-advisor agent + 4 hooks. /fpl-init injects a 13-line forgeplan operating contract into project CLAUDE.md (idempotent v1 marker). SessionStart hook surfaces concrete next-action when forgeplan health is non-clean (orphans/stubs/dups/stale). /sprint and /autorun wire the PRD-057 dispatcher and per-teammate forgeplan claim/evidence loop for artifact-driven sprints. Full feature parity with the legacy dev-toolkit plus 18 additional skills built on forgeplan's artifact lifecycle.",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "author": {
         "name": "ForgePlan"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the ForgePlan Marketplace will be documented in this file
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.1] - 2026-05-08
+
+Bug-fix found during smoke-test of v1.20.0 SessionStart hook (PRD-018 deliverable). Routed Tactical (`forgeplan route`, confidence 90%, no PRD pipeline — just do it). Evidence to be linked back to PRD-018 post-merge.
+
+### Fixed
+- `fpl-skills` v1.7.0 → **1.7.1**:
+  - `plugins/fpl-skills/hooks/scripts/session-start.sh` — `timeout` is GNU coreutils; on bare macOS without homebrew it's not on `$PATH`, causing the new health-probe block to silently fail (exit 127) and never surface the next-action warning. Fix: detect `timeout` availability with `command -v timeout`; if absent, run `forgeplan health --json` directly without the wrapper. forgeplan CLI itself is fast (<1s typical) and the hook still has its own 3-second timeout from `hooks.json`, so the safety net stays intact even without GNU coreutils.
+
+### Changed
+- `marketplace.json`: catalog 1.20.0 → **1.20.1**; fpl-skills entry 1.7.0 → 1.7.1.
+- `plugin.json` (fpl-skills): version 1.7.0 → 1.7.1.
+
+### Notes
+**How this was found**: smoke-test 2 (SessionStart hook all paths) used a fake forgeplan shim with `env PATH="/tmp/fakebin:/usr/bin:/bin"` to simulate non-clean health. The PATH-strip incidentally removed `/opt/homebrew/bin/timeout`, causing `bash -x` trace to show `timeout 2 forgeplan health --json` exiting 127 silently. Real-world impact: any macOS user without homebrew or `gnu-coreutils` had a no-op health hook, defeating the v1.20.0 SessionStart improvement on those systems.
+
+**Re-test after fix**: same simulation now correctly prints `⚠ forgeplan health: 1 orphan / 2 stub(s) (PRD-100, PRD-101) / 1 possible-dup pair(s) / 2 stale evidence — close before new work` plus `→ forgeplan supersede PRD-100 --by <NEW>`.
+
 ## [1.20.0] - 2026-05-08
 
 **Forgeplan operating contract enforcement** — closes the gap where skills described forgeplan integration but didn't enforce it across sessions. Refs PRD-018 (planned and validated via `/forge-cycle` autonomous run).

--- a/plugins/fpl-skills/.claude-plugin/plugin.json
+++ b/plugins/fpl-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fpl-skills",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Flagship workflow plugin for the ForgePlan ecosystem. 21 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, /riper RIPER orchestrator, plus session helpers) + dev-advisor agent + 4 hooks. Every workflow skill is forgeplan-aware. Full feature parity with the legacy dev-toolkit plus 18 additional skills built on forgeplan's artifact lifecycle.",
   "author": {
     "name": "ForgePlan"

--- a/plugins/fpl-skills/hooks/scripts/session-start.sh
+++ b/plugins/fpl-skills/hooks/scripts/session-start.sh
@@ -46,7 +46,13 @@ fi
 # stubs, dups, or stale), print one concrete next-action line. Fail silently
 # on any error — the hook must never block session start.
 if [ "$HAS_FORGEPLAN_DIR" = "yes" ] && command -v forgeplan >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
-  HEALTH_JSON=$(timeout 2 forgeplan health --json 2>/dev/null || echo "")
+  # `timeout` is GNU coreutils — present on Linux + homebrew macOS, missing on bare macOS.
+  # Fall back to running forgeplan directly when timeout is absent.
+  if command -v timeout >/dev/null 2>&1; then
+    HEALTH_JSON=$(timeout 2 forgeplan health --json 2>/dev/null || echo "")
+  else
+    HEALTH_JSON=$(forgeplan health --json 2>/dev/null || echo "")
+  fi
   if [ -n "$HEALTH_JSON" ]; then
     NEXT_ACTION=$(printf '%s' "$HEALTH_JSON" | python3 -c '
 import json, sys


### PR DESCRIPTION
## Summary

**Bug found during smoke-test of v1.20.0** (PR #50, PRD-018 deliverable). The new SessionStart hook health-probe block depends on `timeout` from GNU coreutils — present on Linux and homebrew-installed macOS, missing on bare macOS. On systems without it, the entire health-warning feature was a silent no-op.

This is also the **E2E demonstration** of /forge-cycle Tactical depth — bug found during smoke test → routed Tactical (90% conf, no PRD) → fixed → PR → evidence linked back to PRD-018 → R_eff confidence improvement.

## Root cause

```bash
# v1.20.0 — fails on bare macOS:
HEALTH_JSON=$(timeout 2 forgeplan health --json 2>/dev/null || echo "")
# `timeout` not in /usr/bin or /bin on macOS by default
# Exit 127 → || echo "" substitutes empty → health warning never prints
```

## Fix

```bash
# v1.20.1 — graceful fallback:
if command -v timeout >/dev/null 2>&1; then
  HEALTH_JSON=$(timeout 2 forgeplan health --json 2>/dev/null || echo "")
else
  HEALTH_JSON=$(forgeplan health --json 2>/dev/null || echo "")
fi
```

Why safe without `timeout`:
- `forgeplan health --json` is fast (<1s on typical projects with <100 artifacts)
- Hook still has its own 3-second timeout from `hooks.json`
- The 2-second inner timeout was defense-in-depth; outer timeout is sufficient

## How it was found

Smoke-test 2 (SessionStart hook all paths) used PATH-stripping with a fake forgeplan shim:

```bash
env PATH="/tmp/fakebin:/usr/bin:/bin" bash session-start.sh
# Expected: ⚠ forgeplan health: ... warning
# Actual:   no warning printed
```

Trace via `bash -x` showed: `timeout 2 forgeplan health --json` → exit 127 → fallback `|| echo ""` → empty JSON → no warning.

The PATH-strip incidentally removed `/opt/homebrew/bin/timeout`, exposing the dependency. Real-world impact: any macOS user without homebrew or `gnu-coreutils` had a broken hook.

## Verification

- ✅ Re-tested with same fake-shim setup (timeout-less PATH) — health warning now prints correctly:
  ```
  ⚠ forgeplan health: 1 orphan / 2 stub(s) (PRD-100, PRD-101) / 1 possible-dup pair(s) / 2 stale evidence — close before new work
  → forgeplan supersede PRD-100 --by <NEW>
  ```
- ✅ Healthy project still prints baseline only (no false positives).
- ✅ `./scripts/validate-all-plugins.sh` — ALL PASSED.

## Test plan

- [x] Validation script passes
- [x] Hook works WITH `timeout` available (Linux/homebrew macOS path)
- [x] Hook works WITHOUT `timeout` available (bare macOS path)
- [x] Hook unchanged for healthy projects (no extra line)
- [x] Hook unchanged when forgeplan CLI absent (graceful skip)
- [x] Versions bumped patch (1.7.0 → 1.7.1, catalog 1.20.0 → 1.20.1)

## /forge-cycle Tactical demonstration

This PR is the E2E example of:

| Phase | Output |
|---|---|
| Route | `forgeplan route` → Tactical, conf 90%, no PRD pipeline |
| Build | 1-line `command -v timeout` guard + fallback branch |
| PR | this one |
| Evidence | post-merge — link to PRD-018 to supplement R_eff (currently 0.70 / 1 evidence) |
| Activate | n/a (Tactical — no PRD to activate; PRD-018 already active from v1.20.0) |

Refs: PRD-018, EVID-027

🤖 Generated with [Claude Code](https://claude.com/claude-code)