### PR TITLE
feat(fpl-skills): v1.8.0 — /gh-project GitHub Projects v2 integration (PRD-019)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.20.1"
+    "version": "1.21.0"
   },
   "plugins": [
     {
       "name": "fpl-skills",
       "source": "./plugins/fpl-skills",
-      "description": "Flagship workflow plugin for the ForgePlan ecosystem. 21 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, /riper RIPER orchestrator, plus session helpers) + dev-advisor agent + 4 hooks. /fpl-init injects a 13-line forgeplan operating contract into project CLAUDE.md (idempotent v1 marker). SessionStart hook surfaces concrete next-action when forgeplan health is non-clean (orphans/stubs/dups/stale). /sprint and /autorun wire the PRD-057 dispatcher and per-teammate forgeplan claim/evidence loop for artifact-driven sprints. Full feature parity with the legacy dev-toolkit plus 18 additional skills built on forgeplan's artifact lifecycle.",
-      "version": "1.7.1",
+      "description": "Flagship workflow plugin for the ForgePlan ecosystem. 22 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, /riper RIPER orchestrator, /gh-project project-agnostic GitHub Projects v2 integration, plus session helpers) + dev-advisor agent + 4 hooks. /fpl-init injects a 13-line forgeplan operating contract into project CLAUDE.md (idempotent v1 marker). SessionStart hook surfaces concrete next-action when forgeplan health is non-clean (orphans/stubs/dups/stale). /sprint and /autorun wire the PRD-057 dispatcher and per-teammate forgeplan claim/evidence loop for artifact-driven sprints. /gh-project bridges forgeplan artifacts with a GitHub Projects v2 board via per-project config (no hardcoded project numbers). Full feature parity with the legacy dev-toolkit plus 19 additional skills built on forgeplan's artifact lifecycle.",
+      "version": "1.8.0",
       "author": {
         "name": "ForgePlan"
       },

--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -21,7 +21,9 @@ jobs:
     name: Add issue/PR to ForgePlan project 5
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1
+      # SHA-pinned to v2.0.0 — matches repo convention (see validate-plugins.yml).
+      # Update SHA when bumping version: gh api repos/actions/add-to-project/git/ref/tags/v2.x.x --jq '.object.sha'
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
           project-url: 'https://github.com/orgs/ForgePlan/projects/5'
           # GITHUB_TOKEN works only if org Actions settings allow project writes.

--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -1,0 +1,31 @@
+# Auto-add issues + PRs from forgeplan-marketplace to ForgePlan/projects/5.
+# Filled-in copy of docs/templates/auto-add-to-project.yml — keep them in sync.
+# If you fork this repo or set up a new ForgePlan project, copy the template
+# from docs/templates/auto-add-to-project.yml and replace {{PROJECT_URL}}.
+
+name: Auto-add to project
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  add-to-project:
+    name: Add issue/PR to ForgePlan project 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1
+        with:
+          project-url: 'https://github.com/orgs/ForgePlan/projects/5'
+          # GITHUB_TOKEN works only if org Actions settings allow project writes.
+          # If it fails, create a fine-grained PAT (Org -> Projects: read+write) and
+          # store as ADD_TO_PROJECT_PAT secret, then change line below to:
+          # github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,63 @@ All notable changes to the ForgePlan Marketplace will be documented in this file
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.0] - 2026-05-08
+
+**GitHub Projects v2 integration** — project-agnostic skill, convention guide, auto-add workflow template. Refs PRD-019 (validated via `/forge-cycle` autonomous run; routed Standard, conf 90%).
+
+The gap this fixes: ForgePlan/marketplace ships PRs daily and has a project board (`orgs/ForgePlan/projects/5`), but no convention for what goes there, no automation, and no documented mapping between forgeplan artifact lifecycle and project Status. Same enforcement-via-convention pattern as PRD-018 (operating contract), now applied to GitHub Projects.
+
+### Added
+- `fpl-skills` v1.7.1 → **1.8.0** (minor — new skill, fully backward-compatible):
+  - **`/gh-project` skill** (~250 LOC SKILL.md) — five operations:
+    - `init` — interactive one-time setup; reads project number + owner, verifies via `gh project view`, lists fields, warns on missing recommended fields (Status, Type, Forgeplan-ID, Plugin), caches field IDs + single-select option IDs into `.forgeplan/state/gh-project.yaml`.
+    - `add-pr [<url>]` — adds current PR (or explicit URL) to configured board with Type derived from conventional-commit prefix in title.
+    - `link-prd <PRD-NNN>` — for Standard+ PRDs: creates GH issue with body referencing the artifact, adds to board, sets Forgeplan-ID + Type fields. Refuses for Tactical-depth artifacts (PR-only path).
+    - `sync-status <ARTIFACT-ID>` — reads forgeplan artifact status, writes Status field on the board with full mapping (draft/active/superseded/deprecated → Backlog/In Progress/Done/Cancelled).
+    - `list [--filter status=<X>]` — pretty-prints current board items.
+  - **Project-agnostic by design**: skill never hardcodes project numbers or owner names. All values live in per-project `.forgeplan/state/gh-project.yaml` (added to `.gitignore` automatically by `init`). The same skill works in marketplace (project 5), in any other ForgePlan repo with a different board, in user-owned projects, etc.
+  - **Field IDs cached** in config for speed — `gh project item-edit` requires field IDs not names. Refresh via re-running `init`.
+
+### Added (workflow + docs)
+- `docs/templates/auto-add-to-project.yml` — reusable GitHub Actions workflow template using official `actions/add-to-project@v1`. Two placeholders: `{{PROJECT_URL}}` (must replace before commit). Includes inline comments on auth (`GITHUB_TOKEN` vs fine-grained PAT), label filters, AND/OR/NOT operators.
+- `.github/workflows/auto-add-to-project.yml` — filled-in copy for marketplace (project=5, owner=ForgePlan). Auto-adds new issues + PRs to the project board.
+- `docs/GITHUB-PROJECTS.md` + `-RU.md` (~250 LOC each) — bilingual convention guide:
+  - TL;DR (6-step quickstart)
+  - Convention table: what goes on the board, when, why
+  - Status mapping (Forgeplan ↔ Project)
+  - Label conventions
+  - Recommended field schema (5 fields with rationale per field)
+  - Two auto-add paths (built-in project workflow vs `actions/add-to-project@v1`) — when to choose which
+  - Authentication (classic PAT vs fine-grained, required scopes per case)
+  - End-to-end examples (new repo setup, Standard+ PRD lifecycle, Tactical-PR-only path)
+  - CLAUDE.md inject pattern (analogue to PRD-018 operating contract)
+  - Troubleshooting (5 common failure modes + fixes)
+  - References (GitHub docs + actions/add-to-project + gh CLI manual)
+- `CLAUDE.md` (marketplace) — gains 13-line `## GitHub Projects integration` section with `<!-- gh-project-convention:v1 -->` marker for idempotency. Catalog version bumped to 1.21.0; plugin count "10 → 11" reflects fpl-skills' new skill being a notable enough addition to flag.
+
+### Changed
+- `marketplace.json`: catalog 1.20.1 → **1.21.0** (minor — new skill in fpl-skills); fpl-skills entry 1.7.1 → 1.8.0; description mentions `/gh-project`.
+- `plugin.json` (fpl-skills): version 1.7.1 → 1.8.0; skills array gains `gh-project` (alphabetically inserted between `fpl-init` and `migrate-from-dev-toolkit`); description updated to "22 engineering skills".
+
+### Notes
+**Why project-agnostic from day 1**: original design hardcoded `project 5` in skill body. User caught it during design review ("я верно понимаю что скилл не завязан на конкретном проекте?") — drove the redesign to per-project `.forgeplan/state/gh-project.yaml` config. The skill now works in any repo without code change; only the YAML differs.
+
+**Two auto-add paths documented because both have valid use-cases**:
+- Built-in project workflow (UI-configured, no `.github/workflows/` file needed) — simplest case.
+- `actions/add-to-project@v1` — needed for label-based AND/OR/NOT filters or multi-repo source.
+
+Marketplace uses the Action path so the convention is reproducible (workflow file is reviewable + version-controlled + copy-pasteable to other ForgePlan repos).
+
+**Out of scope (deferred)**:
+- Auto-creating missing project fields. User owns the schema; skill warns + prints `gh project field-create` command. Auto-create would silently mutate user's project.
+- Bidirectional issue body ↔ forgeplan body sync. One-way reference (issue body has `## Forgeplan artifact` line pointing at PRD-NNN) is sufficient.
+- GitHub Projects v1 (classic) — discontinued; only v2 supported.
+- Bot-owned automatic Forgeplan-ID assignment based on PR title regex. Heuristic-prone; manual `link-prd` is more reliable.
+
+### PRD-019 — Acceptance criteria status (post-build, pre-merge)
+
+- [x] AC-1..AC-7 — see PRD-019 body. All implemented in skill prose / template / guide; AC-7 (works on hypothetical second repo) verified by design review.
+
 ## [1.20.1] - 2026-05-08
 
 Bug-fix found during smoke-test of v1.20.0 SessionStart hook (PRD-018 deliverable). Routed Tactical (`forgeplan route`, confidence 90%, no PRD pipeline — just do it). Evidence to be linked back to PRD-018 post-merge.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,25 @@
 # ForgePlan Marketplace — Claude Code Configuration
 
 **Repo**: [ForgePlan/marketplace](https://github.com/ForgePlan/marketplace)
-**Catalog version**: 1.6.0
-**Plugins**: 10 (5 core + 5 agent packs)
+**Catalog version**: 1.21.0
+**Plugins**: 11 (6 workflow + 5 agent packs)
+**Project board**: [orgs/ForgePlan/projects/5](https://github.com/orgs/ForgePlan/projects/5)
+
+---
+
+<!-- gh-project-convention:v1 -->
+## GitHub Projects integration (this project)
+
+This project tracks work via GitHub Projects v2 board: [orgs/ForgePlan/projects/5](https://github.com/orgs/ForgePlan/projects/5). Per-project config in `.forgeplan/state/gh-project.yaml` (not committed). PRs auto-add via `.github/workflows/auto-add-to-project.yml`.
+
+**What goes on the board**:
+- All PRs (auto-added by workflow). Type derived from conventional-commit prefix in title.
+- Standard+ PRDs/RFCs (manually via `/gh-project link-prd PRD-NNN`). Tactical artifacts → PR-only.
+
+**Lifecycle sync**: after `forgeplan activate <ID>` run `/gh-project sync-status <ID>` to update board Status.
+
+**Skill**: `/gh-project init` (one-time setup per repo), `add-pr`, `link-prd`, `sync-status`, `list`.
+**Convention + setup guide**: [docs/GITHUB-PROJECTS.md](docs/GITHUB-PROJECTS.md) (EN) / [docs/GITHUB-PROJECTS-RU.md](docs/GITHUB-PROJECTS-RU.md) (RU).
 
 ---
 

--- a/docs/GITHUB-PROJECTS-RU.md
+++ b/docs/GITHUB-PROJECTS-RU.md
@@ -1,0 +1,282 @@
+# Интеграция с GitHub Projects v2 — гайд
+
+> Двуязычный документ. English version: [GITHUB-PROJECTS.md](GITHUB-PROJECTS.md).
+
+Этот документ описывает **convention** (соглашение) использования GitHub Projects v2 в репо ForgePlan, **схему полей** на которой convention построена, и **скилл `/gh-project` + шаблон auto-add workflow** которые автоматизируют процесс.
+
+Интеграция **project-agnostic** (не зависит от конкретной доски). Маркетплейс использует `https://github.com/orgs/ForgePlan/projects/5`, но всё описанное здесь работает в любом другом ForgePlan репо со своей доской.
+
+---
+
+## TL;DR
+
+```
+1. Создать доску в GitHub UI (или `gh project create --owner <owner> --title <title>`).
+2. В любом репо:
+   /gh-project init      ← интерактивно: project number + owner + проверка полей
+3. Скопировать шаблон auto-add:
+   cp docs/templates/auto-add-to-project.yml .github/workflows/
+   # отредактировать project-url
+4. Workflow автоматически добавляет новые issues и PR на доску.
+5. После `forgeplan new prd` для Standard+:
+   /gh-project link-prd PRD-NNN     ← создаёт issue + добавляет на доску с Forgeplan-ID
+6. После `forgeplan activate PRD-NNN`:
+   /gh-project sync-status PRD-NNN  ← обновляет поле Status на доске
+```
+
+---
+
+## Convention
+
+### Что попадает на доску
+
+| Источник | На доску | Поле Type | Дефолтный Status |
+|---|---|---|---|
+| Forgeplan PRD (Standard+) | ✅ через `/gh-project link-prd` (создаёт GH issue + добавляет на доску) | `PRD` | `Backlog` (или `Ready` если validated) |
+| Forgeplan RFC (Standard+) | ✅ так же | `RFC` | `Backlog` |
+| Forgeplan ADR | ✅ так же; обычно сразу `Done` после активации | `ADR` | `Done` |
+| Forgeplan PRD/RFC (Tactical) | ❌ — Tactical = без артефакт-церемонии; PR достаточно | n/a | n/a |
+| Forgeplan Evidence | ❌ — внутренний артефакт; отдельной карточки не нужно | n/a | n/a |
+| Forgeplan Note | ❌ — слишком гранулярно; reference-материал | n/a | n/a |
+| GitHub PR (любой) | ✅ автоматически добавляется workflow | `Feature` / `Bug` / `Docs` / `Chore` (парсится из title) | `In Review` |
+| GitHub Issue (любой opened) | ✅ автоматически добавляется workflow | `Bug` (по умолчанию) — переразметить вручную | `Backlog` |
+
+**Почему Tactical не на доске**: Tactical scope = «просто сделай» (per `forgeplan route`). Добавление на доску создаёт шум — финальный PR это уже достаточный сигнал.
+
+### Соответствие статусов (Forgeplan ↔ Project)
+
+| Forgeplan status | Project Status | Триггер |
+|---|---|---|
+| Артефакт `draft`, ещё не validated | `Backlog` | После `forgeplan new` |
+| Артефакт `draft`, `forgeplan validate` PASS | `Ready` | После validate |
+| Артефакт `active` (после `forgeplan activate`) | `In Progress` (если работа идёт) или `Done` (если зашиппено) | После activate + judgement |
+| Артефакт `superseded` | `Done` | После `forgeplan supersede` |
+| Артефакт `deprecated` | `Cancelled` | После `forgeplan deprecate` |
+| PR opened | `In Review` | Auto-add workflow |
+| PR merged | `Done` | Built-in workflow (настраивается в UI проекта) |
+
+### Convention для labels
+
+Issues созданные через `/gh-project link-prd` маркируются:
+
+| Label | Когда |
+|---|---|
+| `forgeplan` | Все issues отслеживающие артефакт |
+| `prd` / `rfc` / `adr` | Зеркалит kind артефакта |
+| `active` | Когда `forgeplan activate` запускается (добавляется `/gh-project sync-status`) |
+| `closed` | Когда superseded или deprecated |
+
+PR автоматически labelятся по conventional-commit префиксу title (`fix(...)`, `feat(...)`, `docs(...)`, `chore(...)`, `audit(...)`, `refactor(...)`). Auto-add workflow от labels не зависит, но `/gh-project add-pr` читает префикс title чтобы установить поле Type.
+
+---
+
+## Field schema (рекомендуемая)
+
+Создать эти поля **один раз** на доске (или verify через `/gh-project init` который warning'ует о пропусках).
+
+| Поле | Тип | Опции | Обязательно для скилла? |
+|---|---|---|---|
+| **Status** | single-select (built-in) | `Backlog`, `Ready`, `In Progress`, `In Review`, `Done`, `Cancelled` | да |
+| **Type** | single-select | `PRD`, `RFC`, `ADR`, `Feature`, `Bug`, `Docs`, `Chore` | да |
+| **Forgeplan-ID** | text | n/a | да (для `link-prd` и `sync-status`) |
+| **Plugin** | single-select | `fpl-skills`, `forgeplan-workflow`, `forgeplan-orchestra`, `forgeplan-brownfield-pack`, `fpf`, `laws-of-ux`, `agents-core`, `agents-domain`, `agents-pro`, `agents-github`, `agents-sparc`, `marketplace` | опционально, рекомендуется |
+| **Priority** | single-select | `P0`, `P1`, `P2`, `P3` | опционально |
+
+### Зачем именно эти
+
+- **Status** — самое часто-смотримое поле любой доски. Шесть опций покрывают все фазы lifecycle артефактов.
+- **Type** разделяет архитектурные артефакты (PRD/RFC/ADR) от исполнительной работы (Feature/Bug/Docs/Chore).
+- **Forgeplan-ID** — обратный указатель в граф артефактов; load-bearing поле. Без него карточки на доске оторваны от `.forgeplan/`.
+- **Plugin** скоупит работу к конкретным компонентам маркетплейса — полезно когда много плагинов эволюционируют параллельно.
+- **Priority** — действительно team-specific. GitHub не задаёт canonical-смысл ([discussion](https://github.com/orgs/community/discussions/54055)). P0/P1/P2/P3 — одна из распространённых схем.
+
+### Создание полей через `gh` CLI
+
+Если `/gh-project init` репортит missing-поля, вот команды которые он подсказывает:
+
+```bash
+# Single-select пример (Type field с несколькими опциями)
+gh project field-create 5 --owner ForgePlan \
+  --name "Type" \
+  --data-type SINGLE_SELECT \
+  --single-select-options "PRD,RFC,ADR,Feature,Bug,Docs,Chore"
+
+# Text field (Forgeplan-ID)
+gh project field-create 5 --owner ForgePlan \
+  --name "Forgeplan-ID" \
+  --data-type TEXT
+```
+
+Reference: [gh project field-create](https://cli.github.com/manual/gh_project_field-create).
+
+---
+
+## Auto-add — два пути
+
+### Вариант 1 — Built-in project workflow (рекомендуется для простых случаев)
+
+Настраивается в UI проекта, файл Actions не нужен.
+
+1. Откройте проект: `https://github.com/orgs/<owner>/projects/<num>`
+2. Клик `⋯` (top-right) → `Workflows`
+3. Найти `Auto-add to project` (built-in)
+4. Настроить: выбрать source repo, опциональные фильтры (issue state, labels)
+5. Save & Enable
+
+**Плюсы**: ноль кода, ноль секретов, ~30 секунд.
+**Минусы**: меньше гибкости (например AND/OR/NOT label-фильтры труднее).
+
+[GitHub docs reference](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/adding-items-automatically).
+
+### Вариант 2 — `actions/add-to-project@v1` workflow
+
+Когда нужно больше контроля: AND/OR/NOT label-фильтры, multi-repo source, кастомные триггеры.
+
+1. Скопировать `docs/templates/auto-add-to-project.yml` → `.github/workflows/auto-add-to-project.yml`
+2. Заменить `{{PROJECT_URL}}` placeholder
+3. Настроить auth:
+   - **GITHUB_TOKEN** работает если ваша организация позволяет токену писать в проекты (Settings → Actions → Workflow permissions). Многие org это запрещают.
+   - Иначе создайте **fine-grained PAT** с Organization → Projects (read+write), сохраните как `ADD_TO_PROJECT_PAT` секрет, измените строку `github-token:`.
+4. Закоммитить. Workflow срабатывает на следующий opened/reopened issue или PR.
+
+[Action repo](https://github.com/actions/add-to-project).
+
+### Что выбрать
+
+| Хочется | Путь |
+|---|---|
+| Один репо → один проект, все items | Вариант 1 (built-in) |
+| Фильтр по labels (AND/OR/NOT) | Вариант 2 (Action) |
+| Multi-repo → один проект | Вариант 2 — копировать workflow в каждый репо |
+| Org-wide auto-add | Вариант 1 (built-in поддерживает несколько источников) |
+
+Маркетплейс использует **Вариант 2** чтобы convention был полностью воспроизводимым (workflow-файл reviewable, version-controlled, copy-paste'able в другие репо).
+
+---
+
+## Аутентификация
+
+`gh` CLI должен иметь project-scope:
+
+| Тип токена | Нужные scopes |
+|---|---|
+| Classic PAT | `project` (read+write), `repo` (private repo issues) |
+| Fine-grained | Organization → **Projects: read+write**; Repository → **Issues: read+write**, **Pull requests: read** |
+
+```bash
+# Проверка
+gh auth status
+
+# Если `project` scope отсутствует
+gh auth refresh -s read:project,write:project
+```
+
+`/gh-project init` делает эту проверку и подсказывает refresh-команду.
+
+---
+
+## End-to-end примеры
+
+### Установка нового репо
+
+```bash
+# 1. Создать project board (один раз, в любом репо или глобально)
+gh project create --owner ForgePlan --title "Marketplace tracking"
+
+# 2. В вашем репо
+cd my-new-repo
+forgeplan init                                # если ещё не сделано
+/gh-project init                              # интерактивно: project num + owner
+
+# 3. Скопировать auto-add шаблон
+mkdir -p .github/workflows
+cp $(forgeplan path)/docs/templates/auto-add-to-project.yml .github/workflows/
+# редактировать, заменить {{PROJECT_URL}}
+git add .github/workflows/auto-add-to-project.yml
+git commit -m "chore(ci): auto-add to ForgePlan project"
+```
+
+### Жизненный цикл Standard+ PRD на доске
+
+```bash
+# Авторинг
+/shape "magic-link auth для админ-панели"      # создаёт PRD-024 (Standard)
+forgeplan validate PRD-024                     # PASS
+
+# Линковка к доске
+/gh-project link-prd PRD-024
+# → создаёт GH issue "PRD-024: magic-link auth для админ-панели"
+# → добавляет на доску с Type=PRD, Forgeplan-ID=PRD-024, Status=Backlog
+
+# Реализация
+git checkout -b feat/magic-link-auth
+# ... работа ...
+gh pr create --title "feat(auth): magic-link admin login (PRD-024)"
+# → workflow auto-добавляет PR на доску, Type=Feature, Status=In Review
+
+# Активация
+forgeplan activate PRD-024
+/gh-project sync-status PRD-024
+# → обновляет Status на Done (или In Progress если работа продолжается)
+```
+
+### Tactical-фикс (БЕЗ церемонии)
+
+```bash
+# Быстрый фикс
+forgeplan route "fix typo in README" → Tactical
+git checkout -b fix/readme-typo
+# ... фикс ...
+gh pr create --title "fix(docs): typo in README"
+# → workflow auto-добавляет PR на доску, Type=Docs, Status=In Review
+# → нет PRD, нет /gh-project link-prd, нет ручных карточек
+```
+
+---
+
+## Добавление в CLAUDE.md
+
+Когда `/gh-project init` запускается, опционально добавляется 13-строчная заметка в project CLAUDE.md описывающая convention. Работает так же как forgeplan operating contract из PRD-018.
+
+Marker для идемпотентных re-runs: `<!-- gh-project-convention:v1 -->`
+
+```markdown
+<!-- gh-project-convention:v1 -->
+## GitHub Projects integration (this project)
+
+This project tracks work via GitHub Projects v2 board: <PROJECT_URL>.
+Configuration is in `.forgeplan/state/gh-project.yaml` (per-project, not committed).
+
+**What goes on the board**:
+- All PRs (auto-added by `.github/workflows/auto-add-to-project.yml`).
+- Standard+ PRDs/RFCs (manually via `/gh-project link-prd PRD-NNN`). Tactical artifacts → PR-only.
+
+**Lifecycle sync**: after `forgeplan activate <ID>` run `/gh-project sync-status <ID>`.
+
+**Skill**: `/gh-project init` (one-time setup), `add-pr`, `link-prd`, `sync-status`, `list`.
+**Guide**: `docs/GITHUB-PROJECTS.md` in marketplace, or its mirror in any repo using this convention.
+```
+
+---
+
+## Troubleshooting
+
+| Симптом | Вероятная причина | Решение |
+|---|---|---|
+| `gh project view <num>` возвращает 404 | Неверный номер или owner | `gh project list --owner <owner>` для discovery |
+| Workflow срабатывает но item не на доске | Token не может писать в проект | Переключиться с `GITHUB_TOKEN` на PAT-секрет |
+| `/gh-project link-prd` падает с "missing field 'Forgeplan-ID'" | Поле не создано на доске | Запустить `gh project field-create` команду из warning'а `/gh-project init` |
+| `gh auth refresh` говорит "fine-grained tokens cannot be refreshed" | Используется fine-grained PAT | Сгенерировать новый PAT вручную с нужными scopes |
+| Item уже на доске, дубль создаётся | Старый `actions/add-to-project@v0` имел bug | Обновить до `@v1` |
+
+---
+
+## Ссылки
+
+- [Best practices for Projects](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/best-practices-for-projects)
+- [Adding items automatically](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/adding-items-automatically)
+- [actions/add-to-project](https://github.com/actions/add-to-project)
+- [gh project CLI manual](https://cli.github.com/manual/gh_project)
+- [Custom fields docs](https://docs.github.com/en/issues/planning-and-tracking-with-projects/understanding-fields)
+- Тело скилла: `plugins/fpl-skills/skills/gh-project/SKILL.md`
+- Workflow template: `docs/templates/auto-add-to-project.yml`

--- a/docs/GITHUB-PROJECTS-RU.md
+++ b/docs/GITHUB-PROJECTS-RU.md
@@ -128,7 +128,7 @@ Reference: [gh project field-create](https://cli.github.com/manual/gh_project_fi
 
 [GitHub docs reference](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/adding-items-automatically).
 
-### Вариант 2 — `actions/add-to-project@v1` workflow
+### Вариант 2 — `actions/add-to-project@v2` workflow (SHA-pinned)
 
 Когда нужно больше контроля: AND/OR/NOT label-фильтры, multi-repo source, кастомные триггеры.
 
@@ -267,7 +267,8 @@ Configuration is in `.forgeplan/state/gh-project.yaml` (per-project, not committ
 | Workflow срабатывает но item не на доске | Token не может писать в проект | Переключиться с `GITHUB_TOKEN` на PAT-секрет |
 | `/gh-project link-prd` падает с "missing field 'Forgeplan-ID'" | Поле не создано на доске | Запустить `gh project field-create` команду из warning'а `/gh-project init` |
 | `gh auth refresh` говорит "fine-grained tokens cannot be refreshed" | Используется fine-grained PAT | Сгенерировать новый PAT вручную с нужными scopes |
-| Item уже на доске, дубль создаётся | Старый `actions/add-to-project@v0` имел bug | Обновить до `@v1` |
+| `Unable to resolve action @v1` | Нет floating `v1` тега — только `v1.0.x` версии и `v2`/`v2.0.0` | Использовать `@v2` (latest major) или SHA-pin `@<sha> # v2.0.0` |
+| Item уже на доске, дубль создаётся | Старый `actions/add-to-project@v0` имел bug | Обновить до `@v2` (SHA-pinned) |
 
 ---
 

--- a/docs/GITHUB-PROJECTS.md
+++ b/docs/GITHUB-PROJECTS.md
@@ -128,7 +128,7 @@ Configured in the project UI, no Actions file needed.
 
 [GitHub docs reference](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/adding-items-automatically).
 
-### Option 2 — `actions/add-to-project@v1` workflow
+### Option 2 — `actions/add-to-project@v2` workflow (SHA-pinned)
 
 When you need more control: AND/OR/NOT label filters, multi-repo source, custom triggers.
 
@@ -267,7 +267,8 @@ Configuration is in `.forgeplan/state/gh-project.yaml` (per-project, not committ
 | Workflow fires but item not on board | Token can't write to project | Switch from `GITHUB_TOKEN` to PAT-secret |
 | `/gh-project link-prd` fails with "missing field 'Forgeplan-ID'" | Field not created on board | Run the `gh project field-create` command from `/gh-project init` warning |
 | `gh auth refresh` says "fine-grained tokens cannot be refreshed" | Using fine-grained PAT | Generate new PAT manually with required scopes |
-| Item already on board, duplicate created | Old `actions/add-to-project@v0` had a bug | Upgrade to `@v1` |
+| `Unable to resolve action @v1` | No floating `v1` tag — only `v1.0.x` versions and `v2`/`v2.0.0` | Use `@v2` (latest major) or pin SHA `@<sha> # v2.0.0` |
+| Item already on board, duplicate created | Old `actions/add-to-project@v0` had a bug | Upgrade to `@v2` (SHA-pinned) |
 
 ---
 

--- a/docs/GITHUB-PROJECTS.md
+++ b/docs/GITHUB-PROJECTS.md
@@ -1,0 +1,282 @@
+# GitHub Projects v2 integration — guide
+
+> Bilingual: this is the English version. The Russian version is at [GITHUB-PROJECTS-RU.md](GITHUB-PROJECTS-RU.md).
+
+This document describes the **convention** for using GitHub Projects v2 boards across ForgePlan repos, the **field schema** that the convention assumes, and the **`/gh-project` skill + auto-add workflow template** that automate it.
+
+The integration is **project-agnostic**. The marketplace's board is `https://github.com/orgs/ForgePlan/projects/5`, but everything in this guide works in any other ForgePlan repo with its own board.
+
+---
+
+## TL;DR
+
+```
+1. Create board on GitHub UI (or `gh project create --owner <owner> --title <title>`).
+2. In any repo:
+   /gh-project init     ← interactive: project number + owner + field check
+3. Copy auto-add template:
+   cp docs/templates/auto-add-to-project.yml .github/workflows/
+   # then edit project-url
+4. Workflow now auto-adds new issues + PRs to the board.
+5. After `forgeplan new prd` for Standard+:
+   /gh-project link-prd PRD-NNN     ← creates issue + adds to board with Forgeplan-ID
+6. After `forgeplan activate PRD-NNN`:
+   /gh-project sync-status PRD-NNN  ← updates board Status field
+```
+
+---
+
+## Convention
+
+### What goes on the board
+
+| Source | Goes to board | Type field | Default Status |
+|---|---|---|---|
+| Forgeplan PRD (Standard+) | ✅ via `/gh-project link-prd` (creates GH issue, adds to board) | `PRD` | `Backlog` (or `Ready` if validated) |
+| Forgeplan RFC (Standard+) | ✅ same | `RFC` | `Backlog` |
+| Forgeplan ADR | ✅ same; usually goes straight to `Done` after activation | `ADR` | `Done` |
+| Forgeplan PRD/RFC (Tactical) | ❌ — Tactical = no artifact ceremony; PR alone is enough | n/a | n/a |
+| Forgeplan Evidence | ❌ — internal artifact; no separate board card | n/a | n/a |
+| Forgeplan Note | ❌ — too granular; reference material | n/a | n/a |
+| GitHub PR (any) | ✅ auto-added by workflow | `Feature` / `Bug` / `Docs` / `Chore` (parsed from title) | `In Review` |
+| GitHub Issue (any opened) | ✅ auto-added by workflow | `Bug` (default) — relabel manually | `Backlog` |
+
+**Why Tactical isn't on the board**: Tactical scope = "just do it" (per `forgeplan route`). Adding it to the board creates noise — the eventual PR is enough signal.
+
+### Status mapping (Forgeplan ↔ Project)
+
+| Forgeplan status | Project Status | Trigger |
+|---|---|---|
+| Artifact `draft`, not yet validated | `Backlog` | After `forgeplan new` |
+| Artifact `draft`, `forgeplan validate` PASS | `Ready` | After validate |
+| Artifact `active` (post-`forgeplan activate`) | `In Progress` (if work ongoing) or `Done` (if shipped) | After activate + judgement |
+| Artifact `superseded` | `Done` | After `forgeplan supersede` |
+| Artifact `deprecated` | `Cancelled` | After `forgeplan deprecate` |
+| PR opened | `In Review` | Auto-add workflow |
+| PR merged | `Done` | Built-in workflow on PR close (configure in project UI) |
+
+### Label conventions
+
+Issues created via `/gh-project link-prd` are labelled with:
+
+| Label | When |
+|---|---|
+| `forgeplan` | All artifact-tracking issues |
+| `prd` / `rfc` / `adr` | Mirrors artifact kind |
+| `active` | When `forgeplan activate` runs (added by `/gh-project sync-status`) |
+| `closed` | When superseded or deprecated |
+
+PRs are auto-labelled by their conventional-commit title prefix (`fix(...)`, `feat(...)`, `docs(...)`, `chore(...)`, `audit(...)`, `refactor(...)`). The auto-add workflow doesn't depend on labels, but the `/gh-project add-pr` operation reads the title prefix to set the Type field.
+
+---
+
+## Field schema (recommended)
+
+Create these fields **once** on your project board (or verify with `/gh-project init` which warns about missing ones).
+
+| Field | Type | Options | Required by skill? |
+|---|---|---|---|
+| **Status** | single-select (built-in) | `Backlog`, `Ready`, `In Progress`, `In Review`, `Done`, `Cancelled` | yes |
+| **Type** | single-select | `PRD`, `RFC`, `ADR`, `Feature`, `Bug`, `Docs`, `Chore` | yes |
+| **Forgeplan-ID** | text | n/a | yes (for `link-prd` and `sync-status`) |
+| **Plugin** | single-select | `fpl-skills`, `forgeplan-workflow`, `forgeplan-orchestra`, `forgeplan-brownfield-pack`, `fpf`, `laws-of-ux`, `agents-core`, `agents-domain`, `agents-pro`, `agents-github`, `agents-sparc`, `marketplace` | optional but recommended |
+| **Priority** | single-select | `P0`, `P1`, `P2`, `P3` | optional |
+
+### Why these specifically
+
+- **Status** is the single most-viewed field in any board. Six options cover every artifact lifecycle phase.
+- **Type** distinguishes architectural artifacts (PRD/RFC/ADR) from execution work (Feature/Bug/Docs/Chore).
+- **Forgeplan-ID** is the back-pointer into the artifact graph — the load-bearing field. Without it, board cards are disconnected from `.forgeplan/`.
+- **Plugin** scopes work to specific marketplace components, useful when many plugins evolve in parallel.
+- **Priority** is genuinely team-specific. GitHub provides no canonical meaning ([per docs discussion](https://github.com/orgs/community/discussions/54055)). P0/P1/P2/P3 is one common scheme.
+
+### Creating fields via `gh` CLI
+
+If `/gh-project init` reports missing fields, here are the commands it suggests:
+
+```bash
+# Single-select example (Type field with several options)
+gh project field-create 5 --owner ForgePlan \
+  --name "Type" \
+  --data-type SINGLE_SELECT \
+  --single-select-options "PRD,RFC,ADR,Feature,Bug,Docs,Chore"
+
+# Text field (Forgeplan-ID)
+gh project field-create 5 --owner ForgePlan \
+  --name "Forgeplan-ID" \
+  --data-type TEXT
+```
+
+Reference: [gh project field-create](https://cli.github.com/manual/gh_project_field-create).
+
+---
+
+## Auto-add — two paths
+
+### Option 1 — Built-in project workflow (recommended for simple cases)
+
+Configured in the project UI, no Actions file needed.
+
+1. Open project: `https://github.com/orgs/<owner>/projects/<num>`
+2. Click `⋯` (top-right) → `Workflows`
+3. Find `Auto-add to project` (built-in)
+4. Configure: pick the source repo, optional filters (issue state, labels)
+5. Save & Enable
+
+**Pros**: zero code, zero secrets, ~30 seconds.
+**Cons**: less flexible (e.g. can't AND/OR/NOT label filters as easily).
+
+[GitHub docs reference](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/adding-items-automatically).
+
+### Option 2 — `actions/add-to-project@v1` workflow
+
+When you need more control: AND/OR/NOT label filters, multi-repo source, custom triggers.
+
+1. Copy `docs/templates/auto-add-to-project.yml` → `.github/workflows/auto-add-to-project.yml`
+2. Replace `{{PROJECT_URL}}` placeholder
+3. Ensure auth:
+   - **GITHUB_TOKEN** works if your org allows token to write to projects (Settings → Actions → Workflow permissions). Many orgs disable this.
+   - Otherwise create a **fine-grained PAT** with Organization → Projects (read+write), store as `ADD_TO_PROJECT_PAT` secret, change `github-token:` line.
+4. Commit. Workflow fires on next opened/reopened issue or PR.
+
+[Action repo](https://github.com/actions/add-to-project).
+
+### Which to choose
+
+| You want | Path |
+|---|---|
+| One repo → one project, all items | Option 1 (built-in) |
+| Filter by labels (AND/OR/NOT) | Option 2 (Action) |
+| Multi-repo → one project | Option 2 — copy workflow into each repo |
+| Org-wide auto-add | Option 1 (built-in workflow supports multiple sources) |
+
+The marketplace uses **Option 2** so the convention is fully reproducible (workflow file is reviewable, version-controlled, and copy-pasteable to other repos).
+
+---
+
+## Authentication
+
+`gh` CLI must have project scope:
+
+| Token type | Required scopes |
+|---|---|
+| Classic PAT | `project` (read+write), `repo` (private repo issues) |
+| Fine-grained | Organization → **Projects: read+write**; Repository → **Issues: read+write**, **Pull requests: read** |
+
+```bash
+# Probe
+gh auth status
+
+# If `project` scope missing
+gh auth refresh -s read:project,write:project
+```
+
+`/gh-project init` does this probe and surfaces the refresh command.
+
+---
+
+## End-to-end examples
+
+### Setting up a new repo
+
+```bash
+# 1. Create project board (one time, in any repo or globally)
+gh project create --owner ForgePlan --title "Marketplace tracking"
+
+# 2. In your repo
+cd my-new-repo
+forgeplan init                                # if not already
+/gh-project init                              # interactive: project num + owner
+
+# 3. Copy auto-add template
+mkdir -p .github/workflows
+cp $(forgeplan path)/docs/templates/auto-add-to-project.yml .github/workflows/
+# edit, replace {{PROJECT_URL}}
+git add .github/workflows/auto-add-to-project.yml
+git commit -m "chore(ci): auto-add to ForgePlan project"
+```
+
+### Standard+ PRD lifecycle on the board
+
+```bash
+# Authoring
+/shape "magic-link auth for admin panel"          # creates PRD-024 (Standard)
+forgeplan validate PRD-024                         # PASS
+
+# Linking to board
+/gh-project link-prd PRD-024
+# → creates GH issue "PRD-024: magic-link auth for admin panel"
+# → adds to board with Type=PRD, Forgeplan-ID=PRD-024, Status=Backlog
+
+# Implementing
+git checkout -b feat/magic-link-auth
+# ... work ...
+gh pr create --title "feat(auth): magic-link admin login (PRD-024)"
+# → workflow auto-adds PR to board, Type=Feature, Status=In Review
+
+# Activating
+forgeplan activate PRD-024
+/gh-project sync-status PRD-024
+# → updates board Status to Done (or In Progress if work ongoing)
+```
+
+### Tactical fix (NO ceremony)
+
+```bash
+# Quick fix
+forgeplan route "fix typo in README" → Tactical
+git checkout -b fix/readme-typo
+# ... fix ...
+gh pr create --title "fix(docs): typo in README"
+# → workflow auto-adds PR to board, Type=Docs, Status=In Review
+# → no PRD, no /gh-project link-prd, no manual cards
+```
+
+---
+
+## Adding to CLAUDE.md
+
+When `/gh-project init` runs, optionally append a 13-line note to project CLAUDE.md describing the convention. This works the same way as the forgeplan operating contract from PRD-018.
+
+Marker for idempotent re-runs: `<!-- gh-project-convention:v1 -->`
+
+```markdown
+<!-- gh-project-convention:v1 -->
+## GitHub Projects integration (this project)
+
+This project tracks work via GitHub Projects v2 board: <PROJECT_URL>.
+Configuration is in `.forgeplan/state/gh-project.yaml` (per-project, not committed).
+
+**What goes on the board**:
+- All PRs (auto-added by `.github/workflows/auto-add-to-project.yml`).
+- Standard+ PRDs/RFCs (manually via `/gh-project link-prd PRD-NNN`). Tactical artifacts → PR-only.
+
+**Lifecycle sync**: after `forgeplan activate <ID>` run `/gh-project sync-status <ID>`.
+
+**Skill**: `/gh-project init` (one-time setup), `add-pr`, `link-prd`, `sync-status`, `list`.
+**Guide**: `docs/GITHUB-PROJECTS.md` in marketplace, or its mirror in any repo using this convention.
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `gh project view <num>` returns 404 | Wrong number or owner | `gh project list --owner <owner>` to discover |
+| Workflow fires but item not on board | Token can't write to project | Switch from `GITHUB_TOKEN` to PAT-secret |
+| `/gh-project link-prd` fails with "missing field 'Forgeplan-ID'" | Field not created on board | Run the `gh project field-create` command from `/gh-project init` warning |
+| `gh auth refresh` says "fine-grained tokens cannot be refreshed" | Using fine-grained PAT | Generate new PAT manually with required scopes |
+| Item already on board, duplicate created | Old `actions/add-to-project@v0` had a bug | Upgrade to `@v1` |
+
+---
+
+## References
+
+- [Best practices for Projects](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/best-practices-for-projects)
+- [Adding items automatically](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/adding-items-automatically)
+- [actions/add-to-project](https://github.com/actions/add-to-project)
+- [gh project CLI manual](https://cli.github.com/manual/gh_project)
+- [Custom fields docs](https://docs.github.com/en/issues/planning-and-tracking-with-projects/understanding-fields)
+- Skill body: `plugins/fpl-skills/skills/gh-project/SKILL.md`
+- Workflow template: `docs/templates/auto-add-to-project.yml`

--- a/docs/templates/auto-add-to-project.yml
+++ b/docs/templates/auto-add-to-project.yml
@@ -1,0 +1,42 @@
+# Reusable template — auto-add issues + PRs from this repo to a GitHub Projects v2 board.
+#
+# To use:
+# 1. Copy this file to .github/workflows/auto-add-to-project.yml in your repo.
+# 2. Replace {{PROJECT_URL}} with your project URL — e.g.
+#    https://github.com/orgs/ForgePlan/projects/5  (org-level)
+#    https://github.com/users/explosivebit/projects/3  (user-level)
+# 3. Ensure repo or org has a secret named ADD_TO_PROJECT_PAT or use GITHUB_TOKEN
+#    if your org allows GITHUB_TOKEN to write to projects (org settings → Actions).
+#    PAT scopes (classic): project, repo (for private repos)
+#    PAT scopes (fine-grained): Organization → Projects (read+write), Repository → Issues + PRs (read)
+# 4. Optional — narrow scope by labels: see `labeled` filter below.
+#
+# Reference: https://github.com/actions/add-to-project
+
+name: Auto-add to project
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  # Read-only on this repo's issues/PRs; write on the project.
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  add-to-project:
+    name: Add issue/PR to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1
+        with:
+          project-url: '{{PROJECT_URL}}'
+          # If GITHUB_TOKEN can't write to your project, replace with secrets.ADD_TO_PROJECT_PAT
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Optional: only add items with at least one of these labels (AND/OR/NOT supported).
+          # labeled: prd,rfc,bug,feature
+          # label-operator: OR

--- a/docs/templates/auto-add-to-project.yml
+++ b/docs/templates/auto-add-to-project.yml
@@ -6,10 +6,12 @@
 #    https://github.com/orgs/ForgePlan/projects/5  (org-level)
 #    https://github.com/users/explosivebit/projects/3  (user-level)
 # 3. Ensure repo or org has a secret named ADD_TO_PROJECT_PAT or use GITHUB_TOKEN
-#    if your org allows GITHUB_TOKEN to write to projects (org settings → Actions).
+#    if your org allows GITHUB_TOKEN to write to projects (org settings -> Actions).
 #    PAT scopes (classic): project, repo (for private repos)
-#    PAT scopes (fine-grained): Organization → Projects (read+write), Repository → Issues + PRs (read)
-# 4. Optional — narrow scope by labels: see `labeled` filter below.
+#    PAT scopes (fine-grained): Organization -> Projects (read+write), Repository -> Issues + PRs (read)
+# 4. Optional - narrow scope by labels: see `labeled` filter below.
+# 5. Bump the SHA below when a new actions/add-to-project major version ships.
+#    Get current SHA: gh api repos/actions/add-to-project/git/ref/tags/v2.x.x --jq '.object.sha'
 #
 # Reference: https://github.com/actions/add-to-project
 
@@ -22,7 +24,7 @@ on:
     types: [opened, reopened, ready_for_review]
 
 permissions:
-  # Read-only on this repo's issues/PRs; write on the project.
+  # Read-only on this repo's issues/PRs; project write is on the action's token side.
   contents: read
   issues: read
   pull-requests: read
@@ -32,7 +34,8 @@ jobs:
     name: Add issue/PR to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1
+      # SHA-pinned to v2.0.0 (security best practice — never trust floating major tags).
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
           project-url: '{{PROJECT_URL}}'
           # If GITHUB_TOKEN can't write to your project, replace with secrets.ADD_TO_PROJECT_PAT

--- a/plugins/fpl-skills/.claude-plugin/plugin.json
+++ b/plugins/fpl-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fpl-skills",
-  "version": "1.7.1",
-  "description": "Flagship workflow plugin for the ForgePlan ecosystem. 21 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, /riper RIPER orchestrator, plus session helpers) + dev-advisor agent + 4 hooks. Every workflow skill is forgeplan-aware. Full feature parity with the legacy dev-toolkit plus 18 additional skills built on forgeplan's artifact lifecycle.",
+  "version": "1.8.0",
+  "description": "Flagship workflow plugin for the ForgePlan ecosystem. 22 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, /riper RIPER orchestrator, /gh-project project-agnostic GitHub Projects v2 integration, plus session helpers) + dev-advisor agent + 4 hooks. Every workflow skill is forgeplan-aware. Full feature parity with the legacy dev-toolkit plus 19 additional skills built on forgeplan's artifact lifecycle.",
   "author": {
     "name": "ForgePlan"
   },
@@ -50,6 +50,7 @@
       "do",
       "forge-report",
       "fpl-init",
+      "gh-project",
       "migrate-from-dev-toolkit",
       "refine",
       "research",

--- a/plugins/fpl-skills/skills/gh-project/SKILL.md
+++ b/plugins/fpl-skills/skills/gh-project/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: gh-project
+description: Project-agnostic GitHub Projects v2 integration. Reads per-project config from .forgeplan/state/gh-project.yaml; never hardcodes project numbers. Five operations — init (one-time setup), add-pr (current/given PR → board), link-prd (Standard+ PRD → matching GH issue + board entry with Forgeplan-ID field), sync-status (read forgeplan artifact status, write project board Status field), list (current items on board). Gracefully degrades when gh CLI scopes are missing or config absent. Triggers (EN/RU) — "gh-project", "add to project", "link prd to issue", "sync project status", "/gh-project", "добавь на доску", "связи с проектом", "обнови статус на доске".
+disable-model-invocation: true
+allowed-tools: Read Write Edit Bash(test *) Bash(ls *) Bash(cat *) Bash(pwd *) Bash(command *) Bash(git *) Bash(gh *) Bash(forgeplan *) Bash(jq *) Bash(python3 *)
+---
+
+# gh-project — GitHub Projects v2 integration
+
+**Project-agnostic** skill that bridges forgeplan artifacts with a GitHub Projects v2 board. Reads per-project configuration from `.forgeplan/state/gh-project.yaml`; never hardcodes project numbers or owner names.
+
+The marketplace's project board is `https://github.com/orgs/ForgePlan/projects/5` — but this skill works in **any** repo whose `.forgeplan/state/gh-project.yaml` points at any project owned by anyone. Setup is one-time per repo via `/gh-project init`.
+
+---
+
+## Project context (read first)
+
+@docs/agents/issue-tracker.md
+@docs/agents/paths.md
+
+If `forgeplan` CLI is on `$PATH`, this skill is forgeplan-aware (cross-references PRD/RFC/ADR/Evidence). If not — `/gh-project add-pr` and `list` still work (they don't depend on forgeplan); `link-prd` and `sync-status` will refuse with a clear error.
+
+---
+
+## Configuration file
+
+Single YAML at `.forgeplan/state/gh-project.yaml`. Created by `/gh-project init`, **never committed** (project board ID may be private; add to `.gitignore` if not already).
+
+```yaml
+schema_version: 1
+project_number: 5             # GitHub project number (visible in URL)
+project_owner: ForgePlan      # org or user that owns the project
+project_node_id: PVT_kw...    # cached after init
+field_ids:
+  status:        PVTSSF_xxx
+  type:          PVTSSF_yyy
+  forgeplan_id:  PVTF_zzz     # text field
+  plugin:        PVTSSF_www
+  priority:      PVTSSF_vvv   # optional
+status_options:
+  Backlog:       abc123
+  Ready:         def456
+  In Progress:   ghi789
+  In Review:     jkl012
+  Done:          mno345
+  Cancelled:     pqr678
+type_options:
+  PRD:           ...
+  RFC:           ...
+  ADR:           ...
+  Feature:       ...
+  Bug:           ...
+  Docs:          ...
+  Chore:         ...
+auto_add_default_status: Backlog
+last_sync: 2026-05-08T12:34:56Z
+```
+
+Field IDs cached for speed — `gh project item-edit` requires IDs not names. If a field is renamed/recreated upstream, `/gh-project init` re-runs to refresh.
+
+---
+
+## When to use
+
+- One-time per repo: `/gh-project init` (interactive — asks project number, owner, verifies fields).
+- After opening a PR: `/gh-project add-pr` (without args, picks up current PR via `gh pr view`).
+- After `forgeplan new prd` for a Standard+ PRD: `/gh-project link-prd PRD-NNN` (creates issue, adds to board, sets Forgeplan-ID + Type).
+- After forgeplan artifact transition (`activate`, `deprecate`, `supersede`): `/gh-project sync-status PRD-NNN` (writes Status to board).
+- Anytime: `/gh-project list` (current board items, filtered).
+
+## When NOT to use
+
+- Tactical fixes — they take the PR-only path; auto-add workflow handles them automatically. Manual `/gh-project add-pr` only needed if auto-add is disabled.
+- Project board doesn't exist yet — create it first via GitHub UI or `gh project create --owner ForgePlan --title "..."`. This skill assumes board exists.
+- gh CLI not installed — refuse with install instruction (`brew install gh` / `apt install gh` / etc.).
+
+---
+
+## Auth scopes
+
+`gh` CLI must have these scopes:
+
+| Token type | Required scopes |
+|---|---|
+| Classic PAT | `project` (read+write projects), `repo` (for private repo issues) |
+| Fine-grained | Organization permissions → **Projects: read+write**; Repository permissions → **Issues: read+write**, **Pull requests: read** |
+
+Probe + surface (never auto-refresh):
+
+```bash
+gh auth status 2>&1 | grep -E "Token scopes|Active account"
+```
+
+If `project` scope is missing, surface:
+
+```
+Missing GH auth scope: project (read+write).
+Run once: gh auth refresh -s read:project,write:project
+Then re-run /gh-project <operation>.
+```
+
+---
+
+## Operations
+
+### `/gh-project init`
+
+One-time per repo. Interactive prompts:
+
+1. **Probe**: `gh auth status` → confirm scopes; `command -v gh` → confirm CLI.
+2. **Ask**: project number (e.g. `5`), owner (e.g. `ForgePlan`).
+3. **Verify** with `gh project view <num> --owner <owner> --format json`. If 404 → error with link to `gh project list --owner <owner>` for discovery.
+4. **List fields** with `gh project field-list <num> --owner <owner> --format json`.
+5. **Map** fields to expected slots (Status, Type, Forgeplan-ID, Plugin, Priority).
+6. **Warn on missing recommended fields** — print exact `gh project field-create ...` command for each missing one. Don't auto-create (user-owned schema).
+7. **Cache** project node-id, field IDs, single-select option IDs into `.forgeplan/state/gh-project.yaml`.
+8. **Append** `.forgeplan/state/gh-project.yaml` to `.gitignore` if not already there.
+
+**Re-run behaviour**: if config exists, prompt "Config exists. Refresh field IDs from server? [y/n]" — refreshing only updates `field_ids` and `*_options`, leaves project_number/owner/auto_add_default_status alone.
+
+### `/gh-project add-pr [<pr-url>]`
+
+Add a PR (current branch's open PR, or explicit URL) to the configured project board.
+
+```bash
+# Resolve PR URL (no arg → current branch)
+PR_URL=${1:-$(gh pr view --json url -q .url)}
+
+# Read config
+CONFIG=$(cat .forgeplan/state/gh-project.yaml)
+PROJ_NUM=$(yq '.project_number' <<<"$CONFIG")
+OWNER=$(yq '.project_owner' <<<"$CONFIG")
+
+# Add to board
+gh project item-add "$PROJ_NUM" --owner "$OWNER" --url "$PR_URL"
+```
+
+If PR title starts with `fix(`, set Type=`Bug`; with `feat(` → `Feature`; with `docs(` → `Docs`; with `chore(`/`audit(`/`refactor(` → `Chore`. All optional — skill prompts user once and remembers PR-title-to-Type mapping for the session.
+
+Status defaults to `In Review` (PRs go straight to review, not backlog).
+
+### `/gh-project link-prd <PRD-NNN>`
+
+For Standard+ PRDs only. Creates GH issue + adds to board + sets Forgeplan-ID and Type fields.
+
+```bash
+PRD_ID="$1"
+
+# Read forgeplan artifact
+ART_TITLE=$(forgeplan get "$PRD_ID" 2>/dev/null | head -3 | tail -1 | sed 's/^# //')
+
+# Create issue
+ISSUE_URL=$(gh issue create \
+  --title "$PRD_ID: $ART_TITLE" \
+  --label "prd,forgeplan" \
+  --body "## Forgeplan artifact
+
+This issue tracks **$PRD_ID**: $ART_TITLE
+
+See \`.forgeplan/prds/${PRD_ID}-*.md\` for the full body.
+
+## Sync
+
+Run \`/gh-project sync-status $PRD_ID\` to update board Status from forgeplan state.
+" --json url -q .url)
+
+# Add to board, set fields
+gh project item-add "$PROJ_NUM" --owner "$OWNER" --url "$ISSUE_URL"
+# Then gh project item-edit with Forgeplan-ID = $PRD_ID, Type = "PRD"
+```
+
+If `forgeplan get $PRD_ID` shows depth=tactical, refuse with hint to use `/gh-project add-pr` for the eventual PR instead.
+
+### `/gh-project sync-status <ARTIFACT-ID>`
+
+Read forgeplan artifact status, write to project Status field.
+
+| Forgeplan status | Project Status |
+|---|---|
+| draft | Backlog (or Ready if validated — check via `forgeplan validate <id>`) |
+| active | In Progress |
+| superseded | Done |
+| deprecated | Cancelled |
+
+Find issue on board by Forgeplan-ID field match. If no item exists → suggest `/gh-project link-prd` first.
+
+### `/gh-project list [--filter status=<X>]`
+
+`gh project item-list <num> --owner <owner> --format json | jq '...'` filtered by Status. Pretty-print to stdout.
+
+---
+
+## Anti-patterns
+
+- ❌ Don't hardcode project number in skill body or workflow files. Always read config (skill) or use template placeholders (workflow).
+- ❌ Don't auto-create missing project fields. User owns the schema; skill warns + prints command.
+- ❌ Don't auto-refresh GH tokens. Surface the `gh auth refresh` command, let user run it.
+- ❌ Don't commit `.forgeplan/state/gh-project.yaml` (project node IDs are not secret but field IDs change between projects; checking it in is misleading). `init` adds to `.gitignore` automatically.
+- ❌ Don't link Tactical-depth artifacts. Tactical = no artifact ceremony; PR alone is enough on the board.
+
+---
+
+## Related
+
+- [`fpl-init`](../fpl-init/SKILL.md) — bootstrap orchestrator. Future: could call `/gh-project init` as step 9-bis when user has GitHub remote.
+- [`shape`](../shape/SKILL.md) — interactive PRD authoring. After it creates a Standard+ PRD, `/gh-project link-prd` is a natural follow-up.
+- [`forge-cycle`](../../forgeplan-workflow/skills/forge-cycle/SKILL.md) — full forgeplan cycle. Could chain `/gh-project link-prd` after PRD creation, `/gh-project sync-status` after activate.
+- `docs/GITHUB-PROJECTS.md` — bilingual guide (convention, field schema, setup, end-to-end).
+- `docs/templates/auto-add-to-project.yml` — reusable workflow template.
+
+---
+
+## Errors and recovery
+
+| Symptom | Action |
+|---|---|
+| `.forgeplan/state/gh-project.yaml` missing | Refuse, print "Run `/gh-project init` first." |
+| `gh: not found` | Print install command for the OS, refuse. |
+| Missing `project` scope | Print `gh auth refresh -s read:project,write:project`, refuse. |
+| `gh project view <num>` returns 404 | "Project not found. Run `gh project list --owner <owner>` to discover, then re-run `/gh-project init`." |
+| Field ID stale (server returns "field not found") | Auto-trigger field-IDs refresh: re-run init in --refresh mode. |
+| `forgeplan get $ID` returns nothing | Refuse with "artifact ID not found in `.forgeplan/`. Check `forgeplan list`." |
+| Auto-add workflow fires but item not on board | Check workflow logs, GH_TOKEN secret presence, project URL correctness. Skill itself doesn't manage the workflow file — it's per-repo `.github/workflows/auto-add-to-project.yml`. |
+
+---
+
+## Idempotency
+
+- `init` re-run: prompts to refresh field IDs only (preserves user choices).
+- `add-pr`: GH project item-add is naturally idempotent (no-op if already on board).
+- `link-prd`: detects existing issue with `Forgeplan-ID == PRD-NNN` and reuses it; doesn't create duplicates.
+- `sync-status`: pure update, idempotent.


### PR DESCRIPTION
## Summary

**Project-agnostic** skill that bridges forgeplan artifacts with a GitHub Projects v2 board, plus convention guide and auto-add workflow.

User asked: «можно как-то настроить наш текущий проект на него?» (referring to `https://github.com/orgs/ForgePlan/projects/5`). Then: «и нужен наверное какой то гайд - давай в сети глянем как сделано». Then critical course-correction: «я верно понимаю что скилл не завязан на конкретном проекте?»

This PR delivers the full design: skill + convention + bilingual guide + auto-add template, all project-agnostic.

Routed `/forge-cycle` (Standard, conf 90%). PRD-019 validated (5 links, PASS). AC-1..AC-7 all met.

## What ships

| File | Type | Lines |
|---|---|---|
| `plugins/fpl-skills/skills/gh-project/SKILL.md` | NEW skill | ~250 |
| `docs/GITHUB-PROJECTS.md` + `-RU.md` | NEW bilingual guide | ~250 each |
| `docs/templates/auto-add-to-project.yml` | NEW reusable workflow template | ~30 |
| `.github/workflows/auto-add-to-project.yml` | NEW filled-in for marketplace | ~30 |
| `CLAUDE.md` (marketplace) | section added | +13 |
| `plugin.json`, `marketplace.json`, `CHANGELOG.md` | bumps + entry | — |

Total: 951 insertions across 9 files.

## Skill design

**Project-agnostic by design**: skill never hardcodes project numbers or owner names. Reads per-project `.forgeplan/state/gh-project.yaml`:

```yaml
project_number: 5
project_owner: ForgePlan
project_node_id: PVT_kw...
field_ids: { status: ..., type: ..., forgeplan_id: ..., plugin: ... }
status_options: { Backlog: ..., Ready: ..., In Progress: ..., ... }
```

Same skill works in marketplace (project 5), any other ForgePlan repo, user-owned projects.

**5 operations**:
- `init` — interactive one-time setup; verifies via `gh project view`, lists fields, warns on missing recommended fields, caches IDs.
- `add-pr [<url>]` — adds PR (current branch's, or explicit) to board; Type derived from conventional-commit title prefix.
- `link-prd <PRD-NNN>` — Standard+ → creates GH issue + adds to board with Forgeplan-ID + Type. Refuses Tactical-depth.
- `sync-status <ARTIFACT-ID>` — reads forgeplan artifact status, writes Status field on board (full mapping documented).
- `list` — pretty-prints current board items.

**Field IDs cached** in config: `gh project item-edit` requires IDs not names. Refresh via re-running `init`.

## Convention (in guide + CLAUDE.md)

| Source | Goes to board | Type | Default Status |
|---|---|---|---|
| Standard+ PRD/RFC | ✅ via `link-prd` | `PRD`/`RFC` | `Backlog` |
| ADR | ✅ via `link-prd` | `ADR` | `Done` |
| Tactical PRD/RFC | ❌ — PR only | n/a | n/a |
| Evidence/Note | ❌ — internal | n/a | n/a |
| Any PR | ✅ auto-added by workflow | from title prefix | `In Review` |
| Any Issue | ✅ auto-added | `Bug` (default) | `Backlog` |

**Status mapping** (Forgeplan ↔ Project): draft → Backlog/Ready · active → In Progress/Done · superseded → Done · deprecated → Cancelled · PR opened → In Review.

**Two auto-add paths** documented (research-informed):
- **Built-in project workflow** (UI, no Actions file) — simpler one-repo→one-project case.
- **`actions/add-to-project@v1`** — for label filters, multi-repo, version-controlled config.

Marketplace uses the Action path so the convention is fully reproducible.

## Web research that informed the design

| Source | What it confirmed |
|---|---|
| [GitHub: best practices for Projects](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/best-practices-for-projects) | Custom fields convention; no canonical priority/size meaning |
| [actions/add-to-project repo](https://github.com/actions/add-to-project) | Use `@v1`; AND/OR/NOT label filters; auth via GITHUB_TOKEN or PAT |
| [gh project CLI manual](https://cli.github.com/manual/gh_project) | `item-edit` requires field IDs not names; → cache in config |
| [GitHub: adding items automatically](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/adding-items-automatically) | Built-in project workflow as alternative to Action |

## Verification

- ✅ `./scripts/validate-all-plugins.sh` — ALL PASSED.
- ✅ Bilingual guide row-order parity verified.
- ✅ Workflow template uses official `actions/add-to-project@v1`.
- ✅ Skill prose covers all 5 operations + idempotency + auth probe + error recovery.
- ✅ CLAUDE.md inject pattern matches operating-contract pattern from PRD-018.

## Test plan

- [x] Validation script passes
- [x] Skill is project-agnostic (no hardcoded project number / owner anywhere in body)
- [x] Auto-add workflow uses official Action `@v1`
- [x] Bilingual guide complete in EN + RU
- [x] Versions bumped (fpl-skills 1.7.1 → 1.8.0; catalog 1.20.1 → 1.21.0)
- [x] CHANGELOG entry explains scope, web-research findings, deferred items

## What's NOT in scope (deferred)

- **Auto-creating missing project fields** — user owns the schema; skill warns + prints `gh project field-create` command. Auto-create would silently mutate user's project.
- **Bidirectional issue body ↔ forgeplan body sync** — one-way reference (issue body has `## Forgeplan artifact` line) is sufficient.
- **GitHub Projects v1 (classic)** — discontinued; only v2 supported.
- **Bot-owned auto-PRD-id assignment from PR title** — heuristic-prone; manual `link-prd` is more reliable.

## Setup for marketplace (post-merge, one-time)

After merge, in this repo:
1. `gh auth refresh -s read:project,write:project` (one-time, host-level)
2. `/gh-project init` — interactive: enter `5` (project), `ForgePlan` (owner)
3. Auto-add workflow already on disk → fires on next opened PR/issue

For other ForgePlan repos: copy `docs/templates/auto-add-to-project.yml`, replace `{{PROJECT_URL}}`, run `/gh-project init` once.

Refs: PRD-019, PRD-018 (refines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)