### PR TITLE
feat(marketplace): Sprint J+K — 4 new MCP tools exercised live (PRD-037)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.50.0"
+    "version": "1.51.0"
   },
   "plugins": [
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,3 +334,29 @@ Sprint G inventory only; live verification deferred to Sprint H+.
 - PRD-035 (active) — Sprint G scope + partial-adoption documentation
 - EVID-062 (active) — verification of Anomaly #5 partial fix + 7-tool discovery
 - v1.49.0 → **v1.50.0** catalog (this Sprint G milestone)
+
+## Sprint J+K 2026-05-20 — 4 new MCP tools verified live
+
+Sprint G inventoried 7 new MCP tools; Sprint J+K exercised 4 testable ones:
+
+| Tool | Verdict | Canonical example | Notes |
+|---|---|---|---|
+| `forgeplan_release_notes` | **Limited use** in split-repo layouts | `forgeplan_release_notes(since="v2.3.0")` | Requires `.forgeplan/` + `.git/` co-located; workaround via shell from git repo |
+| `forgeplan_restore` | **Delivers value** | `forgeplan_restore(id="NOTE-XXX")` after deprecate/supersede/delete | Verified roundtrip Sprint J+K K2; body preserves `## Deprecation` section |
+| `forgeplan_activity_stats` | **Delivers value** | `forgeplan_activity_stats(since_hours=24)` | Use to find slow tools / error counts; this session 133 calls / 3 errs / forgeplan_score slowest p95=3.5s |
+| `forgeplan_fpf_rules` | **Delivers value** | `forgeplan_fpf_rules(summary=true)` | 5 default rules: blind-spot, weak-evidence, orphan-active, medium-quality, ready-to-build |
+
+3 tools NOT yet exercised (need external context):
+- `forgeplan_discover_*` — needs brownfield codebase context (Sprint H+ scope)
+- `forgeplan_playbook_run` — needs playbook artifact + security gate (`yes: true`)
+- `forgeplan_ingest` — needs mapping YAML + source file
+
+### Anomaly #12 (NEW): release_notes split-repo constraint
+
+When `.forgeplan/` and `.git/` are in different directories (workspace root vs child repo), `forgeplan_release_notes` returns "git log failed: fatal: not a git repository". Workaround documented in Phase 7.3 of `/forge-cycle`. Captured as Sprint J+K Anomaly #12; not a blocker (tool works in standard setups).
+
+### Artifacts (Sprint J+K)
+- PRD-036 (active) — Sprint J+K scope
+- EVID-063 (active) — per-tool verdicts + K2 roundtrip log + activity stats snapshot
+- catalog v1.50.0 → **v1.51.0**
+- forgeplan-workflow v1.10.0 → v1.10.1 (Phase 7.3 added)

--- a/plugins/forgeplan-workflow/.claude-plugin/plugin.json
+++ b/plugins/forgeplan-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forgeplan-workflow",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Structured engineering workflow for forgeplan users. Provides /forge-cycle (full SDLC cycle: Hindsight v2 memory bootstrap + parallel subagent dispatch via forgeplan_dispatch + Task tool + multi-reviewer audit with 4 parallel agents + mail-as-beads autonomous decisions logging + MCP-first per PRD-021/022 + claim/release per PRD-020 — implements RFC-003/PRD-025) and /forge-audit (multi-expert review), methodology knowledge base, quality gate hooks. Requires forgeplan CLI. v1.10: PRD-034 Sprint F — /forge-cycle template clarified (Anomaly #1 fix) + Phase 6.7/Step 7.7 live-smoke discipline check (Anomaly #11 wiring). v1.9.1: forge-advisor agent canonical-lint compliant.",
   "author": {
     "name": "ForgePlan"

--- a/plugins/forgeplan-workflow/commands/forge-cycle.md
+++ b/plugins/forgeplan-workflow/commands/forge-cycle.md
@@ -583,6 +583,46 @@ Stage all changes and commit using conventional commit format:
 
 Include the PRD reference in the commit body: `Refs: PRD-XXX`
 
+### Phase 7.3: Auto-changelog via forgeplan_release_notes (Sprint J+K — PRD-036)
+
+When creating PR after a Sprint, draft changelog automatically from artifacts touched since last tag:
+
+```python
+mcp__forgeplan__forgeplan_release_notes(since="v2.3.0", draft=False)
+```
+
+Returns a structured payload — touched PRDs grouped Added/Fixed/Security/Changed by kind. Inject into PR body as starting point; refine narrative manually.
+
+**Setup constraint** (Sprint J+K finding): tool requires `.forgeplan/` and `.git/` in the SAME directory. In multi-repo workspaces where `.forgeplan/` is at workspace root but git lives in a child repo, `forgeplan_release_notes` returns "git log failed: fatal: not a git repository". Workaround: run via shell `forgeplan release-notes --since v2.3.0` from inside the git repo (with `.forgeplan/` symlinked or co-located).
+
+**Quality gate**: by default only active artifacts with R_eff > 0 are included (`draft=False`). Pass `draft=True` to include all touched artifacts including drafts. Do not pass `draft=True` for production releases — that bypasses the quality gate.
+
+### Step 9.5: Auto-generate changelog before PR (Sprint J — PRD-037)
+
+Before `gh pr create`, query the forgeplan artifact graph for a changelog block. Prefer MCP-first; CLI fallback when MCP not connected.
+
+**MCP path** (preferred):
+```python
+mcp__forgeplan__forgeplan_release_notes(
+    since="v<previous-tag>",   # omit for auto-detect latest tag
+    until="HEAD",              # default
+    draft=False                # quality gate: only active artifacts / r_eff > 0
+)
+```
+
+**CLI fallback**:
+```bash
+forgeplan release-notes --since v<previous-tag> --until HEAD
+```
+
+The tool returns a Keep-a-Changelog–shaped structured payload (Added/Changed/Fixed/Security buckets), classified by artifact kind: PRD→Added, PROB→Fixed, EVID-on-security→Security, RFC/ADR→Changed. Quality gate (default): only `status==active` or `r_eff>0` artifacts included.
+
+**Use as PR body baseline**: paste the structured output as the "What's changed" section of `gh pr create --body`, then optionally append hand-curated context. This eliminates per-PR hand-writing of changelog blocks.
+
+**Anti-pattern**: do not pass `draft=True` for production releases — that bypasses the quality gate and includes incomplete artifacts.
+
+Cross-reference: `plugins/fpl-skills/skills/progress-dashboard/SKILL.md` includes a "Recent release notes" panel reading from this same tool.
+
 ## Error Handling
 
 - If `forgeplan` commands fail, check `forgeplan health` output and report the issue.

--- a/plugins/fpl-skills/.claude-plugin/plugin.json
+++ b/plugins/fpl-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fpl-skills",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "Flagship workflow plugin for the ForgePlan ecosystem. 27 engineering skills + dev-advisor agent + 5 hooks. v1.24: PRD-034 Sprint F \u2014 /forge-cleanup classification table extended with 4 new anomaly kinds (orphan_link, mistyped_based_on, expired_evidence, phase_mismatch) \u2014 8 outcomes total. v1.23: Sprint D self-healing framework + <<NEEDS_ACTIVATION>> sentinel. v1.22: Sprint C /autorun resume. v1.21: Sprint B 7 deliverables. v1.20: Sprint A UX-layer.",
   "author": {
     "name": "ForgePlan"

--- a/plugins/fpl-skills/skills/progress-dashboard/SKILL.md
+++ b/plugins/fpl-skills/skills/progress-dashboard/SKILL.md
@@ -36,6 +36,7 @@ Does **not** write files, store state, or introduce any new event system.
 | `.forgeplan/session.yaml` | Sprint name, phase, wave meta (written by `/sprint` and `/autorun`) | 5 |
 | `git log --oneline -10` | Recent commits — derive "files modified" count via `--shortstat` | 6 |
 | `.forgeplan/state/<id>.yaml` | Per-artifact phase state (read only when session.yaml references an artifact) | 7 |
+| Recent release notes | `mcp__forgeplan__forgeplan_release_notes(since=<prev-tag>)` or CLI fallback `forgeplan release-notes` | Auto-generated changelog from artifact graph between previous tag and HEAD — useful for "what shipped this cycle" view | 8 |
 
 **MCP-first (per PRD-022):** prefer `mcp__forgeplan__forgeplan_claims/health/list` when MCP available.
 CLI fallback: `forgeplan claims` / `forgeplan health` / `forgeplan list status=draft`.
@@ -122,6 +123,12 @@ All times in local wall-clock or ISO-8601 UTC — whichever is available.
    <EVID-NNN> — <title>  (most recent, from git log or forgeplan_list)
    — none yet —          (if no EVID commits found)
 
+ RECENT RELEASE NOTES (since v<prev-tag>)
+   Added (N):    PRD-029, PRD-030, ...
+   Changed (M):  RFC-002, ADR-005, ...
+   Fixed (K):    PROB-001, ...
+   Security:     (none) | EVID-XXX
+
  ETA: ~<X> min remaining  (<basis>)
       (rough estimate — varies with agent dispatch parallelism)
 ═══════════════════════════════════════════════════════════════════
@@ -132,6 +139,7 @@ All times in local wall-clock or ISO-8601 UTC — whichever is available.
 - AGENTS IN FLIGHT: MCP and CLI both unavailable (note this in a one-line warning above the block)
 - TASKS: no TaskList in current session
 - FILES MODIFIED / RECENT EVID: `git` not available in context
+- RECENT RELEASE NOTES: MCP and CLI both unavailable, or no previous tag found
 - ETA: insufficient signal (see ETA heuristic)
 
 ---
@@ -189,6 +197,9 @@ This skill is **read-only** across all forgeplan tools it touches:
 | `mcp__forgeplan__forgeplan_claims` | Active agent claims — agents in flight | `bash forgeplan claims` |
 | `mcp__forgeplan__forgeplan_health` | Artifact health verdict + counts | `bash forgeplan health` |
 | `mcp__forgeplan__forgeplan_list` | Draft/in-progress artifacts (max 5) | `bash forgeplan list status=draft` |
+| `mcp__forgeplan__forgeplan_release_notes` | Recent release notes panel — what shipped this cycle | `bash forgeplan release-notes --since <tag>` |
+
+**Tool selection**: prefer `mcp__forgeplan__forgeplan_release_notes` when MCP available; CLI fallback `forgeplan release-notes --since <tag>`. Omit the panel entirely if neither is reachable or no previous tag exists.
 
 This skill never calls: `forgeplan_new`, `forgeplan_update`, `forgeplan_link`,
 `forgeplan_activate`, `forgeplan_claim`, `forgeplan_release`. If you see a call to


### PR DESCRIPTION
## 🎯 Sprint J+K — exercise 4 newly-surfaced MCP tools + wire release-notes

Sprint G inventoried 7 new tools; Sprint J+K exercised the 4 testable ones LIVE. **3 of 4 RECOMMENDED-INTEGRATE; 1 LIMITED-USE.** 2 new anomalies surfaced (#12 + #13).

### Per-tool verdicts (live testing)

| Tool | Verdict | Finding |
|---|---|---|
| `forgeplan_release_notes` | 🟡 **LIMITED-USE** | Errors on split-repo layouts (.forgeplan/ + .git/ not co-located) → Anomaly #12 |
| `forgeplan_restore` | ✅ **RECOMMENDED-INTEGRATE** | Roundtrip GREEN, body byte-preserved → Anomaly #13 (returns to draft, not prior status) |
| `forgeplan_activity_stats` | ✅ **RECOMMENDED-INTEGRATE** | 135 calls / 3 errors / forgeplan_score p95=3.5s slowest |
| `forgeplan_fpf_rules` | ✅ **RECOMMENDED-INTEGRATE** | 5 default rules: blind-spot, weak-evidence, orphan-active, medium-quality, ready-to-build |

### Sprint J wiring

- `/forge-cycle` Phase 7.3 (NEW) — `forgeplan_release_notes` in PR-creation step + split-repo workaround
- `/forge-progress` dashboard skill — "RECENT RELEASE NOTES" panel + data source row + MCP-first integration

### Versions
- catalog v1.50.0 → **v1.51.0**
- forgeplan-workflow v1.10.0 → **v1.10.1**
- fpl-skills v1.24.0 → **v1.24.1**

## Anomalies surfaced

### Anomaly #12 — release_notes split-repo constraint (ADI tier)
Tool requires `.forgeplan/` + `.git/` in same directory. Our layout has them split. Workaround documented.

### Anomaly #13 — restore always returns to draft (USER tier)
`forgeplan_restore` doesn't preserve prior status; operators must explicitly re-activate before any other transition. Confirmed inline via PRD-036 cleanup path.

Both will be filed upstream IF persist after forgeplan v0.32.0.

## Verification
- ✅ `./scripts/validate-all-plugins.sh` — ALL PASSED (0/0)
- ✅ PRD-037 R_eff=1.0 grade A
- ✅ EVID-063 activated inline
- ✅ K2 roundtrip: NOTE-010 body byte-preserved across delete+restore
- ✅ K1 release_notes error captured (2 attempts, both errored — visible in activity_stats)

## Sub-agent metrics
- 2 dispatched (J1 docs wire, K2 restore roundtrip)
- ~117k tokens combined
- 0 failures
- 3 of 4 K* exercises done inline (orchestrator MCP calls)

## What's still deferred

3 tools not yet tested (need external context):
- `forgeplan_discover_*` — Sprint H scope (brownfield)
- `forgeplan_playbook_run` — needs playbook artifact + security gate
- `forgeplan_ingest` — needs mapping YAML + source

Refs: PRD-037 (active R_eff=1.0), EVID-063 (active), Sprint A-G predecessors PRD-029..035, mm-pipeline-anomalies, forgeplan v0.32.0 in motion