### PR TITLE
feat(fpl-skills): Sprint Z1 — ADR templates light + full + /decision skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
     "url": "https://github.com/ForgePlan"
   },
   "metadata": {
-    "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
-    "version": "1.61.0"
+    "description": "Official ForgePlan plugin marketplace for Claude Code — UX, frontend, workflow, and developer tools",
+    "version": "1.62.0"
   },
   "plugins": [
     {
       "name": "fpl-hsmem",
       "source": "./plugins/fpl-hsmem",
-      "description": "ForgePlan Hindsight memory plugin for Claude Code. Long-term cross-session memory wrapping Hindsight (vectorize-io). Provides 13 MCP tools (memory_* + mental_model_* + document_ingest_*), 3 auto-hooks (recall on UserPromptSubmit, retain on Stop, force-retain on SessionEnd), and 5 helper skills (/status, /bootstrap, /mental-model, /diagnose, /export-bank). Three activation modes: plugin install (default-on, bank derived from cwd), per-project setup CLI (explicit `.mcp.json`), or direct MCP wire-up (standalone bundle). v2.1.0 \u2014 full documentation set (GETTING-STARTED, CONFIGURATION, USAGE, TROUBLESHOOTING, CHANGELOG) and source code colocation.",
+      "description": "ForgePlan Hindsight memory plugin for Claude Code. Long-term cross-session memory wrapping Hindsight (vectorize-io). Provides 13 MCP tools (memory_* + mental_model_* + document_ingest_*), 3 auto-hooks (recall on UserPromptSubmit, retain on Stop, force-retain on SessionEnd), and 5 helper skills (/status, /bootstrap, /mental-model, /diagnose, /export-bank). Three activation modes: plugin install (default-on, bank derived from cwd), per-project setup CLI (explicit `.mcp.json`), or direct MCP wire-up (standalone bundle). v2.1.0 — full documentation set (GETTING-STARTED, CONFIGURATION, USAGE, TROUBLESHOOTING, CHANGELOG) and source code colocation.",
       "version": "2.1.0",
       "author": {
         "name": "ForgePlan"
@@ -35,7 +35,7 @@
     {
       "name": "fpl-skills",
       "source": "./plugins/fpl-skills",
-      "description": "Flagship workflow plugin for the ForgePlan ecosystem. 27 engineering skills + dev-advisor agent + 5 hooks. v1.24.5: Sprint T PRD-046 \u2014 /forge-cleanup Step 2.5 native forgeplan_anomalies MCP primary + AGENT-AUTHORING-GUIDE Profile B EVID-creation canonical procedure (2-step parent_id auto-link via #295). v1.24.4: Sprint S Step 9c convention. v1.24.3: Sprint O detection script. v1.24.2: Sprint M conventions.",
+      "description": "Flagship workflow plugin for the ForgePlan ecosystem. 27 engineering skills + dev-advisor agent + 5 hooks. v1.24.5: Sprint T PRD-046 — /forge-cleanup Step 2.5 native forgeplan_anomalies MCP primary + AGENT-AUTHORING-GUIDE Profile B EVID-creation canonical procedure (2-step parent_id auto-link via #295). v1.24.4: Sprint S Step 9c convention. v1.24.3: Sprint O detection script. v1.24.2: Sprint M conventions.",
       "version": "1.24.5",
       "author": {
         "name": "ForgePlan"
@@ -121,7 +121,7 @@
     {
       "name": "forgeplan-workflow",
       "source": "./plugins/forgeplan-workflow",
-      "description": "Structured engineering workflow for forgeplan users. Provides /forge-cycle (full SDLC cycle) and /forge-audit. v1.10.3: Sprint T PRD-046 \u2014 forgeplan_unlink MCP adopted (replaces Sprint G CLI workaround per #286). v1.10.2: Sprint S Phase 6.5.1 document_ingest_file wire. v1.10.1: Sprint F + J+K Phase 7.3.",
+      "description": "Structured engineering workflow for forgeplan users. Provides /forge-cycle (full SDLC cycle) and /forge-audit. v1.10.3: Sprint T PRD-046 — forgeplan_unlink MCP adopted (replaces Sprint G CLI workaround per #286). v1.10.2: Sprint S Phase 6.5.1 document_ingest_file wire. v1.10.1: Sprint F + J+K Phase 7.3.",
       "version": "1.10.3",
       "author": {
         "name": "ForgePlan"
@@ -142,7 +142,7 @@
     {
       "name": "dev-toolkit",
       "source": "./plugins/dev-toolkit",
-      "description": "[DEPRECATED \u2014 superseded by fpl-skills] Universal engineering toolkit: multi-expert audit, wave-based sprints, session context recall, card-based structured reports with auto-trigger hooks, and safety hooks. New users should install fpl-skills@ForgePlan-marketplace instead. v1.6.3: dev-advisor agent canonical-lint compliant (LR-1..LR-3).",
+      "description": "[DEPRECATED — superseded by fpl-skills] Universal engineering toolkit: multi-expert audit, wave-based sprints, session context recall, card-based structured reports with auto-trigger hooks, and safety hooks. New users should install fpl-skills@ForgePlan-marketplace instead. v1.6.3: dev-advisor agent canonical-lint compliant (LR-1..LR-3).",
       "version": "1.6.3",
       "deprecated": true,
       "supersededBy": "fpl-skills",
@@ -165,7 +165,7 @@
     {
       "name": "fpf",
       "source": "./plugins/fpf",
-      "description": "First Principles Framework (FPF) \u2014 thinking amplifier for structured reasoning, decomposition, and decision-making. Enhanced plugin with /fpf command, applied patterns, forgeplan integration, and FPF advisor agent. Based on FPF by Anatoly Levenchuk. v1.4.1: fpf-advisor agent canonical-lint compliant (LR-1..LR-3).",
+      "description": "First Principles Framework (FPF) — thinking amplifier for structured reasoning, decomposition, and decision-making. Enhanced plugin with /fpf command, applied patterns, forgeplan integration, and FPF advisor agent. Based on FPF by Anatoly Levenchuk. v1.4.1: fpf-advisor agent canonical-lint compliant (LR-1..LR-3).",
       "version": "1.4.1",
       "author": {
         "name": "ForgePlan"
@@ -228,7 +228,7 @@
     {
       "name": "agents-core",
       "source": "./plugins/agents-core",
-      "description": "Core development agents: debugger, code reviewer, error detective, performance engineer, production validator, plus complete dev team (coder, planner, researcher, reviewer, tester, TDD). v1.3.2: Sprint Q PRD-042 \u2014 ASM-canon frontmatter added to 3 forgeplan-aware agents (skills preload, maxTurns; coder gets isolation:worktree as only writer; code-reviewer + tester get memory:project as learners). v1.3.1: Sprint E body patches.",
+      "description": "Core development agents: debugger, code reviewer, error detective, performance engineer, production validator, plus complete dev team (coder, planner, researcher, reviewer, tester, TDD). v1.3.2: Sprint Q PRD-042 — ASM-canon frontmatter added to 3 forgeplan-aware agents (skills preload, maxTurns; coder gets isolation:worktree as only writer; code-reviewer + tester get memory:project as learners). v1.3.1: Sprint E body patches.",
       "version": "1.3.2",
       "author": {
         "name": "ForgePlan"
@@ -279,6 +279,38 @@
       },
       "homepage": "https://github.com/ForgePlan/marketplace",
       "license": "MIT"
+    },
+    {
+      "name": "cc-best",
+      "source": "./plugins/cc-best",
+      "description": "Claude Code ecosystem reference — opinionated guide for CLAUDE.md, plugins, agents, hooks, MCP, and anti-patterns. Synthesises 47+ audit findings from ForgePlan marketplace work into a navigable agentic-RAG skill. Initial release ships the claude-md section (file structure, hierarchy, patterns, anti-patterns, examples); 5 more sections (plugins, agents, hooks, mcp, antipatterns) queued via RFC-005..RFC-009.",
+      "version": "1.0.0",
+      "author": {
+        "name": "ForgePlan"
+      },
+      "homepage": "https://github.com/ForgePlan/marketplace",
+      "license": "MIT",
+      "category": "knowledge",
+      "keywords": [
+        "claude-code",
+        "best-practices",
+        "claude-md",
+        "plugins",
+        "agents",
+        "hooks",
+        "mcp",
+        "anti-patterns",
+        "opinionated-guide",
+        "reference"
+      ],
+      "components": {
+        "commands": [],
+        "agents": [],
+        "skills": [
+          "cc-best"
+        ],
+        "hooks": []
+      }
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code — UX, frontend, workflow, and developer tools",
-    "version": "1.62.0"
+    "version": "1.63.0"
   },
   "plugins": [
     {
@@ -35,8 +35,8 @@
     {
       "name": "fpl-skills",
       "source": "./plugins/fpl-skills",
-      "description": "Flagship workflow plugin for the ForgePlan ecosystem. 27 engineering skills + dev-advisor agent + 5 hooks. v1.24.5: Sprint T PRD-046 — /forge-cleanup Step 2.5 native forgeplan_anomalies MCP primary + AGENT-AUTHORING-GUIDE Profile B EVID-creation canonical procedure (2-step parent_id auto-link via #295). v1.24.4: Sprint S Step 9c convention. v1.24.3: Sprint O detection script. v1.24.2: Sprint M conventions.",
-      "version": "1.24.5",
+      "description": "Flagship workflow plugin for the ForgePlan ecosystem. 27 engineering skills + dev-advisor agent + 5 hooks. v1.24.5: Sprint T PRD-046 — /forge-cleanup Step 2.5 native forgeplan_anomalies MCP primary + AGENT-AUTHORING-GUIDE Profile B EVID-creation canonical procedure (2-step parent_id auto-link via #295). v1.24.4: Sprint S Step 9c convention. v1.24.3: Sprint O detection script. v1.24.2: Sprint M conventions. v1.25.0: Sprint Z1 PRD-052 — added /decision skill + adr-light/adr-full templates with mandatory Revisit Trigger.",
+      "version": "1.25.0",
       "author": {
         "name": "ForgePlan"
       },

--- a/plugins/agents-pro/agents/adr-architect.md
+++ b/plugins/agents-pro/agents/adr-architect.md
@@ -82,14 +82,40 @@ mcp__forgeplan__forgeplan_new(
 ```
 Returns `ADR-NNN`. Keep `NNN` for later steps.
 
-### Step 6 — Fill the body in MADR 3.0
+### Step 5b — Choose template: light or full (Sprint Z1 — PRD-052)
+
+Two canonical templates exist in `plugins/fpl-skills/templates/`:
+
+- **`adr-light.md`** — 6-section DDR, ≤400 lines. Default choice.
+- **`adr-full.md`** — full MADR 3.0, 9 sections. Use only when criteria below are met.
+
+Switch to `adr-full.md` when ANY of:
+
+1. Decision touches ≥3 modules in the system.
+2. ADI surfaced ≥3 unresolved trade-offs that each need their own subsection.
+3. The decision supersedes or refines an existing **active** ADR.
+4. User explicitly said "full ADR" / "major architectural decision".
+5. The decision is irreversible (one-way door — can't roll back cheaply).
+
+Otherwise — **default to `adr-light.md`**. Easier to escalate from light to full than to compress full into light.
+
+Read the chosen template:
+```
+Read /Users/explosovebit/Work/ForgePlanMarketplace/forgeplan-marketplace/plugins/fpl-skills/templates/adr-light.md
+# OR
+Read /Users/explosovebit/Work/ForgePlanMarketplace/forgeplan-marketplace/plugins/fpl-skills/templates/adr-full.md
+```
+
+Both templates make **`## Revisit Trigger`** (Evidence Decay) a MUST field — not optional. Sprint Z2 (PRD-053) enforces this via `guardian` agent + `/decay-watch` skill.
+
+### Step 6 — Fill the body using the chosen template
 ```
 mcp__forgeplan__forgeplan_update(
   id = ADR-NNN,
-  body = <MADR 3.0 markdown — see template below>
+  body = <markdown filled per chosen template — light or full>
 )
 ```
-Use the template at the bottom of this file. Never embed mock metrics — write `TBD` if a number is unknown rather than invent.
+Never embed mock metrics — write `TBD` if a number is unknown rather than invent. If F+G+R sum for the chosen hypothesis is <12 (light) / <14 (full), dispatch `evidence-gatherer` agent (Sprint Z4 — PRD-055) for rigorous evidence collection before filling the body.
 
 ### Step 7 — Link to parents and related decisions
 ```

--- a/plugins/cc-best/.claude-plugin/plugin.json
+++ b/plugins/cc-best/.claude-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "cc-best",
+  "version": "1.0.0",
+  "description": "Claude Code ecosystem reference — opinionated guide for CLAUDE.md, plugins, agents, hooks, MCP, and anti-patterns. Synthesises 47+ audit findings from ForgePlan marketplace work into a navigable skill. Initial release ships the claude-md section (file structure, hierarchy, patterns, anti-patterns); 5 more sections queued via RFC-005..RFC-009.",
+  "author": {
+    "name": "ForgePlan"
+  },
+  "homepage": "https://github.com/ForgePlan/marketplace",
+  "repository": "https://github.com/ForgePlan/marketplace",
+  "license": "MIT",
+  "keywords": [
+    "claude-code",
+    "best-practices",
+    "claude-md",
+    "plugins",
+    "agents",
+    "hooks",
+    "mcp",
+    "anti-patterns",
+    "opinionated-guide",
+    "reference"
+  ],
+  "category": "knowledge",
+  "requires": {
+    "cli": [],
+    "mcp": [],
+    "plugins": []
+  },
+  "supersedes": {},
+  "components": {
+    "commands": [],
+    "agents": [],
+    "skills": [
+      "cc-best"
+    ],
+    "hooks": []
+  }
+}

--- a/plugins/cc-best/README.md
+++ b/plugins/cc-best/README.md
@@ -1,0 +1,64 @@
+# cc-best — Claude Code Ecosystem Best Practices
+
+> Opinionated reference guide for the Claude Code ecosystem. Six topical sections (CLAUDE.md, plugins, agents, hooks, MCP, anti-patterns). Currently shipping section 1 of 6 (claude-md); the others are stubs queued for follow-up sprints.
+
+## What this plugin gives you
+
+When you install `cc-best`, the `cc-best` skill becomes available as an agentic-RAG knowledge base. The skill router maps user intent to the right section, then the section router loads the relevant file (≤300 lines per agentic-RAG canon).
+
+Example queries the skill handles:
+
+- "How should I structure my project CLAUDE.md?"
+- "What is the difference between global and project CLAUDE.md?"
+- "Show me real CLAUDE.md examples from production."
+- "What anti-patterns should I avoid in CLAUDE.md?"
+
+## Sections
+
+| Section | Status | RFC | What's in it |
+|---|---|---|---|
+| **claude-md** | DONE | RFC-004 | File structure, hierarchy, patterns, anti-patterns, examples |
+| plugins | STUB | RFC-005 | Manifest, components, distribution, versioning, common mistakes |
+| agents | STUB | RFC-006 | Frontmatter canon, profiles, real production examples |
+| hooks | STUB | RFC-007 | Types, ordering, BANNED patterns, examples |
+| mcp | STUB | RFC-008 | When to use, propagation gotchas, debugging |
+| antipatterns | STUB | RFC-009 | Synthesis of 30+ findings + standalone repo packaging |
+
+## Install
+
+```bash
+# Via the ForgePlan marketplace:
+/plugin marketplace add ForgePlan/marketplace
+/plugin install cc-best@ForgePlan-marketplace
+```
+
+## Philosophy
+
+Anthropic ships authoritative reference docs. This skill is **not** that. It is opinionated practitioner knowledge — patterns we keep on hand, mistakes we have made and do not want to repeat, real production examples from 15 plugins worth of marketplace work.
+
+If the official docs say "you can do X", we say "do X like this — and avoid these three traps".
+
+## How sections are organised
+
+Each section is a folder with:
+
+- `_index.md` — a router that maps intent to the right content file.
+- 4-7 content files, each ≤300 lines, each self-contained.
+
+The agent loads exactly one content file per turn — no big-bang context loads.
+
+## Related plugins
+
+- **agentic-rag** — the skill authoring methodology this plugin follows.
+- **fp-cookbook** — recipes (different from reference; complementary).
+- **forgeplan-workflow** — the orchestrator behind our anti-pattern observations.
+
+## License
+
+MIT. Use freely. Pull requests welcome.
+
+## Refs
+
+- PRD-015 — Parent product spec (Sprint Y decomposition).
+- RFC-004 — claude-md section scope (this release).
+- RFC-005..RFC-009 — the other 5 sections, future sprints.

--- a/plugins/cc-best/skills/cc-best/SKILL.md
+++ b/plugins/cc-best/skills/cc-best/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: cc-best
+description: |
+  Claude Code ecosystem best practices — opinionated reference for CLAUDE.md, plugins, agents, hooks, MCP, and anti-patterns. Synthesises real ForgePlan production experience (15 plugins, 47+ audit findings). Use when authoring CLAUDE.md, designing a plugin, writing an agent, configuring hooks, or asking what NOT to do. Sections load on demand via agentic RAG (≤300 lines per file).
+
+  Triggers: "claude code best practices", "claude-md structure", "how to write CLAUDE.md", "plugin patterns", "agent frontmatter", "hook ordering", "mcp gotchas", "anti-patterns claude code", "common claude code mistakes", "лучшие практики Claude Code", "как писать CLAUDE.md"
+---
+
+# cc-best — Claude Code Ecosystem Best Practices
+
+You are the cc-best skill — an opinionated knowledge base for the Claude Code ecosystem. When invoked, route the user's question to the most relevant section, then load the narrowest content file from that section.
+
+## Section router — map user intent to a section
+
+| User intent | Section folder | Status |
+|---|---|---|
+| Structure a project CLAUDE.md, hierarchy questions, language rules, conventions | `sections/claude-md/` | **DONE** |
+| Build a plugin, manifest, components, distribution, versioning | `sections/plugins/` | STUB (RFC-005) |
+| Author an agent, frontmatter canon, agent profiles, real production agents | `sections/agents/` | STUB (RFC-006) |
+| Configure hooks, hook types, ordering, common bugs | `sections/hooks/` | STUB (RFC-007) |
+| Use MCP, when to integrate, propagation issues, debugging | `sections/mcp/` | STUB (RFC-008) |
+| Avoid common mistakes — synthesis across all topics | `sections/antipatterns/` | STUB (RFC-009) |
+
+When the user's question touches multiple sections, prefer the section with the most concrete answer; cite the others.
+
+## Loading procedure
+
+1. Identify the section via the table above.
+2. Read `sections/<section>/_index.md` — it routes to the narrowest content file.
+3. Load that content file only. Do not pre-load all files in a section.
+4. Answer the user's question, citing the file path (e.g., "see `sections/claude-md/hierarchy.md`").
+
+## Stub behaviour
+
+If the matching section is STUB:
+
+1. Tell the user the section is not yet authored.
+2. Cite the RFC ID that scopes it (e.g., "scheduled in RFC-005").
+3. Offer the closest DONE section as a partial answer if possible.
+
+## Cross-section references
+
+When a content file references another section, it uses relative paths (e.g., `../plugins/manifest.md`). Follow them if the target is DONE; otherwise note the stub status.
+
+## Output style
+
+Match the user's language (Russian or English). Keep answers practical — show the rule first, then the example, then the trap. Prefer one strong example over three weak ones.

--- a/plugins/cc-best/skills/cc-best/sections/agents/_index.md
+++ b/plugins/cc-best/skills/cc-best/sections/agents/_index.md
@@ -1,0 +1,16 @@
+# agents — STUB
+
+> **Status**: not yet authored. Coming in **RFC-006**.
+
+This section will cover:
+
+- Frontmatter canon (`name` / `description` / `model` / `color` / `disallowedTools`) per the B2 paradigm
+- Five canonical profiles: A (creator), B (reviewer), C-coder (source-file writer), D (maintainer), and gate
+- When to use each profile and how to recognise misuse
+- Real production examples (annotated from `agents-pro`, `agents-core`, `forgeplan-brownfield-pack`)
+
+Until shipped, see:
+
+- `plugins/fpl-skills/AGENT-AUTHORING-GUIDE.md` — canonical pattern document (~1100 lines)
+- Existing agents in `plugins/agents-pro/agents/` for reference frontmatters
+- LR-1..LR-8 lint rules in `scripts/validate-all-plugins.sh` for enforced invariants

--- a/plugins/cc-best/skills/cc-best/sections/antipatterns/_index.md
+++ b/plugins/cc-best/skills/cc-best/sections/antipatterns/_index.md
@@ -1,0 +1,22 @@
+# antipatterns — STUB
+
+> **Status**: not yet authored. Coming in **RFC-009**.
+
+This section will be the gold mine — synthesis of 47+ audit findings + 30+ anomalies from Sprint A-W across the marketplace.
+
+Planned anti-patterns to document:
+
+- Mixing CommonJS and ESM module shapes without intent.
+- Hooks of type `prompt-type` (BANNED — security regression).
+- `memory: project` agent field (force-enables `Write/Edit` overriding `disallowedTools`).
+- Anglicism mixing in user-facing replies (Sprint W communication rule).
+- "Necessary but not sufficient" — bold-pattern in EVID body required but does not alone give `r_eff > 0`.
+- And ~25 more.
+
+Until shipped, see:
+
+- `plugins/fpl-skills/SPRINT-A-E-RETROSPECTIVE.md` for the original meta-lessons.
+- `.forgeplan/notes/` for individual anomaly captures.
+- The `mm-pipeline-anomalies` mental model in Hindsight bank for the live catalog.
+
+This section will also document the **standalone packaging** path (RFC-009 includes a sub-RFC for repo `ForgePlan/cc-best` distributable via `npx skills add`).

--- a/plugins/cc-best/skills/cc-best/sections/claude-md/_index.md
+++ b/plugins/cc-best/skills/cc-best/sections/claude-md/_index.md
@@ -1,0 +1,28 @@
+# claude-md — router
+
+Six content files. Each is self-contained — load one based on the user's intent, do not pre-load the rest.
+
+## Intent to file
+
+| User asks about | Load |
+|---|---|
+| "what is CLAUDE.md", "where does it live", "lifecycle" | `basics.md` |
+| "global vs project", "user-private", "load order", "conflict resolution" | `hierarchy.md` |
+| "file anatomy", "section ordering", "conventions", "language rules" | `structure.md` |
+| "good patterns", "what to copy", "production-ready examples" | `patterns.md` |
+| "common mistakes", "what NOT to do", "anti-patterns" | `antipatterns.md` |
+| "show me real examples", "annotated production CLAUDE.md" | `examples.md` |
+
+## Cross-references
+
+- Anti-patterns reference patterns ("the right way") and structure ("which section breaks").
+- Examples illustrate basics + structure + patterns together — load `examples.md` for big-picture mental model.
+- Hierarchy explains why the same word in `~/.claude/CLAUDE.md` and `<repo>/CLAUDE.md` can mean different things.
+
+## When the user's question spans multiple files
+
+Pick the file with the most direct answer first. Cite the others by relative path (`see patterns.md`) — do not concatenate them into one response.
+
+## When in doubt
+
+Default to `basics.md` for first-touch questions. Default to `examples.md` for "show me what good looks like".

--- a/plugins/cc-best/skills/cc-best/sections/claude-md/antipatterns.md
+++ b/plugins/cc-best/skills/cc-best/sections/claude-md/antipatterns.md
@@ -1,0 +1,140 @@
+# CLAUDE.md antipatterns — common mistakes
+
+Each antipattern is named, described, diagnosed, and fixed. The order follows approximate frequency — most common failures first.
+
+## Antipattern 1 — Wall of text without sections
+
+**Symptom**: A single `##` block (or no blocks at all) containing everything from workflow rules to sprint history to forbidden commands, written as running prose.
+
+**Why it fails**: CLAUDE.md loads in full every session. Claude Code's context window is finite. Dense, unsectioned prose forces the assistant to scan the entire file to answer even narrow questions ("what is the commit format?"). Structured sections let the assistant locate the relevant block quickly and cite it precisely.
+
+**Fix**: Use `##` to separate major zones. At minimum: Metadata, Workflow, Forbidden, Version Tables, Sprint History. See `structure.md` for the recommended order.
+
+---
+
+## Antipattern 2 — Mixing languages without intent
+
+**Symptom**: English rules interspersed with Russian phrases, or Russian rules with unexplained English technical terms.
+
+**Why it fails**: When the file mixes languages randomly, the assistant mirrors that pattern in its replies. A project that sets a "reply in Russian" rule but writes half the CLAUDE.md in English will get replies that mix languages — exactly because the training signal (the CLAUDE.md itself) is mixed.
+
+**Fix**: Pick one language for the file body and stick to it. The only legitimate exception is a communication-style section that illustrates the failure mode with intentional examples (see `structure.md` — Language rule). That exception must be clearly delimited, not scattered.
+
+---
+
+## Antipattern 3 — Stale TODO lists
+
+**Symptom**: Bullet lists like "Should fix X before the next release" or "TODO: update this section" that have been sitting unchanged for multiple sprints.
+
+**Why it fails**: Stale TODOs consume context budget every session without providing value. They also create false confidence — the assistant sees a TODO and may assume it is being actively tracked, when in fact it was forgotten months ago.
+
+**Fix**: Either fix the item (it was worth tracking) or delete the TODO (it was not worth tracking). If it is genuinely blocked, file a GitHub issue or a forgeplan artifact and replace the inline TODO with a one-line reference: "see issue #312 for X". Do not let TODOs age in CLAUDE.md.
+
+---
+
+## Antipattern 4 — Duplicating content from README or docstrings
+
+**Symptom**: CLAUDE.md reproduces paragraphs from the project README, copies code examples from docstrings, or re-states what is already written in `CONTRIBUTING.md`.
+
+**Why it fails**: Duplication creates two sources of truth. When the original changes, CLAUDE.md does not — now it is wrong. The assistant may cite the CLAUDE.md version (which it sees every turn) over the correct README version.
+
+**Fix**: Reference, do not reproduce. A one-line pointer is enough:
+
+```markdown
+## Contributing
+
+Full guide: [CONTRIBUTING.md](CONTRIBUTING.md). Short form: branch → PR → CI pass → merge.
+```
+
+The CLAUDE.md line gives the assistant the gist (enough for most turns). The link goes to the authoritative source when detail is needed.
+
+---
+
+## Antipattern 5 — Unexplained internal codenames
+
+**Symptom**: Rules written in methodology shorthand: "follow ML-12 before dispatch", "ADI required at Profile B gate", "FPF decompose before shaping".
+
+**Why it fails**: Codenames are opaque to anyone who was not present when the term was coined. A new team member, a new session that lacks the mental model, or a cross-project context will all fail to apply the rule correctly because the meaning is not stated.
+
+**Fix**: Spell out the meaning inline, with the codename as a parenthetical or footnote:
+
+```markdown
+## Before launching sub-agents
+
+Verify the premise against the current codebase first (per ML-12 — the pattern
+from Sprint U where a confident premise was refuted in 5 minutes by a direct test,
+saving ~145k tokens). Only then dispatch agents.
+```
+
+If the codename is used frequently, define it once in a Glossary section and reference it by name after that.
+
+---
+
+## Antipattern 6 — Transient state instead of durable rules
+
+**Symptom**: "Currently working on the authentication refactor", "Sprint X is in progress — don't touch `src/auth/`", "John is reviewing PR #298 this week".
+
+**Why it fails**: Transient state becomes incorrect the moment the state changes — which is often before the next session. The assistant then operates on false context.
+
+**Fix**: CLAUDE.md is for durable rules, not current state. Transient state belongs in:
+- A GitHub issue or PR comment.
+- A forgeplan NOTE artifact (sprint state).
+- A conversation message in the current session.
+
+If you genuinely need "do not touch this module" to persist, write it as a durable rule: "Module `src/auth/` is under active refactor — coordinate with the team before editing. See RFC-007."
+
+---
+
+## Antipattern 7 — No "what NOT to do" section
+
+**Symptom**: CLAUDE.md lists only positive rules ("do X", "use Y format") but has no forbidden section.
+
+**Why it fails**: Positive rules tell the assistant what to do when it knows what it is doing. Forbidden rules cover the failure cases — when the assistant is unsure and might default to the easiest or most familiar option (e.g., `git add .`, `git push origin main`). Without an explicit forbidden list, those defaults happen.
+
+**Fix**: Add a Forbidden section (see Pattern 5 in `patterns.md`). Write it as an absolute list. The bar for inclusion is: "if the assistant did this by mistake, what is the worst case?" If the answer is "data loss, broken main branch, leaked secret" — it belongs in Forbidden.
+
+---
+
+## Antipattern 8 — No version or date on the file
+
+**Symptom**: No "Last Updated" line. Sprint history sections with vague headers like "Recent changes" instead of "Sprint W 2026-05-22".
+
+**Why it fails**: Without dates, neither you nor the assistant can determine if a rule is current. An instruction that made sense six months ago may be actively harmful today (e.g., referencing a workflow that was deprecated). The assistant has no way to detect staleness without temporal anchors.
+
+**Fix**: Add "Last Updated" to the metadata block (see Pattern 2 in `patterns.md`). Date every sprint history section. If you edit a rule mid-file, update the "Last Updated" line — even a one-word fix warrants a date bump.
+
+---
+
+## Antipattern 9 — Using CLAUDE.md as a changelog
+
+**Symptom**: Every small change gets a new dated section: "2026-05-22: Fixed typo in Forbidden section", "2026-05-21: Added plugin version", "2026-05-20: Clarified commit format".
+
+**Why it fails**: Git history is the changelog. CLAUDE.md sprint sections should capture sprint-level decisions and anomalies — things that need context for future sessions. A log of minor edits provides no useful context and inflates the file size.
+
+**Fix**: Use sprint-level summaries only. If you made 12 small edits during a sprint, summarise them in one sprint section: "Sprint T: updated plugin versions, clarified commit format, fixed 3 typos in Forbidden." The individual changes live in `git log`.
+
+---
+
+## Antipattern 10 — Rules without rationale for non-obvious constraints
+
+**Symptom**: "Never use `git add -A`" with no explanation. "Always run the validation script before PR" with no explanation of what it checks.
+
+**Why it fails**: The assistant can follow a rule it understands. A rule without rationale gets silently overridden when the assistant encounters a situation that "seems like an exception". Knowing WHY makes the boundary robust.
+
+**Fix**: Add a one-phrase rationale for any non-obvious constraint:
+
+```markdown
+- `git add .` / `git add -A` — stage specific files only. (Avoids accidentally
+  committing .env files, generated artifacts, or large binaries.)
+```
+
+Save the full explanation for docs or a forgeplan ADR. One phrase is enough to prevent the obvious workaround.
+
+---
+
+## Related
+
+- `patterns.md` — the correct version of each antipattern above
+- `structure.md` — file anatomy that prevents Antipattern 1 and 8
+- `basics.md` — what belongs and does not belong (prevents Antipatterns 3, 4, 6)
+- `examples.md` — annotated real examples showing antipatterns avoided

--- a/plugins/cc-best/skills/cc-best/sections/claude-md/basics.md
+++ b/plugins/cc-best/skills/cc-best/sections/claude-md/basics.md
@@ -1,0 +1,87 @@
+# CLAUDE.md basics — what it is, where it lives, lifecycle
+
+## What CLAUDE.md is
+
+CLAUDE.md is a markdown file that Claude Code automatically loads as system-level context at the start of every session. It acts as standing instructions — the configuration layer between you and the assistant, distinct from chat history, code comments, or README files.
+
+Think of it as a persistent rules contract: things written here are visible every turn, shaping how the assistant behaves across the entire conversation without you repeating yourself.
+
+Key distinction: CLAUDE.md is **project configuration**, not project documentation. A README explains a project to humans. CLAUDE.md tells Claude how to behave while working on it.
+
+## Where it lives (overview)
+
+There are three tiers, each at a different path:
+
+| Tier | Path | Audience |
+|------|------|----------|
+| Global | `~/.claude/CLAUDE.md` | All projects, all sessions |
+| Project | `<repo>/CLAUDE.md` | Everyone who clones the repo |
+| User-private overlay | `<repo>/CLAUDE.local.md` | You only, gitignored |
+
+Full load order and conflict rules are in `hierarchy.md`. Short answer: all three load, in the order listed above.
+
+## When it loads
+
+Claude Code loads CLAUDE.md automatically at two moments:
+
+1. **Session start** — fresh conversation, no existing context.
+2. **Session resume** — continuing a prior conversation in the same project.
+
+It does NOT re-load mid-conversation when you edit the file. Changes take effect on the next session start. If you need a rule active immediately, paste the relevant section into chat directly.
+
+## What belongs in CLAUDE.md
+
+Content that Claude needs on **every turn** to behave correctly:
+
+- Project-wide conventions (commit format, branch naming, file structure rules).
+- Tool usage rules (what is forbidden, what must always run before a PR).
+- Workflow instructions (the sequence: route → validate → commit → PR).
+- Communication style rules (language, tone, format).
+- Version tables and plugin inventories (single source of truth for installed tools).
+- Artifact cross-references (PRD-NNN, RFC-NNN — so Claude knows where decisions live).
+- Sprint history summaries (lightweight context for new sessions).
+
+These are **durable facts** — they remain true across many sessions and many code changes.
+
+## What does NOT belong in CLAUDE.md
+
+| Do not put | Put it instead |
+|---|---|
+| Secrets, tokens, API keys | Environment variables or a secret manager |
+| One-off notes ("remember to fix this before Friday") | A GitHub issue or task |
+| Transient state ("currently working on feature X") | A TODO comment in the code |
+| Full contents of specs / PRDs | A reference: "see PRD-042 for the shape decision" |
+| Code examples already in docstrings or README | A reference: "see docs/CONTRIBUTING.md" |
+| Repeated content from code comments | The code is the source — do not duplicate |
+
+The rule of thumb: if the content becomes stale within one sprint, it does not belong here. See `antipatterns.md` for the full list of what degrades CLAUDE.md over time.
+
+## Lifecycle — how to maintain it
+
+### Adding a section
+
+Add when a rule is repeated in conversation more than twice — that is a signal it should be permanent. Write the rule in positive form first ("do X"), then add the negative ("do NOT do Y") if there is a common failure mode.
+
+### Editing a section
+
+Edit the existing section, do not append a note at the bottom. The bottom is reserved for dated sprint history (see `patterns.md` — Pattern 1). Mid-file edits are intentional: you own the structure.
+
+### Retiring a section
+
+Delete when the rule no longer applies. A rule about a workflow that was changed six months ago is worse than no rule — it creates confusion. If unsure whether to keep, move the rule to a comment block in the relevant source file instead.
+
+### Keeping it fresh
+
+Update the "Last Updated" line in the metadata block any time you make structural changes. Without a date, no one (including you, three months later) can tell whether the rules still apply.
+
+## Hooks — one sentence
+
+CLAUDE.md is loaded by the Claude Code harness directly at session start — it is not triggered by a hook. If you want rule-like behaviour triggered by a specific tool call (e.g., run lint after every Edit), that belongs in `hooks.json`, not in CLAUDE.md. See `../hooks/_index.md` for hook patterns.
+
+## Related
+
+- `hierarchy.md` — global / project / user-private tiers and load order
+- `structure.md` — file anatomy, section ordering, header conventions
+- `antipatterns.md` — what degrades CLAUDE.md over time
+- `patterns.md` — production-proven patterns to adopt
+- `examples.md` — annotated real-world examples

--- a/plugins/cc-best/skills/cc-best/sections/claude-md/examples.md
+++ b/plugins/cc-best/skills/cc-best/sections/claude-md/examples.md
@@ -1,0 +1,240 @@
+# CLAUDE.md examples — annotated real-world examples
+
+Three examples, progressing from complex (production multi-plugin monorepo) to minimal (small library) to global (cross-project personal config). Each shows a 20-40 line excerpt with annotations explaining the choices.
+
+---
+
+## Example 1 — Production multi-plugin monorepo (ForgePlan marketplace)
+
+This is the CLAUDE.md used by the ForgePlan marketplace repository — a monorepo housing 15 Claude Code plugins with active CI, branch protection, and a multi-agent workflow. It is the most complete example of the patterns in this section.
+
+### Excerpt: metadata block + communication style
+
+```markdown
+# ForgePlan Marketplace — Claude Code Configuration
+
+**Repo**: ForgePlan/marketplace
+**Catalog version**: 1.61.0
+**Plugins**: 15 (9 workflow + 5 agent packs + 1 memory plugin)
+**Last Updated**: 2026-05-22 (post Sprint W: LR-8 lint rule active + canonical
+frontmatter schema. 28 anomalies (24 resolved), catalog v1.61.0)
+**Project board**: https://github.com/orgs/ForgePlan/projects/5
+
+---
+
+## User-facing communication style
+
+Write like a PM talking to a PM, not like an engineer talking to an engineer.
+Internal methodology terms stay in forgeplan artifacts; give the user the outcome.
+
+### Principles
+
+1. One language per reply. Russian conversation → Russian reply; English → English.
+2. Conclusion first, justification second.
+3. Short concrete phrases. "Waiting on the forgeplan core team" not "awaiting upstream triage".
+4. If there is nothing to do, say so. Do not dress it up as "production-grade baseline".
+```
+
+**Annotation**:
+- Metadata block is 6 lines — compact but complete. Catalog version + last-updated-with-summary are the two most load-bearing fields.
+- Communication style appears before workflow (Pattern 7). It shapes every reply.
+- "Write like a PM talking to a PM" is opinionated and memorable. Vague rules ("be clear") do not produce consistent behaviour.
+- The principles are numbered to make them scannable. Each is a concrete instruction, not a vague aspiration.
+
+### Excerpt: git workflow + forbidden
+
+```markdown
+## Git Workflow
+
+**CRITICAL: feature branches + PR only. Direct push to `main` and `dev` is forbidden.**
+
+| Branch | Purpose | Protection |
+|-------|-----------|------------|
+| `main` | Production. Stable release | PR + 1 review + CI strict |
+| `dev` | Integration. Next release | PR + CI |
+| `feat/*`, `fix/*`, `chore/*`, `docs/*` | Working branches | No restrictions |
+
+### Commit message format
+
+```
+type(module): short summary
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+```
+
+---
+
+## Forbidden
+
+- `git push --force` — NEVER.
+- `git push origin main` / `git push origin dev` — only through a PR.
+- `git add .` / `git add -A` — stage specific files only.
+- `--no-verify` — do not skip hooks.
+- Merging without green CI.
+```
+
+**Annotation**:
+- The CRITICAL callout at the top of the section is the right place for it — before the table, so it is seen first.
+- The branch table gives the full picture in 5 rows. Names, purposes, and protection rules in one view.
+- Forbidden is adjacent to Git Workflow, not at the bottom of the file. Proximity means context is fresh when the rules are read.
+- Short imperative list. "NEVER" is unambiguous. No hedging.
+
+### Excerpt: plugin version table
+
+```markdown
+## Plugin versions (catalog v1.61.0)
+
+### Workflow plugins
+
+| Plugin | Version |
+|--------|:-------:|
+| **fpl-skills** | **1.24.5** (Sprint T: forge-cleanup Step 2.5 + Profile B EVID 2-step) |
+| **fpl-hsmem** | 2.1.0 |
+| **forgeplan-workflow** | **1.10.3** (Sprint T: forgeplan_unlink MCP adopted) |
+| **laws-of-ux** | 1.4.1 |
+| **dev-toolkit** | 1.6.3 |
+```
+
+**Annotation**:
+- Bold plugin names make the table scannable. Bold version numbers highlight recently-changed entries.
+- Parenthetical sprint notes in the version cell give enough context to understand what changed without reading the full sprint section.
+- The table is the single source of truth. The sprint history section references these versions; the table does not repeat the sprint history.
+
+### Excerpt: sprint history section
+
+```markdown
+## Sprint W 2026-05-22 — Anomaly #27 + #28 closure
+
+Inline tactical sprint. Closed 2 process anomalies that escaped Sprint V CI:
+
+| PRD | Sprint | Deliverable |
+|-----|--------|-------------|
+| **PRD-050** (active) | Sprint W | LR-8 lint rule + AGENT-AUTHORING-GUIDE schema update |
+
+### Anomalies resolved Sprint W
+
+- **#27** → RESOLVED. LR-8 rule live; catches exact Sprint V BLOCKER class in CI.
+- **#28** → RESOLVED. Canonical schema formalises `skills:`, `maxTurns:`, `isolation:`.
+```
+
+**Annotation**:
+- Section title is dated and named. "Sprint W 2026-05-22 — Anomaly #27 + #28 closure" identifies it precisely — no ambiguity about when or what.
+- Opening sentence is a one-line summary. A new session can read just this line and understand the sprint's scope.
+- Anomaly resolution log references numbers — stable identifiers that work across sessions and docs.
+
+---
+
+## Example 2 — Minimal CLAUDE.md for a small library
+
+A small open-source TypeScript library. One maintainer, no CI complexity, no multi-agent workflow. The file should be under 60 lines.
+
+```markdown
+# my-lib — Claude Code Configuration
+
+**Repo**: username/my-lib
+**Language**: TypeScript (Node 20+)
+**Last Updated**: 2026-05-15
+
+---
+
+## Conventions
+
+- All source files in `src/`. Tests co-located: `src/foo.test.ts` next to `src/foo.ts`.
+- Export from `src/index.ts` only — do not add exports to internal modules.
+- No runtime dependencies. Dev dependencies only.
+
+## Commit format
+
+```
+type: short description
+```
+
+Types: `feat`, `fix`, `docs`, `test`, `chore`. No scope needed — repo is small.
+
+## Before pushing
+
+```bash
+npm run build       # must succeed
+npm run test        # must pass
+npm run lint        # zero warnings
+```
+
+## Forbidden
+
+- Do not add runtime dependencies without discussion.
+- Do not modify `src/index.ts` public API without a CHANGELOG entry.
+```
+
+**Annotation**:
+- Metadata block is 4 lines — only what is needed. No catalog version, no project board — those do not exist here.
+- Conventions section replaces the full workflow section. There is no CI, no branch protection, no multi-plugin complexity.
+- "Before pushing" replaces the Forbidden section's CI gate — smaller project, simpler check.
+- Forbidden is two lines. The scope of risk is small; the list should match.
+- Total: ~35 lines. That is appropriate for the complexity.
+
+The lesson: CLAUDE.md should scale with project complexity. Do not copy a 600-line enterprise CLAUDE.md into a small library. Write what is actually needed.
+
+---
+
+## Example 3 — Global CLAUDE.md (`~/.claude/CLAUDE.md`)
+
+A cross-project global config covering habits that apply regardless of which repo is open. This example is paraphrased — the structure and patterns are canonical; the specific rules are illustrative.
+
+```markdown
+# Global Claude Configuration
+
+---
+
+## Output format defaults
+
+When completing a task that spans ≥3 files or ≥5 tool calls, output a structured
+summary instead of prose. Sections: TL;DR, files changed, verified, next steps.
+
+For simple Q&A (no actions taken) — use plain prose. Do not over-report.
+
+---
+
+## Cross-project directory naming
+
+New top-level directories under ~/Work/ use PascalCase, no separators.
+For ecosystem projects: prefix with the org name.
+
+Examples:
+- ~/Work/MyOrgProjectName  — correct
+- ~/Work/my-project        — wrong (kebab-case)
+
+---
+
+## Memory tool behaviour
+
+On session start in a Hindsight-enabled project: one broad recall for project context.
+Save (retain) only when knowledge is non-obvious — bugs + fixes, architectural
+decisions, user preferences. Do not retain ephemeral state or git history.
+
+---
+
+## Security defaults (all projects)
+
+- Never commit secrets, tokens, or API keys.
+- Never `git push --force` without explicit user confirmation.
+- Never `git add .` — stage specific files only.
+```
+
+**Annotation**:
+- No metadata block — global CLAUDE.md does not have a single repo, version, or board.
+- Rules are cross-project habits that apply universally. Nothing project-specific.
+- Memory tool behaviour belongs here because it is the same across all Hindsight-enabled projects — each project should not have to repeat it.
+- Security defaults at the global level mean they apply even to repos that have a minimal or missing project CLAUDE.md.
+- Total: ~40 lines. Global config should be sparse — it loads into every session.
+
+The contrast with Example 1: the global file has zero sprint history, zero version tables, zero workflow sections. Those are project-level concerns. The global file contains only cross-cutting habits.
+
+---
+
+## Related
+
+- `basics.md` — what belongs in CLAUDE.md (the theory behind these examples)
+- `structure.md` — the anatomy rules that produced Example 1's layout
+- `patterns.md` — each pattern in Example 1 is listed and explained there
+- `antipatterns.md` — what Example 2 deliberately avoids (over-engineering a small repo)
+- `hierarchy.md` — how Examples 1 and 3 relate (project tier vs global tier)

--- a/plugins/cc-best/skills/cc-best/sections/claude-md/hierarchy.md
+++ b/plugins/cc-best/skills/cc-best/sections/claude-md/hierarchy.md
@@ -1,0 +1,104 @@
+# CLAUDE.md hierarchy — global, project, and user-private tiers
+
+## Three tiers
+
+Claude Code recognises three CLAUDE.md tiers, loaded in a fixed order every session:
+
+| # | Tier | Path | Committed? |
+|---|------|------|-----------|
+| 1 | Global / user | `~/.claude/CLAUDE.md` | No (personal config) |
+| 2 | Project | `<repo>/CLAUDE.md` | Yes (shared with team) |
+| 3 | User-private overlay | `<repo>/CLAUDE.local.md` | No (gitignored) |
+
+Loading order is 1 → 2 → 3. Each tier's content is appended to the session context after the previous one. None replaces the other.
+
+## Tier 1 — global (`~/.claude/CLAUDE.md`)
+
+Purpose: cross-project habits that apply regardless of which repo you are working in.
+
+Good fits for tier 1:
+- Directory naming conventions (`~/Work/` paths should be PascalCase).
+- Memory tool behaviour (when to `memory_recall`, when to `memory_retain`).
+- Output format preferences (structured reports vs prose, emoji policy).
+- Cross-project security habits (never commit secrets, never push --force).
+
+Avoid putting in tier 1:
+- Anything project-specific — it will pollute every project.
+- Version tables or plugin inventories — those are project-level facts.
+- Large blocks of text — tier 1 loads into every session, so size matters.
+
+## Tier 2 — project (`<repo>/CLAUDE.md`)
+
+Purpose: team-wide conventions for this specific repository.
+
+This is the most important tier for day-to-day work. It carries:
+- Git workflow (branch naming, commit format, PR process).
+- CI/CD rules (what must pass before merge, how to run validation locally).
+- Plugin and agent inventories (version tables, which agents are active).
+- Artifact cross-references (where PRDs, RFCs, and ADRs live).
+- Forbidden operations (what Claude must never do in this repo).
+- Sprint history (lightweight context for new sessions).
+
+Because it is committed, every team member and every Claude Code session that opens this repo gets the same context. This makes it the canonical source of truth for project behaviour.
+
+## Tier 3 — user-private overlay (`<repo>/CLAUDE.local.md`)
+
+Purpose: personal preferences that apply to this project only, not shared with the team.
+
+Good fits for tier 3:
+- Your preferred debug workflow ("I like to start with X tool").
+- Local path overrides ("my DB runs on port 5433, not 5432").
+- Personal communication style preferences that differ from the team default.
+- Temporary rules you are testing before proposing to the team.
+
+Always add `CLAUDE.local.md` to `.gitignore`. It is not a secret file — it just contains user-specific context that would clutter the shared CLAUDE.md.
+
+## How tiers compose — the append model
+
+All three tiers are **appended** into one context block. Claude Code does not merge or override — it concatenates.
+
+Practical consequence: if tier 1 says "write commit messages in English" and tier 2 says "write commit messages in French", Claude Code sees BOTH instructions. It will try to satisfy both, which is impossible. The later-loaded tier does not automatically win — the conflict creates ambiguity.
+
+Conflict resolution strategy:
+1. **Prefer specificity.** If tier 2 gives a project-specific rule, it is more specific than a tier 1 habit. Claude will typically apply it.
+2. **Be explicit.** Write "for this project, override global preference: commit messages in French" in tier 2. Explicit beats implicit.
+3. **Don't duplicate.** If a rule belongs in tier 1, remove it from tier 2. Duplication invites drift.
+
+## Settings.json — same three-tier hierarchy, different merge semantics
+
+The `settings.json` file follows the same three-tier pattern:
+
+| Tier | Path |
+|------|------|
+| Global | `~/.claude/settings.json` |
+| Project | `<repo>/.claude/settings.json` |
+| User-private | `<repo>/.claude/settings.local.json` |
+
+However, `settings.json` uses **key-level merge** semantics, not append. A key in tier 3 overwrites the same key in tier 2, which overwrites tier 1. This is the opposite of CLAUDE.md behaviour.
+
+This distinction matters:
+- CLAUDE.md conflict → ambiguity (both instructions visible, Claude picks).
+- settings.json conflict → deterministic override (later tier wins for that key).
+
+When configuring tool permissions, hooks, or allowed commands, use `settings.json`. When configuring behaviour rules and context, use CLAUDE.md.
+
+## When to put a rule in which tier
+
+| Question | Tier |
+|---------|------|
+| "Do I want this rule in EVERY project?" | 1 (global) |
+| "Do I want teammates to see and follow this?" | 2 (project) |
+| "Is this my personal preference for this repo only?" | 3 (local overlay) |
+| "Is this a temporary rule I'm testing?" | 3 (local overlay), promote to 2 when stable |
+| "Is this a secret or credential?" | Neither — use env vars |
+
+## Subdirectory CLAUDE.md files
+
+Claude Code also supports CLAUDE.md files in subdirectories (e.g., `src/CLAUDE.md`). These load when Claude is working in that subtree. Use them sparingly — one file per repo is usually sufficient. Subdirectory files are useful when a specific module has rules so specialized that they would be noise in the root CLAUDE.md.
+
+## Related
+
+- `basics.md` — what CLAUDE.md is, lifecycle, what belongs
+- `structure.md` — file anatomy and section conventions for tier 2 (project CLAUDE.md)
+- `antipatterns.md` — common mistakes with tier confusion and duplication
+- `examples.md` — a global CLAUDE.md example contrasted with a project CLAUDE.md

--- a/plugins/cc-best/skills/cc-best/sections/claude-md/patterns.md
+++ b/plugins/cc-best/skills/cc-best/sections/claude-md/patterns.md
@@ -1,0 +1,165 @@
+# CLAUDE.md patterns — good practices to copy
+
+These patterns come from production CLAUDE.md files observed across the ForgePlan plugin ecosystem. Each pattern has a name, the rule, an example, and why it works.
+
+## Pattern 1 — Dated sprint sections at the bottom
+
+**Rule**: Append a new dated section at the bottom of CLAUDE.md after each significant sprint or release. Keep all sprint history in one file — do not split until the file exceeds 600 lines.
+
+**Example:**
+
+```markdown
+## Sprint W 2026-05-22 — Anomaly #27 + #28 closure
+
+Inline tactical sprint post-Sprint-V closure. Closed 2 process anomalies that escaped Sprint V CI:
+
+| PRD | Sprint | Deliverable |
+|-----|--------|-------------|
+| **PRD-050** (active, EVID-077 informs) | Sprint W | LR-8 lint rule added ... |
+
+### Anomalies resolved Sprint W
+
+- **#27** → RESOLVED. LR-8 rule live.
+- **#28** → RESOLVED. Canonical schema formalised.
+```
+
+**Why it works**: A new session opened weeks later can scan the bottom of the file and immediately understand what changed recently — without reading the entire file. The date anchors the reader in time; the one-line deliverable summary is enough to orient. Historical context without ceremony.
+
+## Pattern 2 — "Last Updated" in the metadata block
+
+**Rule**: Put a "Last Updated" line in the metadata block with a parenthetical one-sentence summary of what changed.
+
+**Example:**
+
+```markdown
+**Last Updated**: 2026-05-22 (post Sprint W autonomous run: LR-8 lint rule active +
+canonical frontmatter schema formalises skills:/maxTurns:/isolation: fields.
+28 anomalies (24 resolved) + 13 ML + 10 mental models, catalog v1.61.0)
+```
+
+**Why it works**: Claude Code cannot diff files between sessions. Without a date, neither you nor the assistant can tell if a rule is current or stale. The parenthetical summary prevents re-reading the whole sprint history to understand what the "last update" actually changed.
+
+## Pattern 3 — Version-pinned plugin table
+
+**Rule**: Maintain a single version table for all installed plugins. Put it in one place, reference it everywhere else. Bump both the table and the plugin's own `plugin.json` on every change.
+
+**Example:**
+
+```markdown
+## Plugin versions (catalog v1.61.0)
+
+### Workflow plugins
+
+| Plugin | Version |
+|--------|:-------:|
+| **fpl-skills** | **1.24.5** (Sprint T: forge-cleanup Step 2.5 + Profile B EVID 2-step) |
+| **fpl-hsmem** | 2.1.0 |
+| **forgeplan-workflow** | **1.10.3** (Sprint T: forgeplan_unlink MCP adopted) |
+```
+
+**Why it works**: Version drift is one of the most common sources of "why is my agent behaving differently" bugs. A single authoritative table means the assistant always knows what version is installed, and team members know what to expect. Bold for actively-changed entries makes the diff visible at a glance.
+
+## Pattern 4 — Rolling anomaly catalog
+
+**Rule**: Keep a numbered anomaly log. Mark resolved ones RESOLVED; append new ones with fresh numbers. Do not delete old entries — keep them as a record.
+
+**Example:**
+
+```markdown
+| # | Anomaly | Status |
+|---|---------|--------|
+| 21 | Sprint Q sub-agent false-success on `memory: project` | RESOLVED (Sprint R) |
+| 25 | `forgeplan_score` returns r_eff=0 for leaf EVIDs | Filed upstream #325 |
+| 27 | LR-8 lint rule missing — Profile A canon not enforced in CI | RESOLVED (Sprint W) |
+| 28 | Canonical frontmatter schema missing `skills:`, `maxTurns:` fields | RESOLVED (Sprint W) |
+```
+
+**Why it works**: Known bugs and workarounds are invisible without a catalog. When the same anomaly surfaces again — or when you file an upstream issue — you have a record of when it first appeared, what the workaround was, and whether it was ever fixed. The rolling numbering means entries are stable references ("see Anomaly #21").
+
+## Pattern 5 — Explicit Forbidden section
+
+**Rule**: Write a short, absolute list of forbidden operations. No hedging, no "try to avoid" — use "NEVER" or "do not" imperatives.
+
+**Example:**
+
+```markdown
+## Forbidden
+
+- `git push --force` — NEVER.
+- `git push origin main` / `git push origin dev` — only through a PR.
+- `git add .` / `git add -A` — stage specific files only.
+- `--no-verify` — do not skip hooks.
+- Merging without green CI.
+- Files containing secrets (`.env`, credentials, tokens).
+```
+
+**Why it works**: Positive rules ("do X this way") are necessary but not sufficient. Without an explicit forbidden list, the assistant will make judgment calls — and judgment calls on safety-critical operations (force push, secret commits) are not acceptable. The forbidden list is the cheapest safety gate in your entire workflow.
+
+## Pattern 6 — Artifact cross-references
+
+**Rule**: When a rule originates from a recorded decision, cite the artifact. Do not re-explain the decision in CLAUDE.md — just link to where it lives.
+
+**Example:**
+
+```markdown
+## Forgeplan Integration
+
+**Canonical architecture (read first for understanding pipeline)**
+
+| Artifact | Purpose |
+|---|---|
+| **PRD-024** (active) | Full SDLC Pipeline with Quality Gates — 9 phases, 9 kinds, 3 entrypoints |
+| **ADR-005** (active, supersedes ADR-004) | Keep `/forge-cycle` and `/autorun` distinct |
+| **NOTE-004** (active) | Gas Town and Ruflo architectural patterns — what to adopt, what to reject |
+```
+
+**Why it works**: CLAUDE.md is not the right place to write long rationales. Cross-referencing artifacts means the rule stays concise in CLAUDE.md while the full context lives in its proper home. It also means the assistant knows exactly where to look when asked "why is this rule here?"
+
+## Pattern 7 — Communication style rules near the top
+
+**Rule**: Put communication style rules in the top third of the file, before workflow and reference sections.
+
+**Example:**
+
+```markdown
+## User-facing communication style
+
+Write like a PM talking to a PM, not like an engineer talking to an engineer.
+Internal methodology terms stay in forgeplan artifacts; give the user the outcome.
+
+### Principles
+
+1. One language per reply. If the conversation is in Russian, write in Russian.
+2. Conclusion first, justification second.
+3. Short concrete phrases. "Waiting on the forgeplan core team" not "awaiting upstream triage".
+```
+
+**Why it works**: Communication style shapes every reply. If it is buried after 300 lines of sprint history, it is effectively invisible — the assistant's context window is finite and earlier content has higher weight. High-leverage rules belong near the top.
+
+## Pattern 8 — Quick Reference section for common commands
+
+**Rule**: Add a compact Quick Reference block with the 5-10 commands used most often in the project. Use bash code blocks.
+
+**Example:**
+
+```bash
+# Workflow
+git checkout -b feat/my-feature
+git push -u origin feat/my-feature
+gh pr create
+
+# Inspection
+gh pr checks <N>
+
+# Validation
+./scripts/validate-all-plugins.sh
+```
+
+**Why it works**: Common commands do not require explanation — they require recall. A quick reference block eliminates the cognitive overhead of remembering exact flags and script names. It is the one section where brevity beats completeness.
+
+## Related
+
+- `structure.md` — where to place each pattern in the file anatomy
+- `antipatterns.md` — the failure mode corresponding to each pattern
+- `examples.md` — these patterns shown in annotated real-world CLAUDE.md files
+- `basics.md` — what belongs vs what does not belong in CLAUDE.md

--- a/plugins/cc-best/skills/cc-best/sections/claude-md/structure.md
+++ b/plugins/cc-best/skills/cc-best/sections/claude-md/structure.md
@@ -1,0 +1,170 @@
+# CLAUDE.md structure — file anatomy and conventions
+
+## File anatomy overview
+
+A well-structured project CLAUDE.md has five zones, in this order:
+
+1. **Metadata block** — repo facts, version, last-updated, board link.
+2. **Communication style** — how the assistant talks to the user (high leverage, near the top).
+3. **Workflow rules** — the sequence the assistant must follow for common operations.
+4. **Reference tables** — version inventories, plugin lists, branch protection rules.
+5. **Sprint history** — dated sections at the bottom, oldest to newest.
+
+Most files also end with a **Forbidden** section embedded somewhere in the workflow zone — a compact list of operations that must never happen.
+
+## Metadata block
+
+The metadata block sits at the very top, before any `##` sections. It is a compact cluster of bold-label lines (not a table) covering the key facts a new session needs immediately.
+
+Example shape:
+
+```markdown
+# Project Name — Claude Code Configuration
+
+**Repo**: org/repo-name
+**Catalog version**: 1.61.0
+**Plugins**: 15 (brief description of what's installed)
+**Last Updated**: 2026-05-22 (one-sentence summary of what changed)
+**Project board**: https://github.com/orgs/Org/projects/5
+```
+
+Rules:
+- Keep it to 5-10 lines. Every extra line costs tokens on every session.
+- Include the last-updated date with a parenthetical summary. Without the date, no one knows if the content is current.
+- "Plugins: N" is enough — the full version table lives in the Reference tables zone.
+
+## Section ordering — most important first
+
+Put the rules that affect the most common actions at the top. Put historical context (sprint history) at the bottom.
+
+Recommended order:
+
+| Zone | Why this position |
+|------|------------------|
+| Metadata block | Always visible without scrolling |
+| Communication style | Shapes EVERY response — load early |
+| Workflow rules | Git, CI, PRs — the daily operations |
+| Security / Forbidden | Near workflow so context is fresh |
+| Reference tables | Consulted by lookup, not by read-through |
+| Sprint history | Historical — load only when needed |
+
+Avoid putting sprint history mid-file. It grows continuously; if it is in the middle, it pushes workflow rules further and further down as the file grows.
+
+## Header levels
+
+| Level | Use for |
+|-------|---------|
+| `#` | File title only. One per file. |
+| `##` | Major sections (Workflow, Git, CI, Forbidden) |
+| `###` | Subsections within a major section |
+| `####` | Avoid. If you need a 4th level, the section is too long — split it. |
+
+Using `#` for section headers (not just the title) makes the file look flat in editors and breaks the visual hierarchy that Claude Code's parser uses to chunk context.
+
+## Table conventions
+
+Tables are the preferred format for reference data — version inventories, branch rules, tier comparisons. They are faster to scan than bullet lists and cheaper to update.
+
+Rules:
+- Short headers (one or two words). "Plugin" not "Plugin Name and Repository".
+- Fact-dense cells. "1.4.1 (Sprint T: unlink adopted)" in one cell, not split across rows.
+- Align with `:---:` for centered columns (version numbers), `---` for left-aligned (names, descriptions).
+- Do not use tables for procedural content (steps, rules) — use numbered lists or bullet lists there.
+
+```markdown
+| Plugin | Version |
+|--------|:-------:|
+| **fpl-skills** | **1.24.5** (Sprint T: forge-cleanup Step 2.5) |
+| **fpl-hsmem** | 2.1.0 |
+```
+
+## Link conventions
+
+| Type | Format |
+|------|--------|
+| Repo-internal file | Relative path: `[guide](docs/CONTRIBUTING.md)` |
+| Section within same file | `[#Forbidden](#forbidden)` |
+| External URL | Full URL: `[board](https://github.com/orgs/Org/projects/5)` |
+| Artifact reference | Plain text: "see PRD-042" — no link needed if forgeplan is wired |
+
+Do not use absolute filesystem paths for repo-internal links — they break on other machines. Relative paths work regardless of where the repo is cloned.
+
+## Language rule
+
+The file body must be in one language throughout. Mixing languages degrades readability and causes the assistant to mix languages in its replies.
+
+For public or team repositories: use English throughout.
+
+The one legitimate exception is a communication-style section that illustrates the failure mode with examples. If the rule is "do not mix Russian and English", an example showing the wrong Russian phrasing must be in Russian. This is intentional — keep the example, not the mixed language.
+
+Correct structure:
+
+```markdown
+## User-facing communication style
+
+Write in the same language as the user. Do not mix.
+
+### Anti-patterns (Russian conversation)
+
+❌ «Все open items требуют external trigger»
+✅ «Все незакрытые задачи ждут внешнего сигнала»
+```
+
+The anti-pattern examples are in Russian because they illustrate Russian-language failures — not because the file is bilingual.
+
+## File length
+
+Keep the file under ~600 lines. Beyond that, readers (human and AI) start skimming, and important rules get missed.
+
+Strategies when the file grows too long:
+
+1. Move sprint history older than 3 sprints to `docs/SPRINT-HISTORY.md` and link from CLAUDE.md.
+2. Move detailed process guides (e.g., full PR checklist) to `docs/` and link.
+3. Move section-specific rules to a `<repo>/CLAUDE.local.md` if they are user-specific.
+4. Delete stale content — anything that was true 6 months ago and has since changed should be updated, not appended.
+
+When you link out, write a one-line summary in CLAUDE.md so the context is still accessible without following the link:
+
+```markdown
+## Plugin cache troubleshooting
+
+Full guide: [docs/CACHE-TROUBLESHOOTING.md](docs/CACHE-TROUBLESHOOTING.md)
+
+Short answer: if `/plugin install` says "already installed" but new version is present,
+run `/plugin uninstall` then `/plugin install` to force re-resolve.
+```
+
+## Code blocks
+
+Use fenced code blocks with a language tag for all command examples and file content samples.
+
+```bash
+# Good — language tag present
+./scripts/validate-all-plugins.sh plugin-name
+```
+
+Without the language tag, syntax highlighting breaks in editors and the content is harder to distinguish from prose.
+
+## Forbidden section placement
+
+Put the Forbidden section adjacent to the workflow section it protects. If it is buried at the bottom after 400 lines of sprint history, it is invisible when the user is reading about git workflow.
+
+```markdown
+## Forbidden
+
+- `git push --force` — NEVER.
+- `git push origin main` — only through a PR.
+- `git add .` / `git add -A` — stage specific files only.
+- `--no-verify` — do not skip hooks.
+- Merging without green CI.
+```
+
+Short, imperative, absolute. No explanation needed for items that are universally understood as dangerous; one-phrase rationale for anything that might seem arbitrary.
+
+## Related
+
+- `basics.md` — what CLAUDE.md is and what belongs in it
+- `hierarchy.md` — which tier this structure applies to
+- `patterns.md` — good patterns to copy from production CLAUDE.md files
+- `antipatterns.md` — what structural mistakes to avoid
+- `examples.md` — annotated real examples showing anatomy in practice

--- a/plugins/cc-best/skills/cc-best/sections/hooks/_index.md
+++ b/plugins/cc-best/skills/cc-best/sections/hooks/_index.md
@@ -1,0 +1,17 @@
+# hooks — STUB
+
+> **Status**: not yet authored. Coming in **RFC-007**.
+
+This section will cover:
+
+- Hook types (PreToolUse, PostToolUse, SessionStart, UserPromptSubmit, Stop, SessionEnd)
+- Ordering and short-circuit behaviour
+- BANNED patterns (our hard lessons — e.g., the `prompt-type` hook anti-pattern from fpl-hsmem)
+- Configuration locations (`.claude/settings.json` vs `~/.claude/settings.json` vs plugin `hooks/hooks.json`)
+- Examples with input/output JSON shapes
+
+Until shipped, see:
+
+- Anthropic docs on hook events.
+- `plugins/fpl-hsmem/hooks/` for real-world hook scripts with auto-recall / auto-retain semantics.
+- `plugins/forgeplan-workflow/hooks/` for orchestrator-side hook examples.

--- a/plugins/cc-best/skills/cc-best/sections/mcp/_index.md
+++ b/plugins/cc-best/skills/cc-best/sections/mcp/_index.md
@@ -1,0 +1,17 @@
+# mcp — STUB
+
+> **Status**: not yet authored. Coming in **RFC-008**.
+
+This section will cover:
+
+- When to use MCP vs CLI vs hook
+- Server vs client roles and what each can do
+- Propagation gotchas (the Anthropic #53865 `tools:` allowlist trap)
+- Debugging connected vs disconnected states (PROB-072 — MCP cwd frozen at startup)
+- Real production MCP integrations from ForgePlan (`forgeplan`, `hindsight`, `orch`)
+
+Until shipped, see:
+
+- Anthropic MCP specification.
+- `.mcp.json` files in plugin roots for connection patterns.
+- `forgeplan` upstream issues #303, #325 for known limitations.

--- a/plugins/cc-best/skills/cc-best/sections/plugins/_index.md
+++ b/plugins/cc-best/skills/cc-best/sections/plugins/_index.md
@@ -1,0 +1,17 @@
+# plugins — STUB
+
+> **Status**: not yet authored. Coming in **RFC-005**.
+
+This section will cover:
+
+- Plugin manifest (`plugin.json` schema, required vs optional fields)
+- Components (commands, agents, skills, hooks) and how they compose
+- Distribution: marketplace vs standalone repo via `npx skills add`
+- Versioning policy (semver + catalog bump rules)
+- Common mistakes from 15-plugin marketplace work
+
+Until shipped, see:
+
+- The marketplace catalog (`/Users/explosovebit/Work/ForgePlanMarketplace/forgeplan-marketplace/.claude-plugin/marketplace.json`) for examples.
+- Existing plugin sources in `plugins/*/` for shape patterns.
+- `forgeplan-marketplace/CLAUDE.md` "Version Bumping" section for our bump policy.

--- a/plugins/fpl-skills/.claude-plugin/plugin.json
+++ b/plugins/fpl-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fpl-skills",
-  "version": "1.24.5",
-  "description": "Flagship workflow plugin for the ForgePlan ecosystem. 27 engineering skills + dev-advisor agent + 5 hooks. v1.24.3: Sprint O PRD-041 \u2014 scripts/detect_link_footguns.sh ships (76 LOC bash, NDJSON output, walks forgeplan graph detecting supersedes-inversion + informs-inversion; surfaced 4 real findings on first run validating Anomaly #15/#16 patterns). v1.24.2: Sprint M PRD-039 conventions (Step 9b.1 + Step 11 + 9th anomaly kind). v1.24.1: Sprint J+K closure pack. v1.24: PRD-034 Sprint F \u2014 /forge-cleanup 8 outcomes total. v1.23: Sprint D self-healing framework + <<NEEDS_ACTIVATION>> sentinel.",
+  "version": "1.25.0",
+  "description": "Flagship workflow plugin for the ForgePlan ecosystem. 27 engineering skills + dev-advisor agent + 5 hooks. v1.24.3: Sprint O PRD-041 — scripts/detect_link_footguns.sh ships (76 LOC bash, NDJSON output, walks forgeplan graph detecting supersedes-inversion + informs-inversion; surfaced 4 real findings on first run validating Anomaly #15/#16 patterns). v1.24.2: Sprint M PRD-039 conventions (Step 9b.1 + Step 11 + 9th anomaly kind). v1.24.1: Sprint J+K closure pack. v1.24: PRD-034 Sprint F — /forge-cleanup 8 outcomes total. v1.23: Sprint D self-healing framework + <<NEEDS_ACTIVATION>> sentinel. v1.25.0: Sprint Z1 PRD-052 — added /decision skill + templates/adr-light.md + templates/adr-full.md (DDR-style decision records with mandatory Revisit Trigger).",
   "author": {
     "name": "ForgePlan"
   },
@@ -67,7 +67,8 @@
       "setup",
       "shape",
       "sprint",
-      "team"
+      "team",
+      "decision"
     ],
     "hooks": [
       "SessionStart",

--- a/plugins/fpl-skills/skills/decision/SKILL.md
+++ b/plugins/fpl-skills/skills/decision/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: decision
+description: |
+  Fast path for recording a routine decision as a light ADR (200-400 words, 6-section DDR shape). Use when you just chose one approach over another and want to capture the why before it slips out of memory. NOT for big architecture — that's `adr-architect` agent territory.
+
+  Triggers: "record decision", "/decision", "запиши решение", "quick adr", "light adr", "ddr"
+---
+
+# /decision — quick decision record
+
+You are helping the user capture a routine decision they JUST made (lib choice, config tweak, small refactor approach) as a **light ADR** (200-400 words, 6 sections including Revisit Trigger).
+
+## When to use this skill (vs `adr-architect` agent)
+
+| Use `/decision` (this skill) | Use `adr-architect` agent |
+|---|---|
+| Decision touches 1-2 modules | Decision touches ≥3 modules |
+| User says "let's record this", "quick ADR" | User says "full ADR", "major architectural decision" |
+| Routine choice (lib, config, small refactor) | System-level decision (supersedes ADR, multi-sprint scope) |
+| ADI surfaces ≤2 trade-offs | ADI surfaces ≥3 unresolved trade-offs |
+| You're mid-session and don't want to break flow | You can spend 30+ min on the decision |
+
+If in doubt — start with `/decision` (light). Easier to escalate from light to full than to compress full into light.
+
+## Procedure
+
+### Step 1 — Read the template
+
+```
+Read /Users/explosovebit/Work/ForgePlanMarketplace/forgeplan-marketplace/plugins/fpl-skills/templates/adr-light.md
+```
+
+Use it as your structure — 6 named sections.
+
+### Step 2 — Gather facts from the live session
+
+Don't ask the user for things you can already see. From the current chat context:
+
+- **Context**: what was discussed in the last 1-3 turns leading to the choice.
+- **Hypotheses considered**: which options came up in conversation. If only one was discussed, prompt the user for two more (DDR rule: minimum 3).
+- **Decision**: which option the user picked.
+
+Ask the user ONLY for what's missing:
+- Revisit Trigger (the key MUST field — usually not in chat history)
+- Reasons for rejecting alternatives (if not already stated)
+
+### Step 3 — Score F+G+R per hypothesis
+
+For each hypothesis, score by the rubric in the template:
+
+- **F** (Formality): 0 if "gut feel", 9 if "spec/proof"
+- **G** (Granularity): 0 if "slow", 9 if "p99=47ms @ 10k RPS"
+- **R** (Reliability): 0 if "Slack anecdote", 9 if "peer-reviewed or our prod benchmark"
+
+If the chosen hypothesis's F+G+R sum <12, OFFER to dispatch the `evidence-gatherer` agent (Sprint Z4 PRD-055) for more rigorous evidence collection. Do NOT force this — it's user's choice whether the rigour is worth the time.
+
+### Step 4 — Create the ADR
+
+```python
+adr = forgeplan_new(kind="adr", title="<one-sentence decision>")
+forgeplan_update(id=adr.id, body=<filled adr-light.md template>)
+```
+
+### Step 5 — Create EVID + activate
+
+The EVID for a light ADR can be inline (1-2 paragraphs verifying the decision was actually applied — e.g., "config X is now in production as of commit Y"):
+
+```python
+evid = forgeplan_new(kind="evidence", title="Verification — decision <NNN> applied", parent_id=adr.id)
+forgeplan_update(id=evid.id, body=<bold-pattern with Verdict: APPLIED, Congruence level, Evidence type>)
+forgeplan_activate(id=evid.id)
+forgeplan_activate(id=adr.id)
+```
+
+### Step 6 — Confirm to user
+
+Tell the user:
+- ADR-NNN created and active
+- Revisit Trigger summary (1 line — when this will need re-opening)
+- If F+G+R was low: remind about `evidence-gatherer` as a follow-up if rigour matters
+
+## Hard rules
+
+1. **Never skip Revisit Trigger.** This is the DDR distinction from old-style ADR. A decision without a trigger is a memorial.
+2. **Never artificially inflate F+G+R.** If it's a gut feel, write F=2 G=2 R=2. Self-honest weak score is more valuable than a fake strong one.
+3. **If you exceed 400 lines, STOP and switch to `adr-architect` full template.** This is a light record; if it needs more, the decision is bigger than light scope.
+4. **Never wait on the user for >2 follow-up questions.** Make reasonable defaults, note what's assumed, let the user correct after the ADR is created.
+5. **Default Depth = Tactical.** Light ADR is by definition tactical scope.
+
+## References
+
+- Template: `plugins/fpl-skills/templates/adr-light.md`
+- Full ADR alternative: `plugins/fpl-skills/templates/adr-full.md` (via `adr-architect` agent)
+- DDR methodology (user-provided 2026-05-24): 6 sections, 200-400 words, mandatory Revisit Trigger
+- Sprint Z2 (PRD-053): Revisit Trigger enforcement via guardian + decay-watch
+- Sprint Z4 (PRD-055): evidence-gatherer agent for rigorous F+G+R scoring

--- a/plugins/fpl-skills/templates/adr-full.md
+++ b/plugins/fpl-skills/templates/adr-full.md
@@ -1,0 +1,137 @@
+# ADR Full Template (MADR 3.0)
+
+> **Use this template when**: decision touches ≥3 modules, OR ADI surfaces ≥3 unresolved trade-offs, OR decision supersedes another ADR, OR user said "full ADR" / "major decision".
+> For routine choices (lib X vs Y, single-config decision) — use `adr-light.md` instead. Keep this one for the big stuff.
+> **No hard line limit**, but typical full ADR is 800-2000 lines. ADR-006 is a real-world example (~3000 lines, multi-sprint context).
+> **9 sections, Context / Drivers / Options / Outcome / Consequences / Compliance MUST. Invariants / Open Questions / References SHOULD.**
+
+---
+
+# ADR-NNN: <one-sentence decision title>
+
+| Field | Value |
+|---|---|
+| Status | Draft |
+| Date | YYYY-MM-DD |
+| Depth | Standard or Deep |
+| Decision drivers | <comma-separated keywords — risk, compliance, performance, cost> |
+| Decision-makers | <human or agent — autonomous orchestrator + named user> |
+| Supersedes | <ADR-XXX or None> |
+| Superseded-by | (open) |
+
+## Context
+
+<2-4 paragraphs. Full situation: what changed upstream, what's the constraint, what's currently in production, why is this decision being raised NOW. Reference the trigger event (issue, sprint, incident).>
+
+## Decision drivers
+
+Numbered list of constraints / forces shaping this decision. Cite source.
+
+- **DD-1 (RISK)**: <constraint + source>
+- **DD-2 (EMPIRICAL CONSTRAINT)**: <constraint + source>
+- **DD-3 (UPSTREAM DEPENDENCY)**: <constraint + source>
+- **DD-4 (SEPARATION OF DUTY)**: <constraint + source>
+- **DD-5 (DEFENSE IN DEPTH)**: <constraint + source>
+
+## Considered options
+
+Minimum three. Each with its own subsection.
+
+### Option 1 — <name>
+
+Pattern / approach in 2-5 lines or a code block.
+
+**Pro**:
+- <concrete pro 1>
+- <concrete pro 2>
+
+**Con**:
+- <concrete con 1 — cite evidence if quantified>
+- <concrete con 2>
+
+**Verdict**: SUPPORTED / REFUTED / NEEDS MORE DATA — with rationale.
+
+### Option 2 — <name>
+
+(same shape)
+
+### Option 3 — <name>
+
+(same shape)
+
+## Decision outcome
+
+**Chosen option**: **Option N — <name>.**
+
+Rationale referencing DD-1..DD-N:
+
+1. **DD-1 + <evidence>** — <one sentence>
+2. **DD-2 + <evidence>** — <one sentence>
+3. (continue for each DD that drives the choice)
+
+The decision is **reversible / irreversible** by design (one-liner: how to back out).
+
+## Consequences
+
+### Positive
+
+- <one-line concrete benefit>
+- <another>
+
+### Negative
+
+- <one-line concrete cost>
+- <another>
+
+### Neutral
+
+- <one-line — no impact, just noting>
+
+## Compliance / Revisit Trigger — MUST
+
+**This decision MUST be re-opened** when ALL of the following are true:
+
+1. <Concrete trigger — upstream release, metric, date>
+2. <Concrete verification — what observation confirms revisit is needed>
+3. <Concrete next-action — what artifact to create next (ADR-N+1 supersede plan)>
+
+**Operational support**:
+
+- `scripts/<monitor-name>.sh` — one-shot status check (if applicable)
+- `docs/POST-<TRIGGER>-ACTIONS.md` — ready-to-run checklist (if applicable)
+
+Sprint Z2 (PRD-053) wires `decay-watch` skill that reads this section and alerts.
+
+## Invariants — SHOULD
+
+What this decision MUST NEVER allow to be violated:
+
+- **INV-1**: <one-line invariant>
+- **INV-2**: <another>
+
+## Open questions — SHOULD
+
+What this decision INTENTIONALLY does not answer:
+
+- <question deferred to ADR-N+1>
+- <question deferred to evidence collection>
+
+## References
+
+- PRD-NNN — parent product spec
+- EVID-NNN — supporting verification
+- ADR-XXX — superseded ancestors
+- forgeplan#NNN — upstream issue
+- Sprint X retrospective — historical context
+- mm-<model-name> — relevant mental model
+
+---
+
+## How to use this template
+
+1. Default to `adr-light.md`. Only switch here when the "When to use" criteria above are met.
+2. Create the ADR artifact: `forgeplan_new kind=adr title="..."` then `forgeplan_update body=<this filled template>`.
+3. Apply FPF ADI (Abduction → Deduction → Induction) BEFORE filling the Considered options section. Use `forgeplan_reason` or `/fpf-reason`.
+4. For each option, score F+G+R per the underlying evidence. If chosen option's sum <14 (full ADR bar higher than light), dispatch `evidence-gatherer` agent (Sprint Z4 PRD-055) for more rigorous evidence.
+5. Compliance section is MUST — not optional. Decisions without revisit triggers become memorials.
+6. Activate after EVID linked: create EVID with verification, link `informs`, activate EVID first, then ADR.

--- a/plugins/fpl-skills/templates/adr-light.md
+++ b/plugins/fpl-skills/templates/adr-light.md
@@ -1,0 +1,77 @@
+# ADR Light Template
+
+> **HARD LIMIT**: keep the final ADR ≤400 lines. If it grows past that, switch to `adr-full.md`.
+> **Purpose**: a single-screen decision record for routine choices (lib X vs Y, config Z, small refactor). One person reads it, gets the why in 30 seconds, knows when to re-open.
+> **6 sections, all MUST. Revisit Trigger is NOT optional.**
+
+---
+
+# ADR-NNN: <one-sentence decision title>
+
+| Field | Value |
+|---|---|
+| Status | Draft |
+| Date | YYYY-MM-DD |
+| Depth | Tactical |
+
+## Context
+
+<1-2 sentences. What situation, what constraint, what needs deciding.>
+
+## Hypotheses considered
+
+Minimum three. One-line each.
+
+- **H1**: <option A — what it is>
+- **H2**: <option B — what it is>
+- **H3**: <option C — the wild card, often "do nothing" or "in-process alternative">
+
+## Evidence
+
+For each hypothesis: predicted observation if true + one piece of evidence (link / measurement / quote).
+
+| H | Predicted observation | Evidence | F+G+R |
+|---|---|---|---|
+| H1 | <if true, expect X> | <link / number / quote> | F? G? R? |
+| H2 | <if true, expect Y> | <link / number / quote> | F? G? R? |
+| H3 | <if true, expect Z> | <link / number / quote> | F? G? R? |
+
+F+G+R scoring (0-9 each, sum ≥12 = OK to commit):
+- **F** (Formality) — 0: gut feel; 5: explicit conditional claim; 9: spec/proof
+- **G** (Granularity) — 0: "slow"; 5: "15% faster"; 9: "p99=47ms @ 10k RPS, 1KB payload"
+- **R** (Reliability) — 0: Slack anecdote; 5: ≥2 independent sources; 9: peer-reviewed or our prod benchmark
+
+## Decision
+
+<One sentence. Which hypothesis is accepted.>
+
+## Rejected alternatives
+
+- **H?** rejected because <one concrete reason — not "didn't fit">
+- **H?** rejected because <one concrete reason>
+
+## Revisit Trigger (Evidence Decay) — MUST
+
+Re-open this ADR when ANY of:
+
+1. <Concrete event — e.g., "we cross 100k records">
+2. <Concrete metric — e.g., "p99 latency drops below 50ms">
+3. <Date — e.g., "2027-01-01" or "+6 months from creation">
+
+Sprint Z2 enforcement (PRD-053): guardian agent + decay-watch skill will alert when any trigger fires.
+
+---
+
+## How to use this template
+
+1. Copy → fill in placeholders → keep ≤400 lines.
+2. Create the ADR artifact: `forgeplan_new kind=adr title="..."` then `forgeplan_update body=<this filled template>`.
+3. Score: F+G+R per hypothesis. If sum <12 on the chosen hypothesis, gather more evidence (dispatch `evidence-gatherer` agent — Sprint Z4 PRD-055).
+4. Activate after EVID linked (canonical 2-step): create EVID with the test/benchmark/justification, link `informs`, then activate.
+
+## When to switch to adr-full.md
+
+- Decision touches ≥3 modules
+- ADI surfaces ≥3 unresolved trade-offs that need own subsections
+- Decision is supersedes/refines an existing active ADR
+- User explicitly says "full ADR" / "major decision"


### PR DESCRIPTION
## Что и зачем

PM-feedback после Sprint Y: «должен быть для лёгких решений и для больших — то есть на все случаи и шаблоны». Делаю.

## Что в этой версии

**2 шаблона + 1 skill + обновление agent:**

| Файл | Строк | Назначение |
|---|---:|---|
| `templates/adr-light.md` | 77 | DDR-стиль, 6 секций, ≤400 строк — для повседневных решений |
| `templates/adr-full.md` | 137 | MADR 3.0, 9 секций — для крупных решений (3+ модулей, supersede, irreversible) |
| `skills/decision/SKILL.md` | 96 | `/decision` — быстрый путь записать решение из текущего разговора |
| `agents-pro/adr-architect.md` | +30 строк | Step 5b dispatch — сам выбирает light или full |

**Ключевое отличие от старого:** `## Revisit Trigger` (Evidence Decay) теперь **MUST поле** в обоих шаблонах. Sprint Z2 (следующий PR) добавит его автоматическую проверку через guardian + decay-watch.

## Verification

- [x] adr-light 77 строк (target ≤80), 6 секций в фиксированном порядке, hard limit 400 строк в заголовке
- [x] adr-full 137 строк (target ≥120), 9 секций MADR 3.0
- [x] Revisit Trigger MUST в обоих
- [x] adr-architect Step 5b — 5 критериев когда переключаться на full
- [x] /decision skill с F+G+R scoring + offer to dispatch evidence-gatherer (Sprint Z4) если score <12
- [x] `./scripts/validate-all-plugins.sh` → ALL PASSED
- [x] PRD-052 + EVID-081 active
- [x] 9-я подряд успешная демо `forgeplan#295` parent_id auto-link

## Version bumps

- fpl-skills v1.24.5 → v1.25.0 (minor — new skill + 2 templates)
- catalog v1.62.0 → v1.63.0
- agents-pro НЕ bumped — только doc-only body edit в одном агенте

## Что НЕ в этой версии (следующие спринты)

- **Sprint Z2** — enforcement Revisit Trigger через guardian + /decay-watch skill + SessionStart hook
- **Sprint Z3** — апстрим issue audit и filing если есть пробелы
- **Sprint Z4** — evidence-gatherer агент (20-30 источников + R scoring + ask-back для пользовательских бенчмарков/логов)

Refs: PRD-052, EVID-081

🤖 Generated with [Claude Code](https://claude.com/claude-code)