### PR TITLE
feat(marketplace): Sprint O — agentic-rag plugin + link footgun detection (v1.55.0, plugin count 13→14)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.54.0"
+    "version": "1.55.0"
   },
   "plugins": [
     {
@@ -35,8 +35,8 @@
     {
       "name": "fpl-skills",
       "source": "./plugins/fpl-skills",
-      "description": "Flagship workflow plugin for the ForgePlan ecosystem. 27 engineering skills + dev-advisor agent + 5 hooks. v1.24.2: Sprint M PRD-039 \u2014 AGENT-AUTHORING-GUIDE gains Step 9b.1 (EVID body bold-pattern not YAML) + Step 11 (Profile A affected_files declaration) + /forge-cleanup 9th anomaly kind link_direction_footgun. v1.24.1: PRD-034 Sprint F + Sprint J+K closure pack (PRD-038). v1.23: Sprint D self-healing framework + <<NEEDS_ACTIVATION>> sentinel. v1.22: Sprint C resume. v1.21: Sprint B. v1.20: Sprint A.",
-      "version": "1.24.2",
+      "description": "Flagship workflow plugin for the ForgePlan ecosystem. 27 engineering skills + dev-advisor agent + 5 hooks. v1.24.3: Sprint O PRD-041 \u2014 link_direction_footgun detection script (scripts/detect_link_footguns.sh, 76 LOC bash, NDJSON output, surfaced 4 live findings on first run). v1.24.2: Sprint M PRD-039 conventions. v1.24.1: Sprint J+K closure pack. v1.23: Sprint D self-healing framework + <<NEEDS_ACTIVATION>> sentinel.",
+      "version": "1.24.3",
       "author": {
         "name": "ForgePlan"
       },
@@ -54,6 +54,27 @@
         "autorun",
         "bootstrap",
         "methodology"
+      ]
+    },
+    {
+      "name": "agentic-rag",
+      "source": "./plugins/agentic-rag",
+      "description": "Methodology skill for writing skills in agentic RAG format — SKILL.md as router + sections/_index.md + content files (~30-50 LOC each). 6 sections (when-to-use, structure, description-craft, content-quality, templates, distribution) covering everything from decision tree to copy-pasteable starter-kit. Real-world examples from fpf-knowledge (224 sections) and laws-of-ux (30 laws). v1.0.0 PRD-014 Sprint O 2026-05-20 — ships as marketplace plugin (standalone repo deferred per NOTE-003 trigger-driven design).",
+      "version": "1.0.0",
+      "author": {
+        "name": "ForgePlan"
+      },
+      "homepage": "https://github.com/ForgePlan/marketplace",
+      "license": "MIT",
+      "category": "developer-tools",
+      "keywords": [
+        "skills",
+        "agentic-rag",
+        "methodology",
+        "knowledge-base",
+        "skill-authoring",
+        "rag",
+        "claude-code"
       ]
     },
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
 # ForgePlan Marketplace — Claude Code Configuration
 
 **Repo**: [ForgePlan/marketplace](https://github.com/ForgePlan/marketplace)
-**Catalog version**: 1.54.0
-**Plugins**: 13 (7 workflow + 5 agent packs + 1 memory plugin fpl-hsmem)
+**Catalog version**: 1.55.0
+**Plugins**: 14 (8 workflow + 5 agent packs + 1 memory plugin fpl-hsmem) — added `agentic-rag` v1.0.0 Sprint O
 **Agents**: 17 of ~65 forgeplan-aware (PRD-026 canonical B2 paradigm — `disallowedTools` denylist + `forgeplan_generate` primary creation path + 5 profiles A/B/C/C-coder/D)
-**Last Updated**: 2026-05-20 (post Sprint A-N: PRD-040 doc sync + mm-evid-body-convention mental model, 18 anomalies + 10 ML, catalog v1.54.0)
+**Last Updated**: 2026-05-20 (post Sprint A-O: PRD-014 agentic-rag shipped + PRD-041 link footgun detection + 4 LIVE findings surfaced, 19 anomalies + 10 ML, catalog v1.55.0)
 **Project board**: [orgs/ForgePlan/projects/5](https://github.com/orgs/ForgePlan/projects/5)
 
 ---
@@ -226,18 +226,19 @@ gh api repos/ForgePlan/marketplace/rulesets --jq '.[] | .name'  # Rulesets
 
 ---
 
-## Plugin versions (catalog v1.54.0)
+## Plugin versions (catalog v1.55.0)
 
 ### Workflow plugins
 
 | Plugin | Version |
 |--------|:-------:|
-| **fpl-skills** | 1.24.2 |
+| **fpl-skills** | 1.24.3 |
 | **fpl-hsmem** | 2.1.0 |
 | **forgeplan-workflow** | 1.10.1 |
 | **forgeplan-orchestra** | 1.4.1 |
 | **forgeplan-brownfield-pack** | 1.3.2 |
 | **fpf** | 1.4.1 |
+| **agentic-rag** | **1.0.0** (NEW Sprint O) |
 | **laws-of-ux** | 1.4.1 |
 | **dev-toolkit** | 1.6.3 |
 

--- a/plugins/agentic-rag/.claude-plugin/plugin.json
+++ b/plugins/agentic-rag/.claude-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "name": "agentic-rag",
+  "version": "1.0.0",
+  "description": "Agentic RAG methodology for Claude Code skills — how to structure large knowledge bases with SKILL.md as a thin router + sections/_index.md + 30-50 line content files. Use when building a skill with >300 lines or >5 topics. Includes 5+ anti-patterns, copy-pasteable starter-kit, and distribution recipes. Triggers on: agentic RAG, SKILL.md structure, sections pattern, skill methodology, knowledge base design, how to write a skill.",
+  "author": {
+    "name": "ForgePlan"
+  },
+  "homepage": "https://github.com/ForgePlan/marketplace",
+  "repository": "https://github.com/ForgePlan/marketplace",
+  "license": "MIT",
+  "keywords": [
+    "skills",
+    "agentic-rag",
+    "methodology",
+    "knowledge-base",
+    "skill-authoring",
+    "developer-tools",
+    "sections-pattern"
+  ],
+  "category": "developer-tools",
+  "requires": {
+    "cli": [],
+    "mcp": [],
+    "plugins": []
+  },
+  "supersedes": {},
+  "components": {
+    "commands": [],
+    "agents": [],
+    "skills": ["agentic-rag"],
+    "hooks": []
+  }
+}

--- a/plugins/agentic-rag/README.md
+++ b/plugins/agentic-rag/README.md
@@ -1,0 +1,38 @@
+# agentic-rag
+
+Methodology skill for building large Claude Code knowledge bases using the agentic RAG
+pattern: SKILL.md as a thin router, `sections/_index.md` as table-of-contents, and
+30-50 line content files as the actual knowledge.
+
+## Install
+
+```
+/plugin install agentic-rag@ForgePlan-marketplace
+```
+
+## What's included
+
+One skill with 6 sections:
+
+| Section | What it teaches |
+|---------|----------------|
+| `when-to-use` | Decision tree: flat skill vs agentic RAG |
+| `structure` | Router pattern, _index.md format, file budget |
+| `description-craft` | Triggers, EN/RU bilingual, frontmatter rules |
+| `content-quality` | 5 anti-patterns with bad/good examples |
+| `templates` | Copy-pasteable starter-kit |
+| `distribution` | Plugin vs standalone, CI sync pattern |
+
+## Live examples referenced
+
+- `plugins/fpf/skills/fpf-knowledge/` — 224 sections, large-scale RAG
+- `plugins/laws-of-ux/skills/ux-laws/` — 30 laws, medium-scale RAG
+
+## When to use
+
+When building a skill with > 300 lines, > 5 topics, or users request one of many
+sub-topics at a time.
+
+## License
+
+MIT — ForgePlan

--- a/plugins/agentic-rag/skills/agentic-rag/SKILL.md
+++ b/plugins/agentic-rag/skills/agentic-rag/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: agentic-rag
+description: >
+  Agentic RAG methodology for Claude Code skills — how to structure large knowledge bases
+  using SKILL.md as a thin router, sections/_index.md as a table of contents, and
+  30-50 line content files as the actual knowledge. Use when building a skill with
+  >300 lines or >5 distinct topics, or when users ask about SKILL.md structure,
+  sections pattern, skill authoring methodology, knowledge base design, or how to
+  write a large Claude Code skill.
+
+  Методология agentic RAG для навыков Claude Code — как структурировать большие базы
+  знаний, используя SKILL.md как тонкий роутер, sections/_index.md как оглавление и
+  файлы по 30-50 строк как реальные знания. Применяй когда навык >300 строк или
+  охватывает >5 тем.
+
+triggers:
+  - agentic RAG
+  - SKILL.md structure
+  - sections pattern
+  - how to write a skill
+  - skill methodology
+  - knowledge base design
+  - skill authoring
+  - навык agentic RAG
+  - структура SKILL.md
+  - как писать скилл
+---
+
+# Agentic RAG — Methodology for Large Claude Code Skills
+
+A meta-skill: how to build skills using the agentic RAG pattern.
+Two live examples in this marketplace: `fpf-knowledge` (224 sections) and `ux-laws` (30 sections).
+
+## When to use this skill
+
+| Signal | Action |
+|--------|--------|
+| Skill body > 300 lines | Switch to agentic RAG |
+| Knowledge spans > 5 distinct topics | Switch to agentic RAG |
+| Users ask for one of many things at a time | Switch to agentic RAG |
+| Skill is < 100 lines, one clear purpose | Keep it flat — do NOT over-engineer |
+| Quick reference, cheat-sheet, single concept | Keep it flat |
+
+## How to navigate
+
+### Step 1 — Match your need to a section
+
+| What you need | Go to |
+|---|---|
+| **Should I use RAG or flat?** — decision tree | [when-to-use](sections/when-to-use/_index.md) |
+| **How to structure** SKILL.md + sections/ layout | [structure](sections/structure/_index.md) |
+| **How to write description:** and triggers | [description-craft](sections/description-craft/_index.md) |
+| **Anti-patterns** + bad vs good examples | [content-quality](sections/content-quality/_index.md) |
+| **Copy-paste starter-kit** to fork right now | [templates](sections/templates/_index.md) |
+| **Plugin vs standalone** distribution | [distribution](sections/distribution/_index.md) |
+
+### Step 2 — Read _index.md, then the specific file
+
+1. Open the `_index.md` of the target section — it lists files with descriptions.
+2. Read only the specific file you need. Do NOT load entire sections at once.
+3. Each content file is 30-50 lines — load only what is relevant.
+
+### Step 3 — Apply the pattern
+
+Write small files. Be the example you preach.
+
+## Section INDEX
+
+| # | Section | Files | When to use |
+|---|---------|:-----:|-------------|
+| 01 | [when-to-use](sections/when-to-use/_index.md) | 2 | Decide flat vs RAG, understand triggers |
+| 02 | [structure](sections/structure/_index.md) | 2 | SKILL.md router pattern, _index.md format, file budget |
+| 03 | [description-craft](sections/description-craft/_index.md) | 2 | Frontmatter triggers, EN/RU bilingual, model-invocation rules |
+| 04 | [content-quality](sections/content-quality/_index.md) | 2 | Anti-patterns (5+) with bad/good examples |
+| 05 | [templates](sections/templates/_index.md) | 3+ | Copy-pasteable starter-kit ready to fork |
+| 06 | [distribution](sections/distribution/_index.md) | 2 | Plugin (marketplace) vs standalone (npx skills), CI sync |

--- a/plugins/agentic-rag/skills/agentic-rag/sections/content-quality/_index.md
+++ b/plugins/agentic-rag/skills/agentic-rag/sections/content-quality/_index.md
@@ -1,0 +1,19 @@
+# content-quality
+
+Anti-patterns to avoid when building agentic RAG skills, with concrete bad/good examples.
+These are lessons learned from building fpf-knowledge (224 sections) and ux-laws (30 laws).
+
+## Contents
+
+| File | Description | Lines |
+|------|-------------|-------|
+| [anti-patterns.md](anti-patterns.md) | 5 concrete anti-patterns with bad vs good code examples | 50 |
+| [quality-checklist.md](quality-checklist.md) | Pre-publish checklist for RAG skills | 36 |
+
+## The core quality principle
+
+Each file should do exactly one thing. A reader (human or agent) should be able to
+describe the file's purpose in one sentence. If you need "and" — split the file.
+
+A section should have a single coherent theme. If a section's _index.md lists files
+that cover unrelated topics, the section boundaries are wrong.

--- a/plugins/agentic-rag/skills/agentic-rag/sections/content-quality/anti-patterns.md
+++ b/plugins/agentic-rag/skills/agentic-rag/sections/content-quality/anti-patterns.md
@@ -1,0 +1,65 @@
+# Anti-patterns — 5 Concrete Examples
+
+## AP-1: Wall of text in a content file
+
+**BAD** — 300-line file mixing background, rules, examples, edge cases.
+The agent loads 300 lines when the user needs 40.
+
+**GOOD** — split into focused files: `topic-overview.md` (30 lines),
+`topic-examples.md` (40 lines), `topic-edge-cases.md` (35 lines).
+
+---
+
+## AP-2: Duplicate content across sections
+
+**BAD** — Hick's Law fully explained in both `cognitive/_index.md`
+AND `code-patterns/navigation-choices.md`.
+
+**GOOD** — `cognitive/hicks-law.md` owns the definition.
+`code-patterns/navigation-choices.md` links to it and adds only code content:
+```markdown
+See [Hick's Law](../cognitive/hicks-law.md) for the principle.
+Code rule: nav menus must have ≤7 top-level items.
+```
+
+---
+
+## AP-3: SKILL.md as a knowledge container
+
+**BAD** — SKILL.md has 400 lines of knowledge. Every query loads the full file.
+```markdown
+## Hick's Law
+The time to decide increases with number of choices...
+[full explanation — 60 lines inside SKILL.md]
+```
+
+**GOOD** — SKILL.md is 80 lines of navigation only. Knowledge lives in sections/:
+```markdown
+| Hick's Law | [cognitive](sections/02-cognitive/_index.md) |
+```
+
+---
+
+## AP-4: Missing _index.md
+
+**BAD** — section directory has 5 files, no `_index.md`.
+The agent cannot discover those files — it reads only what the router points to.
+
+**GOOD** — every section directory has an `_index.md` listing all files
+with one-line descriptions and line counts.
+
+---
+
+## AP-5: Sections with overlapping boundaries
+
+**BAD** — two sections both cover "triggers and frontmatter":
+- `section-a/` — "triggers and descriptions"
+- `section-b/` — "frontmatter, triggers, and activation rules"
+
+Agent cannot reliably route between them.
+
+**GOOD** — non-overlapping responsibilities:
+- `description-craft/` — how to write description + triggers
+- `structure/` — SKILL.md layout and file budgets
+
+One topic per section, zero overlap. If two sections share a topic, merge them.

--- a/plugins/agentic-rag/skills/agentic-rag/sections/content-quality/quality-checklist.md
+++ b/plugins/agentic-rag/skills/agentic-rag/sections/content-quality/quality-checklist.md
@@ -1,0 +1,34 @@
+# Pre-publish Quality Checklist
+
+## Structure checks
+
+- SKILL.md is ≤ 150 lines — navigation only, no knowledge content
+- Every section directory has an `_index.md`
+- Every file listed in `_index.md` actually exists on disk
+- Every path in the SKILL.md INDEX table resolves to a real `_index.md`
+- No broken links (file names match exactly, case-sensitive)
+
+## File size checks
+
+- No content file exceeds 70 lines
+- No `_index.md` exceeds 40 lines
+- Total plugin LOC is within budget (target: 500-700 lines for MVP)
+
+## Content checks
+
+- Each content file covers exactly one topic (describable in one sentence)
+- No topic appears in full in more than one file (links OK, duplication not)
+- At least one concrete example per concept — not just definitions
+- Section boundaries do not overlap
+
+## Frontmatter checks
+
+- SKILL.md has `name:` and `description:` fields
+- `description:` includes "Use when" and "Triggers on:"
+- `triggers:` list has ≥ 5 phrases covering the main activation vocabulary
+- Language variants included for multilingual target audiences
+
+## Cross-reference checks
+
+- At least one reference to a real living example in the marketplace
+- References point to real paths that exist on disk — not aspirational paths

--- a/plugins/agentic-rag/skills/agentic-rag/sections/description-craft/_index.md
+++ b/plugins/agentic-rag/skills/agentic-rag/sections/description-craft/_index.md
@@ -1,0 +1,18 @@
+# description-craft
+
+How to write `description:` and `triggers:` in SKILL.md frontmatter so the skill
+activates on the right queries and stays silent on irrelevant ones.
+
+## Contents
+
+| File | Description | Lines |
+|------|-------------|-------|
+| [triggers.md](triggers.md) | How to write triggers, EN/RU bilingual rules, `disable-model-invocation` | 40 |
+| [description-format.md](description-format.md) | Description field format, length, tone, what to include and exclude | 34 |
+
+## Why this matters
+
+A skill with perfect content but wrong triggers never fires.
+A skill with vague triggers fires on unrelated queries and pollutes the context.
+The `description:` field is the only signal Claude Code uses to decide whether
+to load this skill — get it wrong and the rest does not matter.

--- a/plugins/agentic-rag/skills/agentic-rag/sections/description-craft/description-format.md
+++ b/plugins/agentic-rag/skills/agentic-rag/sections/description-craft/description-format.md
@@ -1,0 +1,41 @@
+# Description Field Format
+
+## Structure
+
+The `description:` field answers three questions in order:
+1. **What is this?** — one-line identity
+2. **When to use it?** — activation condition
+3. **What triggers it?** — explicit trigger phrases
+
+```yaml
+description: >
+  Agentic RAG methodology for Claude Code skills — how to structure large knowledge
+  bases using SKILL.md as a thin router and 30-50 line content files.
+  Use when building a skill with >300 lines or >5 distinct topics.
+  Triggers on: agentic RAG, SKILL.md structure, skill authoring methodology.
+```
+
+## Length
+
+- Single-purpose skill: 1-3 sentences
+- Multi-purpose skill (like fpf-knowledge): up to 6 sentences
+- Do not write a paragraph. The description is a matching signal, not documentation.
+
+## Tone
+
+- Factual, no marketing language
+- "Use when X" not "This amazing skill helps you..."
+- Include explicit "Triggers on:" list at the end — it reinforces semantic matching
+
+## What to include
+
+- What the skill covers (domain noun)
+- When to activate (use-case verb phrase)
+- Explicit trigger phrases as a comma-separated "Triggers on:" suffix
+
+## What NOT to include
+
+- Author name (use `author` field in plugin.json)
+- Version history ("v1.0.0: added X")
+- Internal notes or TODOs
+- Markdown formatting (the field is plain text / block scalar)

--- a/plugins/agentic-rag/skills/agentic-rag/sections/description-craft/triggers.md
+++ b/plugins/agentic-rag/skills/agentic-rag/sections/description-craft/triggers.md
@@ -1,0 +1,52 @@
+# Writing Triggers
+
+## The triggers field
+
+`triggers:` is a YAML list of phrases that activate the skill. Use natural language
+phrases, not single keywords.
+
+```yaml
+triggers:
+  - agentic RAG
+  - SKILL.md structure
+  - how to write a skill
+  - knowledge base design
+  - навык agentic RAG       # Russian variant
+  - структура SKILL.md      # Russian variant
+```
+
+## EN/RU bilingual rule
+
+Add Russian variants when target audience includes Russian speakers.
+Place EN triggers first, then RU. Both activate the same skill.
+
+`agentic-rag` and `fpf-knowledge` use bilingual triggers.
+`ux-laws` is English-only (different target audience).
+
+## Trigger specificity
+
+**Too broad** — fires on unrelated queries:
+```yaml
+triggers:
+  - skill        # matches "do you have skill in Python?"
+  - knowledge    # matches almost anything
+```
+
+**Too narrow** — never fires:
+```yaml
+triggers:
+  - agentic retrieval augmented generation methodology for SKILL.md
+```
+
+**Correct** — specific to intent, broad enough to catch variants:
+```yaml
+triggers:
+  - agentic RAG
+  - SKILL.md structure
+  - how to write a large Claude Code skill
+```
+
+## disable-model-invocation
+
+Add `disable-model-invocation: true` for pure knowledge stores. The agent should
+read files and answer without a new model call. Command files should NOT use this.

--- a/plugins/agentic-rag/skills/agentic-rag/sections/distribution/_index.md
+++ b/plugins/agentic-rag/skills/agentic-rag/sections/distribution/_index.md
@@ -1,0 +1,17 @@
+# distribution
+
+When and how to distribute an agentic RAG skill — as a marketplace plugin vs
+a standalone skill installable via `npx skills add`.
+
+## Contents
+
+| File | Description | Lines |
+|------|-------------|-------|
+| [plugin-vs-standalone.md](plugin-vs-standalone.md) | Comparison table, decision criteria, tradeoffs | 40 |
+| [ci-sync.md](ci-sync.md) | How to keep a marketplace plugin and standalone repo in sync via CI | 36 |
+
+## Quick rule
+
+Start with the marketplace plugin. Promote to standalone only when ≥ 3 users
+request standalone install (`npx skills add`). This is the NOTE-003 trigger-driven
+design pattern used by the ForgePlan ecosystem.

--- a/plugins/agentic-rag/skills/agentic-rag/sections/distribution/ci-sync.md
+++ b/plugins/agentic-rag/skills/agentic-rag/sections/distribution/ci-sync.md
@@ -1,0 +1,49 @@
+# CI Sync — Keeping Plugin and Standalone in Sync
+
+When promoting a skill to standalone distribution, a CI workflow keeps both repos consistent.
+ForgePlan uses `sync-standalone-skills.yml` in the marketplace repo.
+
+## The sync pattern
+
+```
+marketplace/plugins/my-skill/skills/my-skill/
+         ↕  (CI sync on push to main)
+ForgePlan/my-skill-standalone/
+  SKILL.md          ← copied from skills/my-skill/SKILL.md
+  sections/         ← copied from skills/my-skill/sections/
+  README.md
+```
+
+## Minimal workflow structure
+
+```yaml
+name: Sync standalone skills
+on:
+  push:
+    branches: [main]
+    paths: ['plugins/MY_SKILL/skills/MY_SKILL/**']
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Push skill to standalone repo
+        run: |
+          # Copy SKILL.md + sections/ to standalone repo via GITHUB_TOKEN
+```
+
+See `.github/workflows/sync-standalone-skills.yml` in the ForgePlan marketplace
+for the live reference with matrix strategy for multiple skills.
+
+## What NOT to sync
+
+Do NOT sync `plugin.json`, `commands/`, `agents/`, or `hooks/` to the standalone repo.
+Those are plugin-only. The standalone repo contains only: `SKILL.md` + `sections/`.
+
+## Version discipline
+
+When updating the skill, bump version in:
+1. `plugins/my-skill/.claude-plugin/plugin.json`
+2. `.claude-plugin/marketplace.json`
+
+The CI sync handles the standalone repo commit automatically.

--- a/plugins/agentic-rag/skills/agentic-rag/sections/distribution/plugin-vs-standalone.md
+++ b/plugins/agentic-rag/skills/agentic-rag/sections/distribution/plugin-vs-standalone.md
@@ -1,0 +1,36 @@
+# Plugin vs Standalone — Distribution Decision
+
+Two distribution channels exist in the ForgePlan ecosystem:
+
+## Channel comparison
+
+| | Plugin (marketplace) | Standalone (npx skills) |
+|---|---|---|
+| **Install command** | `/plugin install X@ForgePlan-marketplace` | `npx skills add ForgePlan/X` |
+| **What ships** | Full plugin: commands + agents + hooks + skills | Skills only: SKILL.md + sections |
+| **Maintenance** | One repo (marketplace) | Two repos (marketplace + standalone) |
+| **Discovery** | Via marketplace catalog | Via agentskills.io + npx |
+| **Best for** | New skills, single-author, ForgePlan ecosystem | High-demand skills, cross-ecosystem users |
+
+## Decision criteria
+
+Use **plugin only** (default) when:
+- The skill is new and user demand is unproven
+- The skill is tightly coupled to ForgePlan commands or agents
+- You want a single repo to maintain
+
+Use **both** (plugin + standalone) when:
+- ≥ 3 users have requested `npx skills add` install
+- The skill is useful outside the ForgePlan ecosystem
+- The skill is stable and unlikely to change frequently
+
+## Trigger-driven promotion pattern (NOTE-003)
+
+ForgePlan uses trigger-driven design for standalone repos:
+- Ship as marketplace plugin first
+- Track demand signals (GitHub issues, Discord requests, direct asks)
+- At ≥ 3 signals: create `ForgePlan/<skill-name>-standalone` repo
+- Wire the CI sync workflow (see `ci-sync.md`)
+
+This avoids maintaining unused repos. The `agentic-rag` skill itself
+follows this pattern — shipped as plugin, standalone deferred.

--- a/plugins/agentic-rag/skills/agentic-rag/sections/structure/_index.md
+++ b/plugins/agentic-rag/skills/agentic-rag/sections/structure/_index.md
@@ -1,0 +1,25 @@
+# structure
+
+How to build the three-layer agentic RAG structure: router (SKILL.md),
+table-of-contents (_index.md), and content files.
+
+## Contents
+
+| File | Description | Lines |
+|------|-------------|-------|
+| [router-pattern.md](router-pattern.md) | SKILL.md as a navigation surface — rules, what to include, what to exclude | 42 |
+| [file-budget.md](file-budget.md) | _index.md format, content file size budget, directory naming conventions | 38 |
+
+## Three-layer mental model
+
+```
+SKILL.md          ← Layer 1: Router. Navigation only, no knowledge content.
+  sections/
+    topic/_index.md  ← Layer 2: TOC. Lists files in this section with descriptions.
+    topic/file.md    ← Layer 3: Content. 30-50 lines of actual knowledge.
+```
+
+The agent reads Layer 1 to decide which section to open.
+Then reads Layer 2 to decide which file to load.
+Then reads Layer 3 to answer the question.
+Total tokens per query: ~100-200 instead of the full corpus.

--- a/plugins/agentic-rag/skills/agentic-rag/sections/structure/file-budget.md
+++ b/plugins/agentic-rag/skills/agentic-rag/sections/structure/file-budget.md
@@ -1,0 +1,44 @@
+# File Budget and Directory Conventions
+
+## _index.md format
+
+Every section directory must have an `_index.md`. Format:
+
+```markdown
+# Section Name
+
+One-sentence description of what this section covers.
+
+## Contents
+
+| File | Description | Lines |
+|------|-------------|-------|
+| [file-name.md](file-name.md) | What this file covers | 38 |
+```
+
+Include the approximate line count — it helps the agent decide whether to load the file.
+
+## Content file budget
+
+| File type | Target lines | Hard limit |
+|-----------|:------------:|:----------:|
+| Content file | 30-50 | 70 |
+| _index.md | 15-30 | 40 |
+| SKILL.md | 60-100 | 150 |
+
+If a content file exceeds 70 lines: split it into two files, update `_index.md`.
+
+## Directory naming
+
+Use lowercase kebab-case for section directories and file names:
+- `when-to-use/` not `WhenToUse/` or `when_to_use/`
+- `decision-tree.md` not `DecisionTree.md`
+
+Match directory names to the section INDEX table in SKILL.md exactly.
+A mismatch breaks the router — the agent follows a dead link.
+
+## Real-world reference
+
+`plugins/laws-of-ux/skills/ux-laws/sections/01-heuristics/`:
+4 content files (34-38 lines each) + `_index.md` (12 lines).
+Total section: ~160 lines loaded only when heuristics are relevant.

--- a/plugins/agentic-rag/skills/agentic-rag/sections/structure/router-pattern.md
+++ b/plugins/agentic-rag/skills/agentic-rag/sections/structure/router-pattern.md
@@ -1,0 +1,41 @@
+# SKILL.md — The Router Pattern
+
+SKILL.md is a **navigation surface**, not a knowledge container.
+Its job is to tell the agent where to look, not what the answer is.
+
+## What belongs in SKILL.md
+
+- YAML frontmatter: `name`, `description`, `triggers`
+- A one-paragraph "what this skill does" summary
+- A "when to use / when NOT to use" decision table
+- A "how to navigate" section with 3 steps (identify need → read _index → read file)
+- A section INDEX table mapping need → section path
+
+## What does NOT belong in SKILL.md
+
+- The actual knowledge (laws, rules, patterns, definitions)
+- Step-by-step guides (those go in content files)
+- Full examples (those go in content files)
+- Anti-patterns (those go in a content-quality section)
+
+## Router table format
+
+Each row in the INDEX table answers: "when user needs X, go to Y."
+
+```markdown
+| What you need | Go to |
+|---|---|
+| Decision tree for flat vs RAG | [when-to-use](sections/when-to-use/_index.md) |
+| Copy-paste starter-kit | [templates](sections/templates/_index.md) |
+```
+
+Link directly to the `_index.md` of the section, not to individual files.
+The agent reads the _index to decide which file to load next.
+
+## Size target
+
+SKILL.md should be 60-100 lines. If it grows past 150 lines, you have
+knowledge content in the router — extract it to a section.
+
+See `plugins/laws-of-ux/skills/ux-laws/SKILL.md` for a 89-line router example.
+See `plugins/fpf/skills/fpf-knowledge/SKILL.md` for a 149-line router with a larger index.

--- a/plugins/agentic-rag/skills/agentic-rag/sections/templates/_index.md
+++ b/plugins/agentic-rag/skills/agentic-rag/sections/templates/_index.md
@@ -1,0 +1,22 @@
+# templates
+
+Copy-pasteable starter-kit for building a new agentic RAG skill from scratch.
+
+## Contents
+
+| File | Description | Lines |
+|------|-------------|-------|
+| [starter-kit/README.md](starter-kit/README.md) | How to fork the starter-kit and replace placeholders | 28 |
+| [starter-kit/SKILL.md](starter-kit/SKILL.md) | SKILL.md template with all placeholders — ~40 lines | 42 |
+| [starter-kit/sections/my-topic/_index.md](starter-kit/sections/my-topic/_index.md) | _index.md template for one section | 22 |
+
+## How to use
+
+1. Copy `starter-kit/` to your plugin's `skills/<your-skill>/`
+2. Rename `my-topic/` to your first real section name
+3. Replace all `MY_SKILL_*` placeholders with real content
+4. Add content files following the 30-50 line budget
+5. Run the quality checklist in `content-quality/quality-checklist.md`
+
+The starter-kit is minimal by design. Add sections one at a time as you write content.
+Do not create empty section directories — only create what you have content for.

--- a/plugins/agentic-rag/skills/agentic-rag/sections/templates/starter-kit/README.md
+++ b/plugins/agentic-rag/skills/agentic-rag/sections/templates/starter-kit/README.md
@@ -1,0 +1,33 @@
+# Agentic RAG Starter Kit
+
+A minimal skeleton for a new Claude Code skill using the agentic RAG pattern.
+
+## How to fork
+
+1. Copy this `starter-kit/` directory to your plugin:
+
+```bash
+cp -R starter-kit/ plugins/my-plugin/skills/my-skill/
+```
+
+2. Replace all placeholders (search for `MY_SKILL_`):
+
+| Placeholder | Replace with |
+|-------------|-------------|
+| `MY_SKILL_NAME` | Your skill name (kebab-case, e.g. `fp-cookbook`) |
+| `MY_SKILL_DESCRIPTION` | One-line description of what your skill does |
+| `MY_SKILL_TRIGGER_1` | First activation phrase |
+| `MY_SKILL_TRIGGER_2` | Second activation phrase |
+| `MY_TOPIC` | Name of your first section (kebab-case) |
+| `MY_TOPIC_DESCRIPTION` | One sentence: what this section covers |
+
+3. Rename `sections/my-topic/` to your first real section name (match the placeholder).
+
+4. Add content files (30-50 lines each) inside each section directory.
+
+5. Add your skill to `plugin.json` components.skills array.
+
+## File count target
+
+Start with: 1 SKILL.md + 1 section with _index.md + 2 content files = 4 files.
+Ship early, add sections as you write content.

--- a/plugins/agentic-rag/skills/agentic-rag/sections/templates/starter-kit/SKILL.md
+++ b/plugins/agentic-rag/skills/agentic-rag/sections/templates/starter-kit/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: MY_SKILL_NAME
+description: >
+  MY_SKILL_DESCRIPTION. Use when MY_SKILL_TRIGGER_1 or MY_SKILL_TRIGGER_2.
+  Triggers on: MY_SKILL_TRIGGER_1, MY_SKILL_TRIGGER_2.
+triggers:
+  - MY_SKILL_TRIGGER_1
+  - MY_SKILL_TRIGGER_2
+---
+
+# MY_SKILL_NAME
+
+One paragraph: what this skill is and why it exists.
+
+## When to use
+
+| Signal | Action |
+|--------|--------|
+| User asks about MY_SKILL_TRIGGER_1 | Load this skill |
+| Some other signal | Load this skill |
+| Unrelated query | Do not load |
+
+## How to navigate
+
+### Step 1 — Match your need to a section
+
+| What you need | Go to |
+|---|---|
+| MY_TOPIC_DESCRIPTION | [MY_TOPIC](sections/MY_TOPIC/_index.md) |
+
+### Step 2 — Read _index.md, then the specific file
+
+1. Open the `_index.md` of the target section.
+2. Read only the file you need — do NOT load the full section.
+3. Each content file is 30-50 lines.
+
+### Step 3 — Apply
+
+[Brief instruction: one sentence on how to use the knowledge from this skill.]
+
+## Section INDEX
+
+| # | Section | Files | When to use |
+|---|---------|:-----:|-------------|
+| 01 | [MY_TOPIC](sections/MY_TOPIC/_index.md) | 2 | MY_TOPIC_DESCRIPTION |

--- a/plugins/agentic-rag/skills/agentic-rag/sections/templates/starter-kit/sections/my-topic/_index.md
+++ b/plugins/agentic-rag/skills/agentic-rag/sections/templates/starter-kit/sections/my-topic/_index.md
@@ -1,0 +1,21 @@
+# MY_TOPIC
+
+MY_TOPIC_DESCRIPTION. Use this section when [user need for this section].
+
+## Contents
+
+| File | Description | Lines |
+|------|-------------|-------|
+| [file-one.md](file-one.md) | [What file-one covers — one sentence] | 35 |
+| [file-two.md](file-two.md) | [What file-two covers — one sentence] | 40 |
+
+## Notes for the author
+
+Replace this section with real content when you add actual files.
+Delete this "Notes for the author" block before publishing.
+
+Each content file should:
+- Cover exactly one sub-topic (describable in one sentence without "and")
+- Be 30-50 lines
+- Start with a `# Title` heading
+- Include at least one concrete example

--- a/plugins/agentic-rag/skills/agentic-rag/sections/when-to-use/_index.md
+++ b/plugins/agentic-rag/skills/agentic-rag/sections/when-to-use/_index.md
@@ -1,0 +1,16 @@
+# when-to-use
+
+Decision guide: flat skill vs agentic RAG. Use this section before you write a single line of content.
+
+## Contents
+
+| File | Description | Lines |
+|------|-------------|-------|
+| [decision-tree.md](decision-tree.md) | Checklist + decision tree for flat vs RAG choice with concrete thresholds | 38 |
+| [examples.md](examples.md) | Real examples from fpf-knowledge (224 sections) and ux-laws (30 laws) | 36 |
+
+## One-line summary
+
+Flat skills are correct by default. Switch to agentic RAG **only** when the knowledge
+is too large to scan in one context window, or when users request one of many distinct
+sub-topics at a time.

--- a/plugins/agentic-rag/skills/agentic-rag/sections/when-to-use/decision-tree.md
+++ b/plugins/agentic-rag/skills/agentic-rag/sections/when-to-use/decision-tree.md
@@ -1,0 +1,42 @@
+# Flat Skill vs Agentic RAG — Decision Tree
+
+## Step 1 — Count your content
+
+Estimate the final SKILL.md size before writing it.
+
+| Metric | Flat skill | Agentic RAG |
+|--------|-----------|-------------|
+| Total lines | < 300 | > 300 |
+| Distinct topics | ≤ 5 | > 5 |
+| Typical user request | Entire skill | One of many sub-topics |
+| Knowledge changes independently | No | Yes — per section |
+
+## Step 2 — Answer these questions
+
+1. Will a user ever want ONLY section 3 without loading sections 1-2 and 4-6?
+   → **Yes** = use RAG. **No** = keep flat.
+
+2. Does loading the entire skill in one context window waste tokens for 80% of queries?
+   → **Yes** = use RAG. **No** = keep flat.
+
+3. Is the knowledge a single coherent explanation, or a library to look things up in?
+   → **Library** = use RAG. **Explanation** = keep flat.
+
+## Decision
+
+```
+Total lines > 300?  →  YES  →  Use agentic RAG
+       ↓ NO
+Distinct topics > 5?  →  YES  →  Use agentic RAG
+       ↓ NO
+User requests one sub-topic at a time?  →  YES  →  Use agentic RAG
+       ↓ NO
+Keep it flat. A small skill in RAG format is over-engineering.
+```
+
+## Anti-pattern warning
+
+A 5-file skill split into sections with _index.md is over-engineered.
+The navigation overhead exceeds the content. Flat is better here.
+
+**Threshold**: if your entire skill fits in ~200 lines, keep it flat.

--- a/plugins/agentic-rag/skills/agentic-rag/sections/when-to-use/examples.md
+++ b/plugins/agentic-rag/skills/agentic-rag/sections/when-to-use/examples.md
@@ -1,0 +1,35 @@
+# Real Examples — Flat vs Agentic RAG
+
+Two live examples in the ForgePlan marketplace show both scales of the pattern.
+
+## Example 1 — fpf-knowledge (224 sections, large-scale RAG)
+
+Path: `plugins/fpf/skills/fpf-knowledge/`
+
+FPF is a full philosophical framework spanning 20+ parts (A–K) with hundreds of
+sub-topics. No single query needs all 224 sections. The SKILL.md is a 149-line
+router with a table mapping "thinking verb → section number". Each section has
+an `_index.md` listing its files. Files are 50-65 lines each.
+
+**Why RAG was correct here**: users ask "how do I decompose X?" — they need
+Part A, not Parts D, F, G, H simultaneously. Loading everything wastes context.
+
+## Example 2 — ux-laws (30 laws, medium-scale RAG)
+
+Path: `plugins/laws-of-ux/skills/ux-laws/`
+
+30 UX laws organized into 5 sections (heuristics, cognitive, gestalt, principles,
+code-patterns). A frontend reviewer checking navigation choices needs Hick's Law
+and Choice Overload — not Zeigarnik Effect or Peak-End Rule.
+
+**Why RAG was correct here**: the skill covers 30 distinct topics. A user asking
+about touch targets only needs Fitts's Law (36 lines), not the full 1,200-line corpus.
+
+## Counter-example — a flat skill that should stay flat
+
+A skill explaining "how to write a good git commit message" has one topic,
+5-7 rules, and ~80 lines. It should be a single SKILL.md. Splitting it into
+sections/ with _index.md adds navigation overhead with zero benefit.
+
+**Rule of thumb**: if your knowledge base is a single narrative, keep it flat.
+If it is a library with many independent entries, use RAG.

--- a/plugins/fpl-skills/.claude-plugin/plugin.json
+++ b/plugins/fpl-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fpl-skills",
-  "version": "1.24.2",
-  "description": "Flagship workflow plugin for the ForgePlan ecosystem. 27 engineering skills + dev-advisor agent + 5 hooks. v1.24.2: Sprint M PRD-039 \u2014 AGENT-AUTHORING-GUIDE Step 9b.1 (EVID body bold-pattern NOT YAML \u2014 closes Anomaly #17) + Step 11 (Profile A affected_files declaration \u2014 closes Sprint L ML-10 nudge) + /forge-cleanup 9th anomaly kind link_direction_footgun (closes Anomalies #15/#16). v1.24.1: Sprint J+K closure pack. v1.24: PRD-034 Sprint F \u2014 /forge-cleanup 8 outcomes total. v1.23: Sprint D self-healing framework + <<NEEDS_ACTIVATION>> sentinel. v1.22: Sprint C /autorun resume. v1.21: Sprint B 7 deliverables. v1.20: Sprint A UX-layer.",
+  "version": "1.24.3",
+  "description": "Flagship workflow plugin for the ForgePlan ecosystem. 27 engineering skills + dev-advisor agent + 5 hooks. v1.24.3: Sprint O PRD-041 \u2014 scripts/detect_link_footguns.sh ships (76 LOC bash, NDJSON output, walks forgeplan graph detecting supersedes-inversion + informs-inversion; surfaced 4 real findings on first run validating Anomaly #15/#16 patterns). v1.24.2: Sprint M PRD-039 conventions (Step 9b.1 + Step 11 + 9th anomaly kind). v1.24.1: Sprint J+K closure pack. v1.24: PRD-034 Sprint F \u2014 /forge-cleanup 8 outcomes total. v1.23: Sprint D self-healing framework + <<NEEDS_ACTIVATION>> sentinel.",
   "author": {
     "name": "ForgePlan"
   },

--- a/plugins/fpl-skills/skills/forge-cleanup/SKILL.md
+++ b/plugins/fpl-skills/skills/forge-cleanup/SKILL.md
@@ -54,6 +54,19 @@ CLI fallback: `forgeplan score <ID>`.
 
 ### Step 3 — Classify (first match wins)
 
+**Pre-pass: link_direction_footgun detection (PRD-041)**
+
+Before applying classification rules, run the graph-walk helper to surface directional violations:
+
+```bash
+# Requires: forgeplan CLI v0.31.0+, jq
+# Output: NDJSON — one finding per line, or empty if graph is clean
+scripts/detect_link_footguns.sh
+```
+
+CLI fallback note: script uses only `forgeplan graph --json` + `forgeplan get <id> --json` — no MCP required.
+Any findings are added to the USER tier queue before the main classification sweep.
+
 **Original 4 outcomes (Sprint D):**
 
 1. kind=evid AND verdict set AND CL>0 AND links exist AND r_eff>0 → `ready_to_activate` (AUTO)

--- a/plugins/fpl-skills/skills/forge-cleanup/scripts/detect_link_footguns.sh
+++ b/plugins/fpl-skills/skills/forge-cleanup/scripts/detect_link_footguns.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# detect_link_footguns.sh — Walk forgeplan graph and detect link direction footguns.
+# Part of /forge-cleanup Step 3 classification (PRD-041).
+#
+# Patterns detected:
+#   supersedes_inversion — source.created_at < target.created_at
+#                          (older artifact is the source; newer should supersede older)
+#   informs_inversion    — source.kind in {prd, rfc} AND target.kind = evidence
+#                          (evidence informs PRDs/RFCs, not vice versa)
+#
+# Edge case skip: PRD→PRD informs (refines-style chains are legitimate).
+#
+# Output: NDJSON to stdout, one JSON object per finding.
+# Exit: 0 always (informational tool, not a gate).
+#
+# Requirements: forgeplan CLI v0.31.0+, jq
+
+set -euo pipefail
+
+FORGEPLAN=${FORGEPLAN_CMD:-forgeplan}
+STDERR_FILTER="grep -v '_encode\|_decode'" # suppress zsh completion noise
+
+# --- helpers -----------------------------------------------------------------
+
+# kind_from_id: derive kind string from artifact ID prefix
+# EVID-* → evidence, PRD-* → prd, RFC-* → rfc, ADR-* → adr, NOTE-* → note, etc.
+kind_from_id() {
+  local id="$1"
+  local prefix
+  prefix=$(echo "$id" | sed 's/-[0-9].*//' | tr '[:upper:]' '[:lower:]')
+  case "$prefix" in
+    evid)  echo "evidence" ;;
+    prd)   echo "prd" ;;
+    rfc)   echo "rfc" ;;
+    adr)   echo "adr" ;;
+    note)  echo "note" ;;
+    spec)  echo "spec" ;;
+    epic)  echo "epic" ;;
+    prob)  echo "problem" ;;
+    sol)   echo "solution" ;;
+    *)     echo "$prefix" ;;
+  esac
+}
+
+# artifact_created_at: fetch created_at for a single artifact via forgeplan get --json
+artifact_created_at() {
+  local id="$1"
+  $FORGEPLAN get "$id" --json 2>&1 \
+    | grep -v '_encode\|_decode' \
+    | jq -r '.created_at // empty'
+}
+
+# emit_finding: print one NDJSON finding object
+emit_finding() {
+  local pattern="$1" src_id="$2" tgt_id="$3" src_kind="$4" tgt_kind="$5"
+  local src_created="${6:-}" tgt_created="${7:-}"
+  local fix
+
+  if [ "$pattern" = "supersedes_inversion" ]; then
+    fix="forgeplan unlink $src_id $tgt_id --relation supersedes && forgeplan link $tgt_id $src_id --relation supersedes"
+  else
+    fix="forgeplan unlink $src_id $tgt_id --relation informs && forgeplan link $tgt_id $src_id --relation informs"
+  fi
+
+  jq -n --compact-output \
+    --arg anomaly   "link_direction_footgun" \
+    --arg pattern   "$pattern" \
+    --arg source_id "$src_id" \
+    --arg target_id "$tgt_id" \
+    --arg source_kind "$src_kind" \
+    --arg target_kind "$tgt_kind" \
+    --arg source_created "$src_created" \
+    --arg target_created "$tgt_created" \
+    --arg suggested_fix "$fix" \
+    '{anomaly: $anomaly, pattern: $pattern, source_id: $source_id,
+      target_id: $target_id, source_kind: $source_kind, target_kind: $target_kind,
+      source_created: $source_created, target_created: $target_created,
+      suggested_fix: $suggested_fix}'
+}
+
+# --- main --------------------------------------------------------------------
+
+# Fetch full link graph in one call
+GRAPH=$($FORGEPLAN graph --json 2>&1 | grep -v '_encode\|_decode')
+
+# Extract supersedes edges and check date inversion
+SUPERSEDES_EDGES=$(echo "$GRAPH" | jq -r '.edges[] | select(.relation == "supersedes") | "\(.from) \(.to)"')
+if [ -n "$SUPERSEDES_EDGES" ]; then
+  while IFS=' ' read -r src tgt; do
+    src_created=$(artifact_created_at "$src")
+    tgt_created=$(artifact_created_at "$tgt")
+    # Compare ISO-8601 strings lexicographically (YYYY-MM-DDTHH:MM:SS — safe for date sort)
+    if [ -n "$src_created" ] && [ -n "$tgt_created" ] && [ "$src_created" \< "$tgt_created" ]; then
+      src_kind=$(kind_from_id "$src")
+      tgt_kind=$(kind_from_id "$tgt")
+      emit_finding "supersedes_inversion" "$src" "$tgt" "$src_kind" "$tgt_kind" "$src_created" "$tgt_created"
+    fi
+  done <<< "$SUPERSEDES_EDGES"
+fi
+
+# Extract informs edges and check kind inversion (PRD/RFC → evidence)
+INFORMS_EDGES=$(echo "$GRAPH" | jq -r '.edges[] | select(.relation == "informs") | "\(.from) \(.to)"')
+if [ -n "$INFORMS_EDGES" ]; then
+  while IFS=' ' read -r src tgt; do
+    src_kind=$(kind_from_id "$src")
+    tgt_kind=$(kind_from_id "$tgt")
+    # Skip PRD→PRD (refines-style chains are legitimate per FR-004)
+    if [ "$src_kind" = "prd" ] && [ "$tgt_kind" = "prd" ]; then
+      continue
+    fi
+    # Flag: source is prd or rfc AND target is evidence
+    if { [ "$src_kind" = "prd" ] || [ "$src_kind" = "rfc" ]; } && [ "$tgt_kind" = "evidence" ]; then
+      emit_finding "informs_inversion" "$src" "$tgt" "$src_kind" "$tgt_kind" "" ""
+    fi
+  done <<< "$INFORMS_EDGES"
+fi


