### PR TITLE
docs(polish): post-PRD-026 README refresh + catalog v1.38.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.37.0"
+    "version": "1.38.0"
   },
   "plugins": [
     {
@@ -186,8 +186,8 @@
     {
       "name": "agents-core",
       "source": "./plugins/agents-core",
-      "description": "Core development agents: debugger, code reviewer, error detective, performance engineer, production validator, plus complete dev team (coder, planner, researcher, reviewer, tester, TDD). v1.2: coder forgeplan-aware Profile C-coder reference + code-reviewer + tester Profile B (PRD-026 Phase 3 complete \u2014 3 of 11 agents migrated).",
-      "version": "1.2.0",
+      "description": "Core development agents: debugger, code reviewer, error detective, performance engineer, production validator, plus complete dev team (coder, planner, researcher, reviewer, tester, TDD). v1.2: coder forgeplan-aware Profile C-coder reference + code-reviewer + tester Profile B (PRD-026 Phase 3 complete \u2014 3 of 11 agents migrated). v1.2.1: README refreshed with profile labels + Forgeplan-aware section.",
+      "version": "1.2.1",
       "author": {
         "name": "ForgePlan"
       },
@@ -208,8 +208,8 @@
     {
       "name": "agents-pro",
       "source": "./plugins/agents-pro",
-      "description": "Professional specialist agents: security experts, architecture reviewers, creative tools, research analysts, infrastructure engineers, plus pipeline-canonical roles. v1.7: 3 NEW generic CRUD-R-A agents \u2014 artifact-author (Profile A, forgeplan_generate primary), artifact-maintainer (Profile D, metadata maintenance \u2014 NEW canonical profile), artifact-reviewer (Profile B generic, artifact-health audit). Cumulative: 12 of 28 agents forgeplan-aware.",
-      "version": "1.7.0",
+      "description": "Professional specialist agents: security experts, architecture reviewers, creative tools, research analysts, infrastructure engineers, plus pipeline-canonical roles. v1.7: 3 NEW generic CRUD-R-A agents \u2014 artifact-author (Profile A, forgeplan_generate primary), artifact-maintainer (Profile D, metadata maintenance \u2014 NEW canonical profile), artifact-reviewer (Profile B generic, artifact-health audit). Cumulative: 12 of 28 agents forgeplan-aware. v1.7.1: README refreshed (28 agents grouped by canonical profile + non-canonical specialists).",
+      "version": "1.7.1",
       "author": {
         "name": "ForgePlan"
       },
@@ -230,8 +230,8 @@
     {
       "name": "agents-sparc",
       "source": "./plugins/agents-sparc",
-      "description": "SPARC development methodology: orchestrator with quality gates plus 4 phase specialists (specification, pseudocode, architecture, refinement). v1.1: specification + architecture migrated to forgeplan-aware Profile A (PRD-026 Phase 3 batch 1).",
-      "version": "1.1.0",
+      "description": "SPARC development methodology: orchestrator with quality gates plus 4 phase specialists (specification, pseudocode, architecture, refinement). v1.1: specification + architecture migrated to forgeplan-aware Profile A (PRD-026 Phase 3 batch 1). v1.1.1: README refreshed with profile labels + Forgeplan-aware section.",
+      "version": "1.1.1",
       "author": {
         "name": "ForgePlan"
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # ForgePlan Marketplace — Claude Code Configuration
 
 **Repo**: [ForgePlan/marketplace](https://github.com/ForgePlan/marketplace)
-**Catalog version**: 1.36.0
+**Catalog version**: 1.37.0
 **Plugins**: 13 (7 workflow + 5 agent packs + 1 memory plugin fpl-hsmem)
 **Agents**: 17 of ~65 forgeplan-aware (PRD-026 canonical B2 paradigm — `disallowedTools` denylist + `forgeplan_generate` primary creation path + 5 profiles A/B/C/C-coder/D)
 **Project board**: [orgs/ForgePlan/projects/5](https://github.com/orgs/ForgePlan/projects/5)
@@ -172,6 +172,21 @@ Hook bypass: временно убрать из `.claude/settings.json` (не р
 ./scripts/validate-all-plugins.sh          # Все плагины
 ./scripts/validate-all-plugins.sh plugin-name  # Один плагин
 ```
+
+---
+
+## Plugin cache troubleshooting (workaround for users)
+
+If users report that updates to canonical agents don't appear after `/plugin marketplace update`, the cause is usually Claude Code's plugin cache invalidation behavior (upstream issue, captured in PROB-001 deprecated 2026-05-19):
+
+| Symptom | Root cause | Workaround |
+|---------|------------|------------|
+| `/plugin install` says "already installed" but new version present | Cache exists, settings.local.json shows enabled | `/plugin uninstall` + `/plugin install` (force re-resolve) |
+| `/plugin uninstall` doesn't free disk space | Settings toggle, cache files remain | Manual: `rm -rf ~/.claude-code-plugins/<plugin-name>` then reinstall |
+| New version in marketplace.json not picked up | Catalog `metadata.version` not bumped | Verify catalog `metadata.version` was bumped — required for `/plugin marketplace update` to refresh |
+| Agent loaded but new tools/config not active | Stale subagent cache in conversation | `/reload-plugins` (Claude Code session-level) |
+
+**Rule of thumb when shipping**: always bump both per-plugin `version` AND catalog `metadata.version`. Without the catalog bump, no user gets the update via `/plugin marketplace update`.
 
 ---
 

--- a/plugins/agents-core/.claude-plugin/plugin.json
+++ b/plugins/agents-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-core",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Core development agents: debugger, code reviewer, error detective, performance engineer, production validator, plus a complete dev team (coder, planner, researcher, reviewer, tester, TDD London School). v1.2: coder migrated to forgeplan-aware Profile C-coder reference (PRD-026 Phase 3 batch 3 — Phase 3 complete). v1.1: code-reviewer + tester (batch 2).",
   "author": {"name": "ForgePlan"},
   "homepage": "https://github.com/ForgePlan/marketplace",

--- a/plugins/agents-core/README.md
+++ b/plugins/agents-core/README.md
@@ -8,21 +8,33 @@ Core development agents: debugger, code reviewer, error detective, performance e
 /plugin install agents-core@ForgePlan-marketplace
 ```
 
-## Agents
+## Agents (11)
 
-| Agent | Description |
-|-------|-------------|
-| **debugger** | Expert debugger specializing in complex issue diagnosis, root cause analysis, and systematic problem-solving across multiple languages and environments |
-| **code-reviewer** | Senior code reviewer -- quality, security, performance, and maintainability across any language |
-| **error-detective** | Forensic error investigator -- root cause analysis, cascade mapping, log correlation, and anomaly detection across distributed and monolithic systems |
-| **performance-engineer** | Senior performance engineer covering profiling, bottleneck analysis, optimization techniques, monitoring, SLA management, and capacity planning |
-| **production-validator** | Production readiness validator -- detects mock implementations, verifies real integrations, validates deployment configuration, and ensures no stubs remain in release code |
-| **coder** | Implementation specialist -- writes clean, maintainable, production-quality code |
-| **planner** | Strategic planning -- decomposes complex tasks into actionable execution plans |
-| **researcher** | Deep research and analysis -- investigates codebases, finds patterns, synthesizes knowledge |
-| **reviewer** | Code review and quality assurance -- finds bugs, security issues, and design problems |
-| **tester** | Testing and QA specialist -- designs test strategies, writes tests, validates quality |
-| **tdd-london** | TDD London School specialist -- outside-in development, mock-driven design, behavior verification, and interaction testing for clean object collaboration |
+Legend: ⚙ = forgeplan-aware (B2 paradigm — see [AGENT-AUTHORING-GUIDE.md](../fpl-skills/AGENT-AUTHORING-GUIDE.md)).
+
+| Agent | Profile | Description |
+|-------|:-------:|-------------|
+| **coder** ⚙ | C-coder | Source-mutating implementation agent — the only profile allowed Write/Edit/Bash on source files. Reads parent RFC/SPEC via forgeplan MCP, writes code, hands off to Profile B reviewer for EVIDENCE recording |
+| **code-reviewer** ⚙ | B | Diff/file-set reviewer — runs lint/type-check/tests via Bash, produces forgeplan EVIDENCE artifact with PASS/CONCERNS/BLOCKER verdict + categorised findings (Bug / Style / Architecture / Performance / Docs / Test gap) |
+| **tester** ⚙ | B | Test runner and coverage analyst — executes test suite via Bash, parses output, measures coverage delta against acceptance criteria, records verdict as EVIDENCE artifact linked `informs` to parent |
+| **debugger** | — | Expert debugger specializing in complex issue diagnosis, root cause analysis, and systematic problem-solving across multiple languages and environments |
+| **error-detective** | — | Forensic error investigator — root cause analysis, cascade mapping, log correlation, and anomaly detection across distributed and monolithic systems |
+| **performance-engineer** | — | Senior performance engineer covering profiling, bottleneck analysis, optimization techniques, monitoring, SLA management, and capacity planning |
+| **production-validator** | — | Production readiness validator — detects mock implementations, verifies real integrations, validates deployment configuration, and ensures no stubs remain in release code |
+| **planner** | — | Strategic planning — decomposes complex tasks into actionable execution plans |
+| **researcher** | — | Deep research and analysis — investigates codebases, finds patterns, synthesizes knowledge |
+| **reviewer** | — | Code review and quality assurance — finds bugs, security issues, and design problems (general-purpose, non-canonical) |
+| **tdd-london** | — | TDD London School specialist — outside-in development, mock-driven design, behavior verification, and interaction testing for clean object collaboration |
+
+## Forgeplan-aware agents (3, PRD-026 canonical)
+
+Three agents in this pack implement the **canonical pipeline profiles** for code work:
+
+- **`coder`** (Profile C-coder) — the only agent allowed to mutate source files. Receives RFC/SPEC context via `forgeplan_get`, writes code, requests Profile B review via orchestrator.
+- **`code-reviewer`** (Profile B) — produces EVIDENCE artifact with PASS/CONCERNS/BLOCKER verdict and findings categorised by type.
+- **`tester`** (Profile B) — produces EVIDENCE artifact with pass/fail/skipped/flaky counts and coverage delta.
+
+This trio enables `coder → code-reviewer → tester → guardian` flow in `/forge-cycle` and `/autorun` orchestrators.
 
 ## Groups
 

--- a/plugins/agents-pro/.claude-plugin/plugin.json
+++ b/plugins/agents-pro/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-pro",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Professional specialist agents: security experts, architecture reviewers, creative tools, research analysts, infrastructure engineers, plus pipeline-canonical roles. v1.7: 3 NEW generic CRUD-R-A agents — artifact-author (Profile A, forgeplan_generate primary + forgeplan_new fallback), artifact-maintainer (Profile D, metadata maintenance, NEW canonical profile), artifact-reviewer (Profile B generic, artifact-health audit distinct from code/security/RFC/test reviewers). Cumulative: 12 of 28 agents forgeplan-aware.",
   "author": {"name": "ForgePlan"},
   "homepage": "https://github.com/ForgePlan/marketplace",

--- a/plugins/agents-pro/README.md
+++ b/plugins/agents-pro/README.md
@@ -1,6 +1,6 @@
 # agents-pro
 
-Professional specialist agents: security experts, architecture reviewers, creative tools, research analysts, and infrastructure engineers.
+Professional specialist agents: security experts, architecture reviewers, creative tools, research analysts, infrastructure engineers, and **forgeplan-aware canonical pipeline agents** (PRD-026, B2 paradigm).
 
 ## Installation
 
@@ -8,26 +8,41 @@ Professional specialist agents: security experts, architecture reviewers, creati
 /plugin install agents-pro@ForgePlan-marketplace
 ```
 
-## Agents (21)
+## Agents (28)
 
-### Security (4)
+Legend: ⚙ = forgeplan-aware (B2 paradigm — `disallowedTools` denylist + canonical pipeline profile A/B/C/D).
+
+### Forgeplan canonical pipeline (12 agents, all ⚙)
+
+| Agent | Profile | Description |
+|-------|:-------:|-------------|
+| `artifact-author` ⚙ | A (generic) | Generic Profile A creator for any forgeplan artifact kind (primary `forgeplan_generate`, fallback `forgeplan_new` + manual body) |
+| `artifact-maintainer` ⚙ | D (NEW) | In-place metadata maintenance on EXISTING artifacts — congruence_level, evidence_type, broken links, status changes |
+| `artifact-reviewer` ⚙ | B (generic) | Artifact health audit — schema completeness, link graph health, freshness/decay, R_eff trust |
+| `adr-architect` ⚙ | A | Architecture Decision Records using MADR 3.0 format |
+| `architect-reviewer` ⚙ | B | RFC fitness review against parent PRD — modular boundaries, coupling, data-flow, blast radius |
+| `brief-intake` ⚙ | A | First-touch intake — raw idea → structured Brief NOTE artifact |
+| `evidence-recorder` ⚙ | B (fallback) | Generic Profile B EVIDENCE recorder for phases without kind-specialist |
+| `goal-planner` ⚙ | A | GOAP decomposition — PRD/EPIC → set of RFC tasks via `forgeplan_decompose` |
+| `guardian` ⚙ | B-gate | Pre-activation gate — binary verdict PASS/CONCERNS/BLOCKER from full EVID chain |
+| `research-analyst` ⚙ | C (read-only) | Read-only research — internal context + external prior art, never persists state |
+| `security-expert` ⚙ | B | Security audit — OWASP/STRIDE/CWE findings as EVIDENCE artifact |
+| `system-dev` ⚙ | B (staff) | Staff/principal-level final auditor — long-term maintainability, blast radius, system-wide review |
+
+### Security (3 specialists, non-canonical)
 
 | Agent | Description |
 |-------|-------------|
-| `security-expert` | OWASP Top 10 detection, secret scanning, threat modeling (STRIDE/DREAD), compliance auditing |
 | `claims-authorizer` | Claims-based ABAC/RBAC policies, fine-grained permissions, audit trails |
 | `injection-analyst` | Prompt injection and jailbreak detection with 6-type threat taxonomy |
 | `pii-detector` | PII and credential scanning with API key regexes and compliance mapping |
 
-### Architecture (6)
+### Architecture (3 specialists, non-canonical)
 
 | Agent | Description |
 |-------|-------------|
-| `adr-architect` | Architecture Decision Records using MADR 3.0 format |
-| `architect-reviewer` | System design validation, pattern assessment, scalability analysis |
 | `ddd-domain-expert` | Bounded contexts, aggregate design, domain modeling, context mapping |
 | `distributed-systems-expert` | Consensus protocols (Raft, PBFT, Paxos), CRDTs, gossip protocols |
-| `goal-planner` | Goal-Oriented Action Planning (GOAP) with A* search and OODA loop |
 | `microservices-architect` | Microservice design, service boundaries, resilience, operational excellence |
 
 ### Creative (4)
@@ -39,14 +54,13 @@ Professional specialist agents: security experts, architecture reviewers, creati
 | `prompt-engineer` | Prompt design, optimization, few-shot/CoT patterns, A/B testing |
 | `ui-designer` | Design systems, interaction patterns, visual hierarchy, accessibility |
 
-### Research (5)
+### Research (4 specialists, non-canonical)
 
 | Agent | Description |
 |-------|-------------|
 | `code-analyzer` | Code quality analysis across quality, performance, security, architecture, and tech debt |
 | `memory-specialist` | HNSW indexing, vector quantization, hybrid search with RRF fusion |
 | `ml-developer` | End-to-end ML workflows: preprocessing, training, tuning, evaluation |
-| `research-analyst` | Information gathering, synthesis, source evaluation, actionable intelligence |
 | `search-specialist` | Advanced information retrieval, query optimization, knowledge discovery |
 
 ### Infrastructure (2)
@@ -56,14 +70,36 @@ Professional specialist agents: security experts, architecture reviewers, creati
 | `mcp-developer` | Model Context Protocol server/client implementation, JSON-RPC 2.0 |
 | `platform-engineer` | Internal developer platforms, self-service infrastructure, GitOps |
 
+## Forgeplan-aware agent layer (PRD-026)
+
+The 12 forgeplan-aware agents in this pack implement the **B2 paradigm** — `disallowedTools` denylist (not `tools:` allowlist) — to work around Claude Code's MCP propagation bug (#53865) where wildcard entries in subagent tools silently strip the entire MCP server.
+
+Each agent has a **canonical profile** dictating its forgeplan surface:
+
+| Profile | Identity | Forgeplan operations allowed |
+|---------|----------|-------------------------------|
+| **A** Creator | Creates new artifacts | `forgeplan_new`, `_update`, `_link`, `_validate`, `_generate`, `_get`, `_list`, `_search`; denies `_activate` |
+| **B** Reviewer | Audits, produces EVIDENCE | `forgeplan_new` (EVID kind), `_update`, `_link`, `_validate`, `_get`, `_list`, `_search`; denies `_activate/_reason/_claims/_release/memory_retain` |
+| **C** Read-only | Research, no state mutation | `forgeplan_get`, `_list`, `_search`, `_health`; denies ALL mutations |
+| **C-coder** | Source files only | Source mutations via Write/Edit/Bash; denies all forgeplan mutations |
+| **D** Maintainer | Fix existing artifacts | `forgeplan_update`, `_link`, `_validate`, `_get`, `_list`, `_search`; denies `_new`, `_activate`, `_reason`, Write/Edit |
+
+See [AGENT-AUTHORING-GUIDE.md](../fpl-skills/AGENT-AUTHORING-GUIDE.md) for full authoring conventions and the 5 canonical profiles documentation.
+
 ## Usage
 
-After installation, agents are available via the `@agent-name` syntax:
+After installation, agents are available via the `Task` tool with `subagent_type`:
 
 ```
-@security-expert Review this code for OWASP Top 10 vulnerabilities
-@architect-reviewer Evaluate the architecture of this project
-@prompt-engineer Optimize this system prompt for accuracy
+# Canonical pipeline
+Task({ subagent_type: "artifact-author", prompt: "Create PRD for ..." })
+Task({ subagent_type: "artifact-reviewer", prompt: "Audit PRD-026 health" })
+Task({ subagent_type: "guardian", prompt: "Gate check PRD-026 for activation" })
+
+# Domain specialists
+Task({ subagent_type: "security-expert", prompt: "Review codebase for OWASP Top 10" })
+Task({ subagent_type: "architect-reviewer", prompt: "Review RFC-003 fitness" })
+Task({ subagent_type: "prompt-engineer", prompt: "Optimize this system prompt" })
 ```
 
 ## License

--- a/plugins/agents-sparc/.claude-plugin/plugin.json
+++ b/plugins/agents-sparc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-sparc",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "SPARC development methodology agents: orchestrator with quality gates, plus 4 phase specialists (specification, pseudocode, architecture, refinement/TDD). v1.1: specification + architecture migrated to forgeplan-aware canonical Profile A pattern (PRD-026 Phase 3 batch 1).",
   "author": {"name": "ForgePlan"},
   "homepage": "https://github.com/ForgePlan/marketplace",

--- a/plugins/agents-sparc/README.md
+++ b/plugins/agents-sparc/README.md
@@ -1,6 +1,6 @@
 # agents-sparc
 
-SPARC development methodology agents: orchestrator with quality gates, plus 4 phase specialists (specification, pseudocode, architecture, refinement/TDD).
+SPARC development methodology agents: orchestrator with quality gates, plus 4 phase specialists (specification, pseudocode, architecture, refinement/TDD). **Specification and architecture phases are forgeplan-aware** (PRD-026 canonical profiles).
 
 ## Installation
 
@@ -20,23 +20,32 @@ C -> Completion     -> Integration, validation, deployment
 
 ## Agents (5)
 
-| Agent | Description |
-|-------|-------------|
-| `sparc-orchestrator` | Master coordinator -- manages phase flow, enforces quality gates, delegates to phase specialists |
-| `specification` | Requirements analysis, constraint identification, acceptance criteria definition |
-| `pseudocode` | Algorithm design, data structure selection, complexity analysis |
-| `architecture` | System design, component architecture, infrastructure planning, security architecture |
-| `refinement` | TDD red-green-refactor, code optimization, performance tuning, error handling |
+Legend: ⚙ = forgeplan-aware (B2 paradigm — see [AGENT-AUTHORING-GUIDE.md](../fpl-skills/AGENT-AUTHORING-GUIDE.md)).
+
+| Agent | Profile | Description |
+|-------|:-------:|-------------|
+| `sparc-orchestrator` | — | Master coordinator — manages phase flow, enforces quality gates, delegates to phase specialists |
+| `specification` ⚙ | A (Creator) | SPARC Specification phase — produces PRD or SPEC artifacts via forgeplan MCP with SMART acceptance criteria, requirements, constraints, out-of-scope |
+| `pseudocode` | — | Algorithm design, data structure selection, complexity analysis |
+| `architecture` ⚙ | A (Creator) | SPARC Architecture phase — transforms PRD/SPEC into concrete RFC artifact (module breakdown, component contracts, data flow, function signatures, trade-offs) via forgeplan MCP |
+| `refinement` | — | TDD red-green-refactor, code optimization, performance tuning, error handling |
+
+## Forgeplan-aware agents (2, PRD-026 canonical)
+
+- **`specification`** (Profile A) — converts user requirements to forgeplan PRD or SPEC kind via `forgeplan_generate` (primary) or `forgeplan_new` + manual body fill (fallback). Calls `forgeplan_reason` before finalising acceptance criteria.
+- **`architecture`** (Profile A) — converts parent PRD/SPEC to concrete RFC via the same dual-path approach. Calls FPF ADI reasoning before picking a design option, weighs at least two alternatives.
+
+Both agents are A-Creator profile: `disallowedTools` denylist forbids `Write/Edit/NotebookEdit` and `forgeplan_activate`, but allows all other forgeplan mutations needed to create + link + validate the artifact.
 
 ## Usage
 
-After installation, agents are available via the `@agent-name` syntax:
+After installation, agents are available via the `Task` tool with `subagent_type`:
 
 ```
-@sparc-orchestrator Guide the development of a new authentication service through all SPARC phases
-@specification Define requirements for a payment processing module
-@architecture Design the system architecture for a real-time chat service
-@refinement Apply TDD to implement and optimize this feature
+Task({ subagent_type: "sparc-orchestrator", prompt: "Guide development of authentication service through all SPARC phases" })
+Task({ subagent_type: "specification", prompt: "Define PRD for payment processing module" })
+Task({ subagent_type: "architecture", prompt: "Design RFC for real-time chat service from PRD-NNN" })
+Task({ subagent_type: "refinement", prompt: "Apply TDD to implement and optimize this feature" })
 ```
 
 ## License


### PR DESCRIPTION
## Summary
- Refresh 3 agent pack READMEs (agents-core, agents-pro, agents-sparc) to reflect canonical profile labels (A/B/C/C-coder/D) and the 17 forgeplan-aware agents per PRD-026
- Bump catalog v1.37.0→v1.38.0 (required for /plugin marketplace update to push out the docs to users)
- Patch-bump 3 agent packs (1.2.0→1.2.1, 1.7.0→1.7.1, 1.1.0→1.1.1)
- Marketplace CLAUDE.md: stale version label fix + new "Plugin cache troubleshooting" workaround section (closes PROB-001 which was deprecated since the underlying CLI cache logic is upstream in Claude Code itself)

## Verification
- ✅ ./scripts/validate-all-plugins.sh — ALL PASSED (0 errors, 121 legacy warns — pre-existing)
- ✅ 17 forgeplan-aware agents listed correctly per pack (3 in agents-core, 12 in agents-pro, 2 in agents-sparc)
- ✅ Catalog version + per-plugin versions in lockstep
- ✅ PROB-001 deprecated via forgeplan_update (status='deprecated')

## Test plan
- ✅ jq parses all modified JSON files
- ✅ Per-plugin agent counts match plugin.json components.agents arrays
- ✅ AGENT-AUTHORING-GUIDE.md link target exists in agents-pro README references
- ✅ No empty `- [ ]` checkboxes in modified files

Refs: PRD-026, PROB-001