### PR TITLE
fix(fpl-skills): v1.9.2 — /fpl-init MCP args ["mcp"] → ["serve"]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.22.1"
+    "version": "1.22.2"
   },
   "plugins": [
     {
       "name": "fpl-skills",
       "source": "./plugins/fpl-skills",
       "description": "Flagship workflow plugin for the ForgePlan ecosystem. 22 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, /riper RIPER orchestrator, /gh-project project-agnostic GitHub Projects v2 integration, plus session helpers) + dev-advisor agent + 4 hooks. /fpl-init injects a 13-line forgeplan operating contract into project CLAUDE.md (idempotent v1 marker). SessionStart hook surfaces concrete next-action when forgeplan health is non-clean (orphans/stubs/dups/stale). UNCONDITIONAL claim/dispatch wiring (PRD-020): /sprint + /autorun derive synthetic SESSION-YYYY-MM-DD-HHMMSS for chat-driven mode — every teammate registers in the artifact graph regardless of whether task references PRD-NNN. /gh-project bridges forgeplan artifacts with a GitHub Projects v2 board via per-project config (no hardcoded project numbers). Full feature parity with the legacy dev-toolkit plus 19 additional skills built on forgeplan's artifact lifecycle.",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "author": {
         "name": "ForgePlan"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to the ForgePlan Marketplace will be documented in this file
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.2] - 2026-05-08
+
+**Fix `/fpl-init` MCP server config** — `args: ["mcp"]` produced a hanging command (`forgeplan mcp` is a parent command waiting for subcommand), causing Claude Code to report `failed to reconnect to forgeplan` for every project bootstrapped with v1.6.0+ of `/fpl-init`. Switched to `args: ["serve"]` — the direct stdio MCP server entry-point.
+
+### Fixed
+- `fpl-skills` v1.9.1 → **1.9.2** (patch — config-template fix in `/fpl-init`):
+  - `plugins/fpl-skills/skills/fpl-init/SKILL.md` step 5 (Wire `.mcp.json`):
+    - **Target shape `args` field**: `["mcp"]` → `["serve"]`. `forgeplan mcp` is a parent command with subcommands (`serve`, `install`, `help`); without a subcommand it hangs awaiting one, which manifests as MCP handshake failure in Claude Code.
+    - **Python merge implementation**: now detects the buggy `args == ["mcp"]` shape on existing `.mcp.json` files and upgrades to `["serve"]` automatically (idempotent — re-running `/fpl-init` migrates broken configs).
+    - **Added "Why `args: ["serve"]` not `["mcp"]`" rationale** inline so future edits don't regress.
+
+### Changed
+- `marketplace.json`: catalog 1.22.1 → **1.22.2**; fpl-skills 1.9.1 → 1.9.2.
+- `plugin.json` (fpl-skills): version 1.9.1 → 1.9.2.
+
+### Notes
+**Discovery process**: user ran `/mcp` in Claude Code, output showed `forgeplan · ✘ failed`. Investigation: `forgeplan serve --help` revealed `Usage: forgeplan serve` (no subcommand needed, no `--stdio` flag), while `forgeplan mcp --help` showed it's a parent command. Empirical fix on this repo's `.mcp.json` from `["mcp"]` → `["serve"]` confirmed working.
+
+**Existing `.mcp.json` files in user projects**: the upgraded merge logic in `/fpl-init` step 5 will auto-fix them on re-run (`args == ["mcp"]` is detected and replaced). Users can also patch manually with one-liner:
+```bash
+python3 -c "import json,pathlib; p=pathlib.Path('.mcp.json'); d=json.loads(p.read_text()); d['mcpServers']['forgeplan']['args']=['serve']; p.write_text(json.dumps(d,indent=2)+'\n')"
+```
+
+**No behavior change in working systems** — only repairs broken MCP wiring. Skills using forgeplan via shell (existing flow) are unaffected.
+
+**Forward-compat to Option B (forgeplan MCP-first wiring)**: now that the MCP server actually starts, `mcp__forgeplan__*` tools should appear in Claude Code's deferred-tools list. PRD-021 (skill prose preferring MCP over shell) becomes practically possible — was theoretical until this fix.
+
 ## [1.22.1] - 2026-05-08
 
 **Convention drift fix** — `/gh-project` skill prose + bilingual guides now match `orgs/ForgePlan/projects/5` server reality discovered during empirical setup (Step 4-6 of post-PRD-020 verification, EVID-031).

--- a/plugins/fpl-skills/.claude-plugin/plugin.json
+++ b/plugins/fpl-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fpl-skills",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Flagship workflow plugin for the ForgePlan ecosystem. 22 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, /riper RIPER orchestrator, /gh-project project-agnostic GitHub Projects v2 integration, plus session helpers) + dev-advisor agent + 4 hooks. Every workflow skill is forgeplan-aware with UNCONDITIONAL claim/dispatch wiring (PRD-020) — chat-driven sprints derive synthetic SESSION-YYYY-MM-DD-HHMMSS for claim-loop, no more bypass. Full feature parity with the legacy dev-toolkit plus 19 additional skills built on forgeplan's artifact lifecycle.",
   "author": {
     "name": "ForgePlan"

--- a/plugins/fpl-skills/skills/fpl-init/SKILL.md
+++ b/plugins/fpl-skills/skills/fpl-init/SKILL.md
@@ -146,20 +146,21 @@ Target shape:
   "mcpServers": {
     "forgeplan": {
       "command": "forgeplan",
-      "args": ["mcp"],
+      "args": ["serve"],
       "transport": "stdio"
     }
   }
 }
 ```
 
+**Why `args: ["serve"]` not `["mcp"]`** — `forgeplan mcp` is a *parent* command with subcommands (`mcp serve`, `mcp install`, `mcp help`). Launching it without a subcommand makes the server hang waiting for one, and Claude Code reports `failed to reconnect`. The canonical MCP server command is `forgeplan serve` (stdio is the default and only transport, no `--stdio` flag exists). `["mcp", "serve"]` also works as an alias path but `["serve"]` is the most direct.
+
 Rules:
 - File missing → write the minimal version above.
 - File present + `mcpServers.forgeplan` missing → merge the entry in,
   preserving every other server (e.g. `hindsight`, `orch`).
-- File present + `mcpServers.forgeplan` already there → diff against
-  target shape; if it matches, skip; if not, ask the user before
-  changing.
+- File present + `mcpServers.forgeplan.args == ["mcp"]` → **upgrade to `["serve"]`** (this is the buggy v1.6.0 init output that fails to reconnect; the upgrade is idempotent and safe).
+- File present + `mcpServers.forgeplan.args == ["serve"]` already → skip (correct shape).
 
 Implementation: prefer `python3` for the merge (always available, no
 dependency on `jq`):
@@ -170,11 +171,13 @@ import json, pathlib
 p = pathlib.Path(".mcp.json")
 data = json.loads(p.read_text()) if p.exists() else {}
 data.setdefault("mcpServers", {})
-data["mcpServers"].setdefault("forgeplan", {
-    "command": "forgeplan",
-    "args": ["mcp"],
-    "transport": "stdio",
-})
+fp = data["mcpServers"].get("forgeplan")
+if fp is None or fp.get("args") == ["mcp"]:  # missing OR buggy old shape
+    data["mcpServers"]["forgeplan"] = {
+        "command": "forgeplan",
+        "args": ["serve"],
+        "transport": "stdio",
+    }
 p.write_text(json.dumps(data, indent=2) + "\n")
 PY
 ```


### PR DESCRIPTION
## Summary

**Bug discovered live**: user ran \`/mcp\` in Claude Code, got \`forgeplan · ✘ failed to reconnect\`. Root cause: \`/fpl-init\` step 5 (Wire \`.mcp.json\`) generated config with \`args: ["mcp"]\`. But \`forgeplan mcp\` is a *parent command* with subcommands (\`serve\`, \`install\`, \`help\`) — without a subcommand it hangs awaiting one → MCP handshake never completes → Claude Code reports failed.

The canonical MCP server entry-point is \`forgeplan serve\` (stdio is the default and only transport — no \`--stdio\` flag exists).

## What changed

- \`plugins/fpl-skills/skills/fpl-init/SKILL.md\` step 5:
  - Target shape \`args\` field: \`["mcp"]\` → \`["serve"]\`
  - Python merge implementation now **auto-detects** buggy \`args == ["mcp"]\` on existing \`.mcp.json\` files and upgrades to \`["serve"]\` (idempotent re-run heals broken configs)
  - Added "Why \`args: [\"serve\"]\` not \`[\"mcp\"]\`" rationale block inline

- \`plugin.json\` (fpl-skills): 1.9.1 → 1.9.2 (patch)
- \`marketplace.json\`: catalog 1.22.1 → 1.22.2; fpl-skills 1.9.1 → 1.9.2
- \`CHANGELOG.md\`: new 1.22.2 entry with discovery process + recovery one-liner for users

## Empirical proof

\`\`\`bash
# Before fix (broken):
\$ cat .mcp.json | jq .mcpServers.forgeplan
{ "command": "forgeplan", "args": ["mcp"], "transport": "stdio" }

\$ # /mcp in Claude Code → "forgeplan · ✘ failed"

# After fix:
\$ python3 -c "import json,pathlib; p=pathlib.Path('.mcp.json'); d=json.loads(p.read_text()); d['mcpServers']['forgeplan']['args']=['serve']; p.write_text(json.dumps(d,indent=2)+'\n')"

\$ timeout 2 forgeplan serve  # accepts stdin (MCP server behavior), no errors
\`\`\`

## Recovery one-liner for users with v1.6.0+ broken \`.mcp.json\`

Either re-run \`/fpl-init\` (idempotent — auto-fixes), or:

\`\`\`bash
python3 -c "import json,pathlib; p=pathlib.Path('.mcp.json'); d=json.loads(p.read_text()); d['mcpServers']['forgeplan']['args']=['serve']; p.write_text(json.dumps(d,indent=2)+'\n')"
\`\`\`

## Verification

- ✅ \`./scripts/validate-all-plugins.sh\` passes
- ✅ Local \`.mcp.json\` patched manually, \`forgeplan serve\` runs cleanly
- ✅ Documentation explains both target shape and migration path

## Test plan

- [x] forgeplan CLI verified — \`serve\` is the right entry-point, no flags needed
- [x] Skill prose updated with rationale + auto-migration logic
- [x] Versions bumped (1.9.1 → 1.9.2, catalog 1.22.1 → 1.22.2)
- [ ] Post-merge: user re-runs \`/fpl-init\` in test repo → MCP server actually appears in deferred tools list
- [ ] Post-merge: \`mcp__forgeplan__*\` tools become available → unlocks PRD-021 (Option B — skill prose preferring MCP over shell)

## What this unblocks

- **PRD-021 (Option B MCP-first wiring)** becomes practically possible. Until now skill prose mentioned \`mcp__forgeplan__*\` as forward-compat note, but those tools never actually appeared because the server didn't start. Now they will (after Claude Code restart in projects with fixed \`.mcp.json\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)