### PR DESCRIPTION
## Summary

First **user-driven build sprint** of A-O series. 2 parallel Profile C-coder sub-agents shipped 23 new files + 2 modified in ~10 min wall-clock. Detection script surfaced **4 LIVE link_direction_footgun findings on first run** — validates Sprint M Anomalies #15/#16 patterns were pre-existing in graph.

## What shipped

### Plugin #1: agentic-rag v1.0.0 ([PRD-014](.forgeplan/prds/PRD-014-*))

NEW marketplace plugin — methodology skill for writing skills in agentic RAG format. The skill is itself an example of the pattern it teaches.

| Property | Value |
|---|---|
| Files | 22 |
| LOC | 802 (substantive content 632) |
| Sections | 6 (when-to-use, structure, description-craft, content-quality, templates, distribution) |
| Anti-patterns | 5 (with concrete bad-vs-good pairs) |
| Real-world refs | fpf-knowledge (224 sections) + laws-of-ux (30 laws) |
| Starter-kit | Copy-pasteable template + sections skeleton |
| Distribution | Marketplace plugin (standalone repo deferred per NOTE-003) |

Install: `/plugin install agentic-rag@ForgePlan-marketplace`

### Script: detect_link_footguns.sh ([PRD-041](.forgeplan/prds/PRD-041-*))

