### PR TITLE
feat(agents-sparc): 100% canonical-lint compliance (v1.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.39.0"
+    "version": "1.40.0"
   },
   "plugins": [
     {
@@ -230,8 +230,8 @@
     {
       "name": "agents-sparc",
       "source": "./plugins/agents-sparc",
-      "description": "SPARC development methodology: orchestrator with quality gates plus 4 phase specialists (specification, pseudocode, architecture, refinement). v1.1: specification + architecture migrated to forgeplan-aware Profile A (PRD-026 Phase 3 batch 1). v1.1.1: README refreshed with profile labels + Forgeplan-aware section.",
-      "version": "1.1.1",
+      "description": "SPARC development methodology: orchestrator with quality gates plus 4 phase specialists (specification, pseudocode, architecture, refinement). v1.2: ALL 5 agents canonical-lint compliant — sparc-orchestrator + pseudocode + refinement migrated to valid model + hex color + bilingual EN/RU/Triggers descriptions. 100% pack passes LR-1..LR-3. specification + architecture remain forgeplan-aware Profile A (PRD-026 Phase 3 batch 1).",
+      "version": "1.2.0",
       "author": {
         "name": "ForgePlan"
       },

--- a/plugins/agents-sparc/.claude-plugin/plugin.json
+++ b/plugins/agents-sparc/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agents-sparc",
-  "version": "1.1.1",
-  "description": "SPARC development methodology agents: orchestrator with quality gates, plus 4 phase specialists (specification, pseudocode, architecture, refinement/TDD). v1.1: specification + architecture migrated to forgeplan-aware canonical Profile A pattern (PRD-026 Phase 3 batch 1).",
+  "version": "1.2.0",
+  "description": "SPARC development methodology agents: orchestrator with quality gates, plus 4 phase specialists (specification, pseudocode, architecture, refinement/TDD). v1.2: ALL 5 agents canonical-lint compliant — sparc-orchestrator + pseudocode + refinement migrated to model=opus|sonnet, hex colors, bilingual EN/RU/Triggers descriptions (legacy lint warnings eliminated). 100% of agents-sparc pack passes LR-1..LR-3. specification + architecture remain forgeplan-aware Profile A (PRD-026 Phase 3 batch 1).",
   "author": {"name": "ForgePlan"},
   "homepage": "https://github.com/ForgePlan/marketplace",
   "repository": "https://github.com/ForgePlan/marketplace",

--- a/plugins/agents-sparc/agents/pseudocode.md
+++ b/plugins/agents-sparc/agents/pseudocode.md
@@ -1,9 +1,12 @@
 ---
 name: pseudocode
-description: SPARC Pseudocode phase specialist for algorithm design, data structure selection, and complexity analysis
-model: inherit
+description: |
+  EN: SPARC Pseudocode phase specialist. Takes a parent SPEC/PRD or RFC draft and produces algorithm sketches, data structure choices, and complexity analysis (Big-O for time + space) BEFORE any code is written. Bridges Specification → Architecture by validating that the algorithmic core fits the constraints. Not forgeplan-aware — operates on local pseudo-code files. Hand off to `architecture` for concrete RFC, then to `coder` (C-coder profile) for implementation.
+  RU: Специалист фазы SPARC Pseudocode. Берёт родительский SPEC/PRD или черновик RFC и выдаёт скетчи алгоритмов, выбор структур данных и анализ сложности (Big-O для времени и памяти) ДО написания кода. Мост между Specification → Architecture: проверяет, что алгоритмическое ядро влезает в ограничения. Не forgeplan-aware — работает с локальными pseudo-code файлами. Передаёт `architecture` для конкретного RFC, далее `coder` (Profile C-coder) для реализации.
+  Triggers: "pseudocode", "algorithm design", "complexity analysis", "Big-O", "data structure choice", "SPARC pseudocode phase", "псевдокод", "анализ сложности", "выбор алгоритма", "выбор структуры данных", "before implementation sketch"
+model: sonnet
 tools: [Read, Write, Edit, Bash, Glob, Grep]
-color: indigo
+color: '#3F51B5'
 ---
 
 # SPARC Pseudocode Agent

--- a/plugins/agents-sparc/agents/refinement.md
+++ b/plugins/agents-sparc/agents/refinement.md
@@ -1,9 +1,12 @@
 ---
 name: refinement
-description: SPARC Refinement phase specialist for TDD red-green-refactor, code optimization, performance tuning, and error handling
-model: inherit
+description: |
+  EN: SPARC Refinement phase specialist. Executes red-green-refactor TDD loop on a code surface produced by `coder`: writes failing test (red), implements minimal change to pass (green), refactors for clarity/performance (refactor). Also handles post-implementation polish — error handling, edge cases, performance tuning. Operates on source files only; not forgeplan-aware. Hand off to `tester` (Profile B) for coverage delta EVIDENCE recording.
+  RU: Специалист фазы SPARC Refinement. Прогоняет цикл red-green-refactor TDD на код-поверхности от `coder`: пишет падающий тест (red), реализует минимальное изменение для прохождения (green), рефакторит для ясности/производительности (refactor). Также post-implementation polish — error handling, edge cases, performance tuning. Работает только с source files; не forgeplan-aware. Передаёт `tester` (Profile B) для записи coverage delta в EVIDENCE.
+  Triggers: "TDD refinement", "red green refactor", "refactor this code", "improve test coverage", "tune performance", "SPARC refinement", "TDD", "tighten the implementation", "уточни реализацию", "TDD цикл", "рефакторинг", "оптимизация производительности"
+model: sonnet
 tools: [Read, Write, Edit, Bash, Glob, Grep]
-color: violet
+color: '#673AB7'
 ---
 
 # SPARC Refinement Agent

--- a/plugins/agents-sparc/agents/sparc-orchestrator.md
+++ b/plugins/agents-sparc/agents/sparc-orchestrator.md
@@ -1,7 +1,10 @@
 ---
 name: sparc-orchestrator
-description: SPARC methodology orchestrator coordinating five development phases with quality gates and structured delegation
-model: inherit
+description: |
+  EN: SPARC methodology orchestrator. Coordinates 5 development phases (Specification → Pseudocode → Architecture → Refinement → Completion) by dispatching the corresponding phase-specialist agent for each phase, enforcing quality gates between phases, and aggregating phase outcomes into a final delivery report. Operates one level above individual phase specialists — picks the right specialist for the current phase, hands them context, evaluates their output, decides next phase. Not forgeplan-aware itself; delegates to specialists that may be forgeplan-aware (specification, architecture are Profile A creators).
+  RU: Оркестратор методологии SPARC. Координирует 5 фаз разработки (Specification → Pseudocode → Architecture → Refinement → Completion) через диспатч соответствующего phase-specialist агента для каждой фазы, контроль quality gates между фазами и агрегацию результатов в финальный delivery-отчёт. Работает на уровень выше отдельных phase-специалистов — выбирает правильного специалиста для текущей фазы, передаёт ему контекст, оценивает output, решает следующую фазу. Сам не forgeplan-aware; делегирует специалистам, которые могут быть forgeplan-aware (specification, architecture — Profile A creators).
+  Triggers: "SPARC orchestration", "SPARC pipeline", "guide through SPARC", "five-phase delivery", "SPARC quality gates", "structured delegation", "SPARC methodology", "guide development through all phases", "проведи через SPARC", "SPARC оркестрация", "координируй пять фаз", "SPARC pipeline"
+model: opus
 tools: [Read, Write, Edit, Bash, Glob, Grep]
 color: '#FF5722'
 ---


### PR DESCRIPTION
## Summary
- Migrate 3 remaining legacy SPARC agents (sparc-orchestrator, pseudocode, refinement) to canonical lint format (LR-1: valid model, LR-2: hex color, LR-3: bilingual EN/RU/Triggers descriptions)
- agents-sparc pack now 100% canonical-compliant (0 warnings) — first pack to reach this milestone
- Marketplace-wide warning count: 121 → 113 (-8)
- agents-sparc v1.1.1 → v1.2.0, catalog v1.39.0 → v1.40.0

## Why these 3 weren't B2 paradigm migrated
These agents are NOT forgeplan-aware (no MCP integration). Their `tools: [Read, Write, Edit, Bash, Glob, Grep]` allowlist uses only recognized base tools — does NOT trigger the wildcard-stripping bug #53865 that motivates B2 paradigm. Only frontmatter hygiene (LR-1..LR-3) was at issue.

## Verification
- ✅ ./scripts/validate-all-plugins.sh agents-sparc — 0 errors, 0 warns (was 8 warns)
- ✅ ./scripts/validate-all-plugins.sh (full) — ALL PASSED, 113 warns (was 121)
- ✅ 17 forgeplan-aware agents unaffected
- ✅ Descriptions bilingual with Triggers section per AGENT-AUTHORING-GUIDE pattern

## Pattern established for remaining 51 legacy agents
This PR demonstrates the migration recipe for non-forgeplan-aware legacy agents:
1. `model: inherit` → `model: sonnet` (or opus for orchestrators)
2. `color: <name>` → `color: '#RRGGBB'` (Material Design palette)
3. Description: rewrite as `EN: ... RU: ... Triggers: ...` bilingual block
4. KEEP `tools:` allowlist if non-forgeplan-aware (no MCP wildcards involved)

Future PRs apply this to agents-core (8 legacy), agents-domain (11), agents-github (7), agents-pro (15 non-canonical specialists), advisor agents (4) in similar pack-by-pack batches.

## Test plan
- ✅ Validation script: ALL PASSED
- ✅ Manual frontmatter inspection: all 3 agents have valid model + hex color + bilingual description
- ✅ Lint counts: SPARC pack 0/8 → 0/0 warns
- ✅ Versions in lockstep (plugin.json + marketplace.json catalog entry)

Refs: PRD-026 (canonical agent layer), future legacy-migration workstream