### PR TITLE
fix(lint): LR forgeplan-aware detection — B2 disallowedTools support + CLAUDE.md sync

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.36.0"
+    "version": "1.37.0"
   },
   "plugins": [
     {
@@ -36,7 +36,7 @@
       "name": "fpl-skills",
       "source": "./plugins/fpl-skills",
       "description": "Flagship workflow plugin for the ForgePlan ecosystem. 22 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, /riper RIPER orchestrator, /gh-project project-agnostic GitHub Projects v2 integration, plus session helpers) + dev-advisor agent + 4 hooks. v1.15.0: AGENT-AUTHORING-GUIDE.md \u2014 CRUD-R-A matrix (5-operation lifecycle with designated profile per operation), Profile D/Maintainer (NEW \u2014 artifact-maintainer, in-place fixes via forgeplan_update, forgeplan_new DENIED), artifact-reviewer generic (Profile B, reviews artifact schema/links/freshness \u2014 distinct from code/security/design reviewers), forgeplan_generate primary creation path (DRY, ~2s, ~$0.005/artifact). v1.14.0: PRD-026 Phase 5 \u2014 fpl-init v2.0 canonical layer scaffold; LR-1..LR-7 canonical-pattern lint rules. Full feature parity with the legacy dev-toolkit plus 19 additional skills built on forgeplan's artifact lifecycle.",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "author": {
         "name": "ForgePlan"
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,9 @@
 # ForgePlan Marketplace — Claude Code Configuration
 
 **Repo**: [ForgePlan/marketplace](https://github.com/ForgePlan/marketplace)
-**Catalog version**: 1.21.0
-**Plugins**: 11 (6 workflow + 5 agent packs)
+**Catalog version**: 1.36.0
+**Plugins**: 13 (7 workflow + 5 agent packs + 1 memory plugin fpl-hsmem)
+**Agents**: 17 of ~65 forgeplan-aware (PRD-026 canonical B2 paradigm — `disallowedTools` denylist + `forgeplan_generate` primary creation path + 5 profiles A/B/C/C-coder/D)
 **Project board**: [orgs/ForgePlan/projects/5](https://github.com/orgs/ForgePlan/projects/5)
 
 ---

--- a/plugins/fpl-skills/.claude-plugin/plugin.json
+++ b/plugins/fpl-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fpl-skills",
-  "version": "1.15.0",
-  "description": "Flagship workflow plugin for the ForgePlan ecosystem. 22 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, /riper RIPER orchestrator, /gh-project project-agnostic GitHub Projects v2 integration, plus session helpers) + dev-advisor agent + 4 hooks. Every workflow skill is forgeplan-aware with UNCONDITIONAL claim/dispatch wiring (PRD-020) and hybrid MCP-first dispatch (PRD-021 Phase 1 + PRD-022 Phase 2 Batch 1: shape/rfc/diagnose/restore/briefing migrated to mcp__forgeplan__* with CLI fallback) — chat-driven sprints derive synthetic SESSION-YYYY-MM-DD-HHMMSS for claim-loop, no more bypass. Full feature parity with the legacy dev-toolkit plus 19 additional skills built on forgeplan's artifact lifecycle.",
+  "version": "1.15.1",
+  "description": "Flagship workflow plugin for the ForgePlan ecosystem. 22 engineering skills (research, refine, sprint, audit, diagnose, autorun, /fpl-init bootstrap, forge-report structured reports, /shape interview-from-scratch, /migrate-from-dev-toolkit automation, /ddd-decompose, /c4-diagram, /riper RIPER orchestrator, /gh-project project-agnostic GitHub Projects v2 integration, plus session helpers) + dev-advisor agent + 4 hooks. Every workflow skill is forgeplan-aware with UNCONDITIONAL claim/dispatch wiring (PRD-020) and hybrid MCP-first dispatch (PRD-021 Phase 1 + PRD-022 Phase 2 Batch 1: shape/rfc/diagnose/restore/briefing migrated to mcp__forgeplan__* with CLI fallback) \u2014 chat-driven sprints derive synthetic SESSION-YYYY-MM-DD-HHMMSS for claim-loop, no more bypass. Full feature parity with the legacy dev-toolkit plus 19 additional skills built on forgeplan's artifact lifecycle.",
   "author": {
     "name": "ForgePlan"
   },
@@ -37,7 +37,9 @@
   },
   "components": {
     "commands": [],
-    "agents": ["dev-advisor"],
+    "agents": [
+      "dev-advisor"
+    ],
     "skills": [
       "audit",
       "autorun",

--- a/scripts/validate-all-plugins.sh
+++ b/scripts/validate-all-plugins.sh
@@ -208,8 +208,24 @@ def check_agent(plugin, agent_path):
         tools = []
     tools_set = set(tools)
 
-    # Detect forgeplan-aware
-    is_fp_aware = any(t.startswith('mcp__forgeplan__') for t in tools)
+    # Parse disallowedTools (B2 paradigm — comma-separated string OR list)
+    disallowed_raw = fm.get('disallowedTools', '') or ''
+    if isinstance(disallowed_raw, str):
+        disallowed_set = set(t.strip() for t in disallowed_raw.split(',') if t.strip())
+    elif isinstance(disallowed_raw, list):
+        disallowed_set = set(disallowed_raw)
+    else:
+        disallowed_set = set()
+
+    # Detect forgeplan-aware:
+    #   - Legacy v1 path: tools allowlist contains mcp__forgeplan__*
+    #   - B2 canonical path: disallowedTools mentions mcp__forgeplan__forgeplan_activate
+    #     (only canonical Profile A/B/D agents explicitly deny activate)
+    #   - Body path: mentions mcp__forgeplan__ MCP calls
+    is_fp_aware_legacy = any(t.startswith('mcp__forgeplan__') for t in tools)
+    is_fp_aware_b2 = 'mcp__forgeplan__forgeplan_activate' in disallowed_set or any(t.startswith('mcp__forgeplan__') for t in disallowed_set)
+    is_fp_aware_body = bool(body and 'mcp__forgeplan__' in body)
+    is_fp_aware = is_fp_aware_legacy or is_fp_aware_b2 or is_fp_aware_body
     if is_fp_aware:
         forgeplan_aware += 1
     else:


### PR DESCRIPTION
## Summary

After B2 paradigm migration, LR-1..LR-7 detection in validate-all-plugins.sh missed all 17 canonical agents (saw 0 forgeplan-aware, 65 legacy). Now correctly detects via 3-way OR: tools allowlist (legacy v1) | disallowedTools contains forgeplan_activate (B2 canonical) | body mentions mcp__forgeplan__ (semantic fallback).

Result: 17 forgeplan-aware detected (was 0), LR-4/LR-5/LR-6 now applied correctly to canonical agents.

## Verification

- `./scripts/validate-all-plugins.sh` — ALL PASSED, 17 forgeplan-aware / 51 legacy / 0 errors / 121 warns (migration nudges)

## Other

- CLAUDE.md project-level: catalog version stale 1.21.0 → 1.36.0; agents count noted (17 of ~65)

## Version bumps

- fpl-skills: 1.15.0 → 1.15.1 (lint script patch)
- catalog: 1.36.0 → 1.37.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)