NEW bash helper for `/forge-cleanup` Step 3 classification.

- 76 substantive LOC bash, NDJSON output to stdout
- Detects supersedes-inversion + informs-inversion patterns from Sprint M Anomalies #15/#16
- Edge case: skips PRD→PRD informs (refines-style chains legitimate)
- Surfaced as USER-tier per PRD-041 NG1 (no auto-fix)

**4 LIVE findings on first run** (validates tool works on real production data):

| # | Inverted link | Pattern | Suggested fix |
|---|---|---|---|
| 1 | ADR-004 → ADR-005 | supersedes_inversion | unlink + relink with ADR-005 as source |
| 2 | PRD-023 → PRD-024 | supersedes_inversion | unlink + relink with PRD-024 as source |
| 3 | RFC-001 → RFC-002 | supersedes_inversion | unlink + relink with RFC-002 as source |
| 4 | PRD-027 → EVID-049 | informs_inversion | review — PRD informs EVID is backwards by convention |

These 4 inverted links accumulated pre-Sprint M (when Anomalies #15/#16 weren't documented yet). Tool surfaces them; user decides USER-tier resolution.

## Anomaly #19 (NEW)

`forgeplan` CLI emits `zsh: command not found: _encode/_decode` to stderr on every invocation (zsh completion side-effect). Script must `grep -v '_encode\|_decode'` filter for clean JSON parsing. Workaround documented in script comments.

## Artifact chain

| Artifact | Status | R_eff | Grade |
|---|---|---:|:---:|
| PRD-014 | active | **1.00** | A |
| PRD-041 | active | 0.90 | A |
| EVID-067 | active | 1.0 | — |
| EVID-068 | active | 1.0 | — |

PRD-014 initially hit R_eff=0 (Anomaly #5 cascade — legacy `based_on PRD-012` link from April 2026); Sprint G CLI workaround `forgeplan unlink` recovered to R_eff=1.0.

## Version bumps

| Plugin | Before | After |
|---|---|---|
| marketplace catalog | v1.54.0 | **v1.55.0** |
| fpl-skills | v1.24.2 | v1.24.3 |
| agentic-rag | (new) | **1.0.0** |

Plugin count **13 → 14**.

## Verification

- ✅ `./scripts/validate-all-plugins.sh` — ALL PASSED (0 errors, 0 warnings on 68 agents, 14 commands no collision)
- ✅ Both PRDs activated with grade A
- ✅ Sub-agent failures: **0** (both Profile C-coder dispatches returned cleanly)
- ✅ Methodology compound interest: 4th consecutive PRD activated R_eff≥0.9 first scoring

## Test plan

- [x] agentic-rag plugin structure validated
- [x] starter-kit produces valid plugin skeleton
- [x] detect_link_footguns.sh NDJSON output verified
- [x] 4 live findings cross-checked against graph via forgeplan_get
- [x] All ACs verified in EVID-067 + EVID-068

Refs: PRD-014, PRD-041, EVID-067, EVID-068, Anomaly #15, #16, #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)