### PR TITLE
feat(fpl-skills,docs): Sprint Z8 — OpenSpec delta-spec mandatory at supersede

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official ForgePlan plugin marketplace for Claude Code — UX, frontend, workflow, and developer tools",
-    "version": "1.67.0"
+    "version": "1.68.0"
   },
   "plugins": [
     {
@@ -36,7 +36,7 @@
       "name": "fpl-skills",
       "source": "./plugins/fpl-skills",
       "description": "Flagship workflow plugin for the ForgePlan ecosystem. 27 engineering skills + dev-advisor agent + 5 hooks. v1.24.5: Sprint T PRD-046 — /forge-cleanup Step 2.5 native forgeplan_anomalies MCP primary + AGENT-AUTHORING-GUIDE Profile B EVID-creation canonical procedure (2-step parent_id auto-link via #295). v1.24.4: Sprint S Step 9c convention. v1.24.3: Sprint O detection script. v1.24.2: Sprint M conventions. v1.25.0: Sprint Z1 PRD-052 — added /decision skill + adr-light/adr-full templates with mandatory Revisit Trigger. v1.26.0: Sprint Z2 PRD-053 — Evidence Decay enforcement. v1.27.0: Sprint Z5 PRD-056 — deferred-items tracker (NOTE-013) + /decay-watch 4-source extension.",
-      "version": "1.27.0",
+      "version": "1.28.0",
       "author": {
         "name": "ForgePlan"
       },
@@ -121,8 +121,8 @@
     {
       "name": "forgeplan-workflow",
       "source": "./plugins/forgeplan-workflow",
-      "description": "Structured engineering workflow for forgeplan users. Provides /forge-cycle (full SDLC cycle) and /forge-audit. v1.10.3: Sprint T PRD-046 — forgeplan_unlink MCP adopted (replaces Sprint G CLI workaround per #286). v1.10.2: Sprint S Phase 6.5.1 document_ingest_file wire. v1.10.1: Sprint F + J+K Phase 7.3.",
-      "version": "1.10.3",
+      "description": "Structured engineering workflow for forgeplan users. Provides /forge-cycle (full SDLC cycle) and /forge-audit. v1.11.0: Sprint Z6 PRD-057 — Step 6.5 BMAD adversarial review mandatory for Standard+ activation. v1.10.3: Sprint T PRD-046 — forgeplan_unlink MCP adopted.",
+      "version": "1.11.0",
       "author": {
         "name": "ForgePlan"
       },
@@ -250,8 +250,8 @@
     {
       "name": "agents-pro",
       "source": "./plugins/agents-pro",
-      "description": "Professional specialist agents: security experts, architecture reviewers, creative tools, research analysts, infrastructure engineers, plus pipeline-canonical roles. v1.8.2: Sprint Q PRD-042 — ASM-canon frontmatter added to 12 forgeplan-aware agents (skills preload, maxTurns, MCP deps comments; 5 learners get memory:project: architect-reviewer/adr-architect/goal-planner/security-expert/system-dev). v1.8.1: Sprint E body patches. v1.9.0: Sprint Z4 PRD-055 — evidence-gatherer agent. v1.9.1: Sprint Z-audit fix.",
-      "version": "1.9.1",
+      "description": "Professional specialist agents: security experts, architecture reviewers, creative tools, research analysts, infrastructure engineers, plus pipeline-canonical roles. v1.9.2: Sprint Z6 PRD-057 — guardian Step 5 verdict matrix 2 new BMAD rows (Standard+ zero Profile B EVID → BLOCKER; empty ## Findings → CONCERNS). v1.9.1: Sprint Z-audit fix. v1.9.0: Sprint Z4 PRD-055 — evidence-gatherer agent.",
+      "version": "1.9.2",
       "author": {
         "name": "ForgePlan"
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
 # ForgePlan Marketplace — Claude Code Configuration
 
 **Repo**: [ForgePlan/marketplace](https://github.com/ForgePlan/marketplace)
-**Catalog version**: 1.61.0
+**Catalog version**: 1.68.0
 **Plugins**: 15 (9 workflow + 5 agent packs + 1 memory plugin fpl-hsmem) — brownfield-pack now ships canonical Profile A `discover` agent
 **Agents**: 18 of ~65 forgeplan-aware (PRD-026 canonical B2 paradigm — `disallowedTools` denylist + Sprint Q PRD-042 ASM-canon frontmatter + Sprint S Step 9c filesystem verification + Sprint T v0.32.1 native MCP adoption + Sprint V PRD-048 brownfield Discover Agent migrated to plugin. **`memory: project` REJECTED Sprint R** — Hindsight covers use case.)
-**Last Updated**: 2026-05-22 (post Sprint U/V/adopt-#288/W autonomous run: Sprint U pivot empirically refuted Resume Prompt batch-fix premise + filed forgeplan#325; Sprint V migrated brownfield Discover Agent to plugin v1.4.0; Sprint adopt-#288 ADR-006 KEEP CURRENT 4-layer sentinel; Sprint W closed Anomaly #27+#28 — LR-8 lint rule active + canonical frontmatter schema formalises skills:/maxTurns:/isolation: fields. 28 anomalies (24 resolved) + 13 ML + 10 mental models, catalog v1.61.0)
+**Last Updated**: 2026-05-25 (post Sprint Z6 PRD-057: BMAD adversarial review mandatory for Standard+ activation — forgeplan-workflow v1.11.0 Step 6.5 + agents-pro v1.9.2 guardian 2 new verdict rows + CLAUDE.md BMAD discipline section. Catalog v1.68.0. 28 anomalies (24 resolved) + 13 ML + 10 mental models)
 **Project board**: [orgs/ForgePlan/projects/5](https://github.com/orgs/ForgePlan/projects/5)
 
 ---
@@ -218,6 +218,79 @@ Quick path for a defer:
 
 ---
 
+## BMAD adversarial review discipline (Sprint Z6 — PRD-057)
+
+Foundation: EPIC-001 «4-layer pipeline», S11 BMAD quality-gate layer. MSR 2026 measures **+25–41% complexity gap** in AI-assisted projects without adversarial review controls — artifacts are plausible-sounding but under-specified.
+
+### Rules
+
+1. **Every Standard+ PRD, RFC, or ADR MUST have ≥1 Profile B EVID** linked `informs` before `forgeplan_activate` is called. Zero-evidence activation = BLOCKER at guardian gate.
+
+2. **Profile B EVID body MUST contain a `## Findings` section with ≥1 item.** Zero findings = reviewer was not adversarial enough. The reviewer's role is explicitly adversarial: assume the artifact has a gap, look for it, and name it.
+
+3. **Motivation (MSR 2026)**: AI-generated artifacts exhibit confident incompleteness — they look finished but silently omit non-obvious requirements, measurability constraints, or risk mitigations. A structured adversarial reviewer closes this gap. Without it, the pipeline amplifies AI confidence without adding human-equivalent verification.
+
+4. **What to write when genuinely nothing is wrong**: if after thorough adversarial search the reviewer finds no actionable issue, write a `## Findings` section with exactly one line stating so **plus ≥2 sentences explaining what was specifically checked and why no gap was found**. A bare "no findings" is not acceptable — it reads identically to "reviewer didn't look". Default expectation: ≥1 finding exists. Genuinely zero-gap artifacts are exceptional.
+
+5. **Enforcement**:
+   - `/forge-cycle` Step 6.5 dispatches `agents-pro:artifact-reviewer` with adversarial mandate for all Standard+ depth tasks
+   - `guardian` Step 5 verdict matrix: zero Profile B EVID with verdict=PASS → **BLOCKER**; Profile B EVID with empty `## Findings` → **CONCERNS** (re-dispatch recommended)
+
+Quick path for the reviewer:
+
+```markdown
+## Findings
+
+1. **[Severity: HIGH]** AC-3 has no measurable threshold — "system should respond quickly" is not SMART.
+   Recommendation: replace with "System shall respond within 200ms at p95 under 1000 concurrent users".
+```
+
+Reference: PRD-057, EPIC-001 (4-layer pipeline S11), MSR 2026 (+25–41% complexity without controls).
+
+---
+
+## OpenSpec delta-spec discipline (Sprint Z8 — PRD-058)
+
+Foundation: EPIC-001 «4-layer pipeline», S12 OpenSpec structure layer. Every **supersede** operation
+MUST produce an explicit delta-spec — a structured record of what was ADDED, MODIFIED, REMOVED, and
+UNCHANGED relative to the predecessor. Without delta, the supersede history silently loses context.
+
+### Rules
+
+1. **Every supersede MUST use `adr-supersede.md` template** (or include the equivalent delta sections
+   in a custom body). The four sub-sections — `### ADDED`, `### MODIFIED`, `### REMOVED`,
+   `### UNCHANGED` — are ALL required in the new artifact body.
+
+2. **Empty delta is fine if explicit.** If a category genuinely has nothing, write «no items».
+   Implicit empty (missing section entirely) is the violation — not the absence of content.
+
+3. **`/decay-watch` Step 2e enforces.** On every invocation it enumerates all active artifacts with
+   a `supersedes` link and classifies each:
+   - `HAS-DELTA` — delta-spec present, compliant.
+   - `MISSING-DELTA` — pre-Z8 supersede, no delta section, backward-compatible warning.
+   - `NO-DELTA-WHEN-REQUIRED` — Z8+ supersede (created on/after 2026-05-25) missing delta → **CONCERNS** in next health check.
+
+4. **Use `/supersede` skill for the workflow.** It walks Steps 1-8: reads old ADR, verifies active
+   status, computes delta, fills template, creates new ADR, links `supersedes`, marks predecessor
+   `superseded`. Do not manually create supersede artifacts without running this procedure.
+
+5. **REMOVED > 50% of predecessor → reconsider.** If the new decision removes more than half the
+   predecessor's substance, it may be a replacement rather than an evolution. Write a standalone ADR
+   (using `adr-light.md` or `adr-full.md`) instead. The `/supersede` skill surfaces this check in
+   Step 3.
+
+Quick path for a supersede:
+
+```bash
+# In your session:
+/supersede ADR-NNN
+# The skill reads the old ADR, prompts for delta, creates new ADR with delta-spec, links + marks superseded.
+```
+
+Reference: PRD-058, EPIC-001 (4-layer pipeline S12 OpenSpec).
+
+---
+
 ## Version Bumping
 
 When a plugin changes, bump version in two places:
@@ -294,16 +367,16 @@ gh api repos/ForgePlan/marketplace/rulesets --jq '.[] | .name'  # rulesets
 
 ---
 
-## Plugin versions (catalog v1.66.0)
+## Plugin versions (catalog v1.68.0)
 
 ### Workflow plugins
 
 | Plugin | Version |
 |--------|:-------:|
-| **fpl-skills** | **1.26.0** (Sprint Z2: /decay-watch skill + decay-reminder.sh SessionStart hook; Sprint Z1: /decision skill + adr templates) |
+| **fpl-skills** | **1.28.0** (Sprint Z8: /supersede skill + templates/adr-supersede.md + /decay-watch Step 2e; Sprint Z5: /decay-watch 4-source extension; Sprint Z2: /decay-watch + decay-reminder.sh; Sprint Z1: /decision + adr templates) |
 | **cc-best** | **1.0.0** (Sprint Y phase 1: claude-md section + 5 STUB sections) |
 | **fpl-hsmem** | 2.1.0 |
-| **forgeplan-workflow** | 1.10.3 |
+| **forgeplan-workflow** | **1.11.0** (Sprint Z6: Step 6.5 BMAD adversarial review mandatory for Standard+) |
 | **forgeplan-orchestra** | 1.4.1 |
 | **forgeplan-brownfield-pack** | 1.4.0 (Sprint V: Discover Agent migrated) |
 | **fpf** | 1.4.1 |
@@ -318,7 +391,7 @@ gh api repos/ForgePlan/marketplace/rulesets --jq '.[] | .name'  # rulesets
 |--------|:-------:|---|
 | **agents-core** | 1.3.2 | Sprint Q |
 | **agents-domain** | 1.1.0 | — |
-| **agents-pro** | **1.9.1** | Sprint Z4 (evidence-gatherer agent) + Sprint Z-audit (guardian Step 5 verdict matrix row) |
+| **agents-pro** | **1.9.2** | Sprint Z6 (guardian Step 5: 2 new BMAD rows — BLOCKER + CONCERNS for adversarial review) |
 | **agents-github** | 1.1.0 | — |
 | **agents-sparc** | 1.2.1 | Sprint Q |
 

--- a/plugins/fpl-skills/.claude-plugin/plugin.json
+++ b/plugins/fpl-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fpl-skills",
-  "version": "1.27.0",
-  "description": "Flagship workflow plugin for the ForgePlan ecosystem. 27 engineering skills + dev-advisor agent + 5 hooks. v1.24.3: Sprint O PRD-041 — scripts/detect_link_footguns.sh ships (76 LOC bash, NDJSON output, walks forgeplan graph detecting supersedes-inversion + informs-inversion; surfaced 4 real findings on first run validating Anomaly #15/#16 patterns). v1.24.2: Sprint M PRD-039 conventions (Step 9b.1 + Step 11 + 9th anomaly kind). v1.24.1: Sprint J+K closure pack. v1.24: PRD-034 Sprint F — /forge-cleanup 8 outcomes total. v1.23: Sprint D self-healing framework + <<NEEDS_ACTIVATION>> sentinel. v1.25.0: Sprint Z1 PRD-052 — added /decision skill + templates/adr-light.md + templates/adr-full.md (DDR-style decision records with mandatory Revisit Trigger). v1.26.0: Sprint Z2 PRD-053 — Evidence Decay enforcement: /decay-watch skill + decay-reminder.sh SessionStart hook + adr templates parseable Revisit Trigger syntax. v1.27.0: Sprint Z5 PRD-056 — /decay-watch extended to 4 sources (ADR triggers / NOTE-013 deferred items / upstream issue check-scripts / ADR line-count) + decay-reminder.sh now alerts across all 4. NOTE-013 «Deferred items tracker» introduced. Closes audit Finding #4.",
+  "version": "1.28.0",
+  "description": "Flagship workflow plugin for the ForgePlan ecosystem. 28 engineering skills + dev-advisor agent + 5 hooks. v1.24.3: Sprint O PRD-041 — scripts/detect_link_footguns.sh ships (76 LOC bash, NDJSON output, walks forgeplan graph detecting supersedes-inversion + informs-inversion; surfaced 4 real findings on first run validating Anomaly #15/#16 patterns). v1.24.2: Sprint M PRD-039 conventions (Step 9b.1 + Step 11 + 9th anomaly kind). v1.24.1: Sprint J+K closure pack. v1.24: PRD-034 Sprint F — /forge-cleanup 8 outcomes total. v1.23: Sprint D self-healing framework + <<NEEDS_ACTIVATION>> sentinel. v1.25.0: Sprint Z1 PRD-052 — added /decision skill + templates/adr-light.md + templates/adr-full.md (DDR-style decision records with mandatory Revisit Trigger). v1.26.0: Sprint Z2 PRD-053 — Evidence Decay enforcement: /decay-watch skill + decay-reminder.sh SessionStart hook + adr templates parseable Revisit Trigger syntax. v1.27.0: Sprint Z5 PRD-056 — /decay-watch extended to 4 sources (ADR triggers / NOTE-013 deferred items / upstream issue check-scripts / ADR line-count) + decay-reminder.sh now alerts across all 4. NOTE-013 «Deferred items tracker» introduced. Closes audit Finding #4. v1.28.0: Sprint Z8 PRD-058 — OpenSpec S12 delta-spec mandatory at supersede: /supersede skill + templates/adr-supersede.md + /decay-watch Step 2e supersede chain delta verification (HAS-DELTA / MISSING-DELTA / NO-DELTA-WHEN-REQUIRED).",
   "author": {
     "name": "ForgePlan"
   },
@@ -69,7 +69,8 @@
       "sprint",
       "team",
       "decision",
-      "decay-watch"
+      "decay-watch",
+      "supersede"
     ],
     "hooks": [
       "SessionStart",

--- a/plugins/fpl-skills/skills/decay-watch/SKILL.md
+++ b/plugins/fpl-skills/skills/decay-watch/SKILL.md
@@ -94,6 +94,49 @@ if is_light_adr(adr_body) and line_count > 400:
 
 Full ADRs have no hard limit (typical 800-2000 lines) — only warn if exceeds 3000 (likely scope creep).
 
+### Step 2e — Supersede chain delta-spec verification (Sprint Z8 PRD-058)
+
+Enumerate all active artifacts that have a `supersedes` link to another artifact. For each,
+verify the body contains the mandatory OpenSpec delta-spec sections.
+
+```python
+# Fetch all active artifacts and filter those with supersedes links
+active_artifacts = forgeplan_list(status="active")
+for artifact in active_artifacts:
+    details = forgeplan_get(id=artifact.id)
+    has_supersedes_link = any(
+        link.relation == "supersedes"
+        for link in details.get("dependency_links", [])
+    )
+    if not has_supersedes_link:
+        continue
+
+    body = details.get("body", "")
+    has_delta_section = "## Delta-spec" in body or "### ADDED" in body
+
+    # Classify
+    if has_delta_section:
+        classification = "HAS-DELTA"        # delta-spec present — compliant
+    else:
+        # Determine if pre-Z8 or Z8+ by checking creation date
+        created = details.get("created_at", "")
+        if created >= "2026-05-25":         # Z8 epoch: Sprint Z8 PRD-058 shipped
+            classification = "NO-DELTA-WHEN-REQUIRED"   # Z8+ supersede missing delta → CONCERNS
+        else:
+            classification = "MISSING-DELTA"            # pre-Z8 supersede → backward-compat warning
+```
+
+Classifications:
+
+| Classification | Meaning | Action |
+|---|---|---|
+| **HAS-DELTA** | `## Delta-spec` section present in body | Compliant — no action |
+| **MISSING-DELTA** | Supersede created before Z8 (pre-2026-05-25), no delta section | Warning — backward-compatible; recommend adding delta retrospectively |
+| **NO-DELTA-WHEN-REQUIRED** | Supersede created Z8+ (on/after 2026-05-25), no delta section | CONCERNS — violates Sprint Z8 enforcement; file for remediation |
+
+**Note**: pre-Z8 supersedes are flagged as warnings, not blockers, to preserve backward
+compatibility. The discipline is **mandatory for new supersedes from Sprint Z8 onward**.
+
 ### Step 3 — Classify each trigger
 
 Three categories:
@@ -107,7 +150,7 @@ Three categories:
 
 ### Step 4 — Output structured report
 
-When invoked silently (by hook) — output ONLY if there are FIRED / DATE-FIRED / ISSUE-FIRED / LINE-LIMIT-EXCEEDED items across any of the 4 sources:
+When invoked silently (by hook) — output ONLY if there are FIRED / DATE-FIRED / ISSUE-FIRED / LINE-LIMIT-EXCEEDED / NO-DELTA-WHEN-REQUIRED items across any of the 5 sources:
 
 ```
 🔔 N item(s) need attention:
@@ -115,6 +158,7 @@ When invoked silently (by hook) — output ONLY if there are FIRED / DATE-FIRED 
   - NOTE-013 deferred item closed (issue): forgeplan#NNN
   - check-issue-NNN: state changed OPEN → CLOSED
   - ADR-YYY exceeds 400-line limit (current: NNN)
+  - ADR-ZZZ: Z8+ supersede missing delta-spec (NO-DELTA-WHEN-REQUIRED)
 Run /decay-watch for details.
 ```
 
@@ -156,6 +200,19 @@ When invoked directly by user — output full multi-source report:
 - **ADR-XXX (light)**: 432 lines — exceeds 400 limit
   - Recommend: split into 2 light ADRs, OR migrate to adr-full template
 
+### 5. Supersede chain delta-spec (Sprint Z8)
+
+#### NO-DELTA-WHEN-REQUIRED (Z8+ supersede — CONCERNS)
+- **ADR-XXX**: supersedes ADR-YYY — created YYYY-MM-DD — missing `## Delta-spec` section
+  - Action: add delta-spec using `templates/adr-supersede.md` or run `/supersede` retroactively
+
+#### MISSING-DELTA (pre-Z8 supersede — warning)
+- **ADR-AAA**: supersedes ADR-BBB — pre-Sprint-Z8 artifact — no delta-spec (backward-compatible)
+  - Recommend: add delta retrospectively when the ADR is next touched
+
+#### HAS-DELTA (compliant)
+- Count: N — all delta-specs present
+
 ### SUMMARY
 
 - Total active ADRs: N (M light / K full)
@@ -163,6 +220,7 @@ When invoked directly by user — output full multi-source report:
 - NOTE-013 deferred: N total / N fired / N pending
 - Upstream issues: N watched / N newly CLOSED
 - Line-count violations: N
+- Supersede chain delta-spec: N HAS-DELTA / N MISSING-DELTA (pre-Z8) / N NO-DELTA-WHEN-REQUIRED (Z8+)
 ```
 
 ## Hard rules
@@ -189,7 +247,10 @@ When invoked directly by user — output full multi-source report:
 
 ## References
 
-- PRD-053 (this Sprint Z2 scope)
+- PRD-053 (Sprint Z2 scope — this skill's original introduction)
+- PRD-056 (Sprint Z5) — 4-source extension (NOTE-013 / check-issue scripts / line-count)
+- PRD-058 (Sprint Z8) — Step 2e supersede chain delta-spec verification
 - PRD-052 / Sprint Z1 — ADR templates with parseable Revisit Trigger
 - guardian agent (`plugins/agents-pro/agents/guardian.md`) Step 4b
 - ADR-006 — example with full Compliance section (currently pre-Sprint-Z2 format, will be migrated when revisited)
+- EPIC-001 S12 OpenSpec layer — authority for delta-spec discipline

--- a/plugins/fpl-skills/skills/supersede/SKILL.md
+++ b/plugins/fpl-skills/skills/supersede/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: supersede
+description: |
+  Walk the complete supersede-ADR workflow with mandatory OpenSpec delta-spec discipline.
+  Reads the old ADR, verifies it is active, computes the user's intended delta, creates the
+  new ADR using the adr-supersede.md template (all four delta sections: ADDED / MODIFIED /
+  REMOVED / UNCHANGED), links supersedes, and marks the predecessor superseded.
+
+  Triggers: "supersede", "supersede ADR", "замени ADR", "обнови решение", "supersede decision",
+  "evolve ADR", "replace ADR", "/supersede"
+
+  Sprint Z8 PRD-058 — EPIC-001 S12 OpenSpec layer.
+---
+
+# /supersede — Supersede ADR with OpenSpec delta-spec
+
+This skill walks the mandatory 8-step procedure for superseding an active ADR. It enforces the
+**S12 OpenSpec delta-spec discipline** (Sprint Z8 PRD-058): every supersede MUST document what
+is ADDED, MODIFIED, REMOVED, and UNCHANGED relative to the predecessor.
+
+## When to invoke
+
+- User wants to replace an existing ADR with an updated decision.
+- A Revisit Trigger fired (`[x]` in the ADR body, or `/decay-watch` reported FIRED / DATE-FIRED).
+- Upstream event (issue closed, sprint decision, empirical finding) makes the predecessor obsolete.
+- User says: «supersede ADR-XXX», «replace ADR-XXX with new decision», «update ADR-XXX».
+
+## Core principle
+
+> «Supersede is for evolutionary refinement, not replacement.»
+>
+> If the new decision has NO relationship to the old one, write a standalone ADR (use
+> `adr-light.md` or `adr-full.md`). Supersede is only correct when the old decision is
+> still the right *context* but the *conclusion* has evolved due to new information.
+
+---
+
+## Procedure
+
+### Step 1 — Read the predecessor ADR
+
+```python
+old_adr = forgeplan_get(id="ADR-NNN")
+```
+
+Print title, status, and decision section to the user so you both share the same baseline.
+
+### Step 2 — Verify predecessor is active
+
+```python
+if old_adr.status != "active":
+    raise Error(f"Cannot supersede ADR-{N}: status is '{old_adr.status}'. "
+                "Only active ADRs can be superseded. "
+                "If status is 'draft', activate it first or write a new ADR instead.")
+```
+
+Halt if not active. Report status and stop — do NOT proceed with a non-active predecessor.
+
+### Step 3 — Compute delta in working memory
+
+Before writing anything, enumerate the delta between what the user wants to decide and what
+ADR-NNN currently says. Answer all four questions explicitly:
+
+| Question | Answer |
+|---|---|
+| What's ADDED that didn't exist in the predecessor? | <list or «none»> |
+| What's MODIFIED (same topic, different conclusion)? | <list with before/after or «none»> |
+| What's REMOVED (no longer applies at all)? | <list or «none»> |
+| What's UNCHANGED (carries over exactly)? | <summary or «everything else»> |
+
+**Hard rule**: If you cannot answer these four questions with at least one non-«none» answer
+across ADDED + MODIFIED + REMOVED, this is not a supersede — it's either a new decision or a
+correction. Stop and clarify with the user.
+
+**Hard rule**: If REMOVED covers more than ~50% of the predecessor's substance, reconsider:
+this may be a wholesale replacement, not an evolution. Recommend a new standalone ADR instead.
+Present the concern to the user before proceeding.
+
+### Step 4 — Read the adr-supersede template
+
+```python
+template = read_file("templates/adr-supersede.md")
+```
+
+Use this as the structural reference for the new ADR body. Fill all sections including the
+four delta sub-sections. Never leave any delta sub-section blank — write «no items» explicitly
+if a category genuinely has nothing.
+
+### Step 5 — Create the new ADR artifact
+
+```python
+new_adr = forgeplan_new(
+    kind="adr",
+    title="<descriptive title reflecting the evolved decision>",
+    depth="standard",   # or "deep" if decision touches ≥3 modules
+)
+```
+
+Then fill the body using `forgeplan_update(id=NEW-ADR, body=<filled template>)`.
+
+The body MUST contain:
+- `## Why supersede` section
+- `## Delta-spec (OpenSpec format) — MUST` with all four sub-sections
+- `## Predecessor reference` citing the old ADR's exact decision text
+- `## Revisit Trigger (Evidence Decay) — MUST` with parseable syntax
+
+### Step 6 — Fill body with delta-spec — never empty
+
+For each delta sub-section:
+- **ADDED**: list every new rule, constraint, or feature introduced in this version.
+- **MODIFIED**: for each changed item, show **before (ADR-XXX):** and **after (this ADR):** lines.
+- **REMOVED**: list every rule, constraint, or workaround being retired, with reason.
+- **UNCHANGED**: one sentence summarising what carries over verbatim.
+
+If any sub-section genuinely has nothing: write «no items» — NOT a blank line, NOT omitted.
+
+```python
+# Validate before saving
+for section in ["### ADDED", "### MODIFIED", "### REMOVED", "### UNCHANGED"]:
+    assert section in body, f"Missing required delta sub-section: {section}"
+    idx = body.index(section)
+    next_section = body.find("###", idx + len(section))
+    content = body[idx:next_section if next_section != -1 else len(body)]
+    assert len(content.strip()) > len(section) + 10, \
+        f"Delta sub-section {section} appears empty — write 'no items' if none"
+```
+
+### Step 7 — Link: new supersedes old
+
+```python
+forgeplan_link(
+    source=new_adr.id,    # new ADR
+    target=old_adr.id,    # old ADR
+    relation="supersedes"
+)
+```
+
+Direction: **source (newer) → target (older)**. This is the canonical direction per
+Anomaly #15 (Sprint L) — inversion is silently accepted by forgeplan but semantically wrong.
+
+Verify with `forgeplan_get(id=new_adr.id)` that `supersedes` link appears in dependency_links.
+
+### Step 8 — Mark old ADR as superseded
+
+```python
+forgeplan_update(
+    id=old_adr.id,
+    status="superseded"
+)
+```
+
+Confirm the FSM transition succeeded (active → superseded is a valid path). If forgeplan
+rejects the transition, surface the error — do NOT silently proceed.
+
+---
+
+## Post-supersede checklist
+
+After the 8 steps complete:
+
+1. Create EVID: `forgeplan_new(kind="evidence", parent_id=new_adr.id)` — documents the
+   trigger + justification for the supersede decision.
+2. Link EVID: `forgeplan_link(source=EVID-NNN, target=new_adr.id, relation="informs")`.
+3. Activate new ADR: `forgeplan_activate(id=new_adr.id)`.
+4. Run `/decay-watch` — confirms Step 2e sees the new ADR's delta-spec as HAS-DELTA.
+
+---
+
+## Hard rules
+
+1. **Verify status=active before proceeding.** Cannot supersede draft / superseded / deprecated.
+2. **Delta-spec is non-negotiable.** Supersede without delta-spec = implicit empty delta =
+   history loss. `/decay-watch` Step 2e will flag it as MISSING-DELTA or NO-DELTA-WHEN-REQUIRED.
+3. **Write «no items» — never blank.** Implicit empty is the violation; explicit «no items» is fine.
+4. **Check REMOVED > 50% rule.** If you're removing more than half the predecessor, recommend
+   a new standalone ADR. Surface this to the user; don't proceed without acknowledgment.
+5. **Link direction: new → old.** `forgeplan_link(source=NEW, target=OLD, relation="supersedes")`.
+   Inversion is silently accepted upstream but semantically wrong (Anomaly #15).
+6. **Cite Sprint Z8 PRD-058 + EPIC-001 S12** in the new ADR's References section so reviewers
+   can trace the enforcement lineage.
+
+---
+
+## What this skill does NOT do
+
+- Does NOT make the supersede decision for you. It scaffolds the artifact; the decision is yours.
+- Does NOT write the predecessor's EVID or archive it. That's the user's responsibility.
+- Does NOT run decay-watch automatically post-supersede. Call it explicitly if you want confirmation.
+
+---
+
+## Integration points
+
+- **`templates/adr-supersede.md`** — structural template used in Step 4 / Step 6.
+- **`/decay-watch` Step 2e** — scans every active artifact with `supersedes` link to verify
+  delta-spec presence (HAS-DELTA / MISSING-DELTA / NO-DELTA-WHEN-REQUIRED).
+- **`guardian` agent** — may surface CONCERNS on supersede chains missing delta-spec during
+  pre-activation review.
+- **EPIC-001 S12 OpenSpec layer** — authority for this discipline.
+
+---
+
+## References
+
+- PRD-058 (Sprint Z8) — mandate for OpenSpec delta-spec at supersede
+- EPIC-001 S12 — OpenSpec structure layer
+- `templates/adr-supersede.md` — the structural template
+- `skills/decay-watch/SKILL.md` Step 2e — decay verification of supersede chains
+- Anomaly #15 (Sprint L) — supersedes link direction (new→old canonical)
+- `templates/adr-light.md`, `templates/adr-full.md` — for non-supersede decisions

--- a/plugins/fpl-skills/templates/adr-supersede.md
+++ b/plugins/fpl-skills/templates/adr-supersede.md
@@ -1,0 +1,140 @@
+# ADR Supersede Template (OpenSpec S12)
+
+> **Use this template** when creating a new ADR that supersedes (replaces) an existing active ADR.
+> For routine new decisions — use `adr-light.md` or `adr-full.md` instead.
+> **This template enforces the S12 OpenSpec delta-spec discipline** — every supersede MUST document
+> exactly what changed from the predecessor: ADDED / MODIFIED / REMOVED / UNCHANGED.
+> Sprint Z8 PRD-058 — EPIC-001 S12 layer.
+
+---
+
+# ADR-NNN: <one-sentence decision title>
+
+| Field | Value |
+|---|---|
+| Status | Draft |
+| Date | YYYY-MM-DD |
+| Supersedes | ADR-XXX — <predecessor title> |
+| Reason | <one-line trigger: what changed externally that makes the old decision obsolete> |
+
+## Why supersede
+
+<1-2 sentences: what changed upstream (event, sprint, empirical finding, upstream issue) that
+makes ADR-XXX's decision no longer accurate or safe. This is NOT a critique of ADR-XXX — it
+was the right call at the time. Name the trigger explicitly.>
+
+Example: «The upstream `forgeplan#325` issue closed, shipping native `auto_activate_source`
+support (ADR-XXX chose KEEP CURRENT pending that fix). ADR-XXX's revisit trigger has fired.»
+
+## Delta-spec (OpenSpec format) — MUST
+
+> This section is the reason supersede exists as a distinct operation.
+> Every bullet MUST be concrete (path, field name, version, behaviour before/after).
+> Leaving a sub-section blank is NOT acceptable — write «no items» explicitly.
+> If REMOVED > 50% of predecessor content, consider writing a NEW standalone ADR instead
+> (supersede is for evolutionary refinement, not wholesale replacement).
+
+### ADDED — what's new in this version
+
+Items that did NOT exist in ADR-XXX and are being introduced:
+
+- `<Feature / rule / constraint>` — <one line explaining why it's being added>
+- <...>
+
+If nothing new: «no items»
+
+### MODIFIED — what changed from predecessor
+
+Items that existed in ADR-XXX but are being changed. Use **before** / **after** format:
+
+- `<Field / rule / behaviour>`
+  - **Before (ADR-XXX)**: <exact wording or value>
+  - **After (this ADR)**: <new wording or value>
+  - **Why**: <trigger — upstream change, empirical finding, sprint X decision>
+- <...>
+
+If nothing changed (only additions/removals): «no items»
+
+### REMOVED — what no longer applies
+
+Items from ADR-XXX that are being explicitly retired:
+
+- `<Rule / constraint / workaround>` — <why it's being retired; what makes it unnecessary>
+- <...>
+
+If nothing removed: «no items»
+
+### UNCHANGED — what carries over verbatim
+
+<One concise sentence summarising what from ADR-XXX remains fully valid in this version.
+If everything changed, write «no items». If most carries over, a phrase like
+«All other constraints from ADR-XXX carry over (sections Context / Evidence / Rejected alternatives)»
+is sufficient.>
+
+---
+
+## Predecessor reference
+
+> Cite the exact decision text being superseded so it's clear what we are evolving.
+
+**ADR-XXX decision**: «<copy the ## Decision section verbatim from ADR-XXX>»
+
+Link: `forgeplan_get(id="ADR-XXX")` — review before filling delta-spec above.
+
+---
+
+## Context (for this version)
+
+<2-4 sentences: what situation NOW that led to superseding. Focus on what's different from
+ADR-XXX's context, not the full background (that's in the predecessor). The delta drives this.>
+
+## Decision
+
+<One sentence. What we are deciding in THIS version.>
+
+## Consequences
+
+- **Positive**: <what improves>
+- **Negative / trade-offs**: <what we accept>
+- **Neutral**: <what stays the same>
+
+## Revisit Trigger (Evidence Decay) — MUST
+
+Re-open this ADR when ANY of the triggers below fires:
+
+- [ ] **Type**: date — <e.g., "2027-06-01">
+- [ ] **Type**: metric — <e.g., "error rate on supersede flows > 2%">
+- [ ] **Type**: event — <e.g., "upstream forgeplan#XXX closes">
+
+**Mark `[x]` to flag a trigger as fired.** `/decay-watch` Step 2e will verify delta-spec
+presence on this artifact. Sprint Z8 enforcement: missing delta-spec on a Z8+ supersede → CONCERNS.
+
+---
+
+## References
+
+- OpenSpec methodology — EPIC-001 S12 (structure layer)
+- Sprint Z8 PRD-058 — delta-spec mandatory at supersede
+- ADR-XXX — predecessor (superseded by this ADR)
+- `/supersede` skill — workflow for creating this artifact correctly
+- `templates/adr-light.md` / `templates/adr-full.md` — use for non-supersede decisions
+
+---
+
+## How to use this template
+
+1. Run `/supersede OLD-ADR-NNN` — the skill walks you through Steps 1-8 and fills the delta-spec.
+2. Or manually: `forgeplan_get(id="ADR-XXX")` → compute delta → create new ADR via
+   `forgeplan_new(kind="adr", title="...")` → fill body using this template.
+3. Link: `forgeplan_link(source=NEW-ADR, target=OLD-ADR, relation="supersedes")`.
+4. Update old ADR status: `forgeplan_update(id="ADR-XXX", status="superseded")`.
+5. Create EVID with `parent_id=NEW-ADR` → link → activate.
+
+### Hard rules
+
+- **Never leave a delta sub-section blank.** Write «no items» explicitly if applicable.
+- **REMOVED > 50% of predecessor?** Reconsider: that's a replacement, not an evolution.
+  Write a new standalone ADR (or adr-full.md) instead.
+- **Cannot supersede a non-active ADR.** Verify `status=active` before proceeding.
+- **If you don't have a concrete delta** — don't supersede. Write a new standalone ADR.
+  Supersede is for evolutionary refinement, not replacement of an unrelated decision.


### PR DESCRIPTION
## Summary

- Add `templates/adr-supersede.md` — supersede ADR template with mandatory ADDED/MODIFIED/REMOVED/UNCHANGED delta-spec sections (OpenSpec S12 layer, EPIC-001)
- Add `skills/supersede/SKILL.md` — new `/supersede` skill: 8-step workflow that reads old ADR, verifies active status, computes delta, fills template, links `supersedes`, marks predecessor superseded
- Extend `skills/decay-watch/SKILL.md` with Step 2e: enumerates all active artifacts with `supersedes` link, classifies as HAS-DELTA / MISSING-DELTA (pre-Z8 backward-compat warning) / NO-DELTA-WHEN-REQUIRED (Z8+ CONCERNS)
- Add «OpenSpec delta-spec discipline» section to `CLAUDE.md` (appended after BMAD adversarial review section)
- Bump `fpl-skills`: v1.27.0 → **v1.28.0**; catalog: v1.67.0 → **v1.68.0**

## Verification

- ML-11 grep counts: `adr-supersede.md` Delta-spec keywords = 7 (≥6 required) | `decay-watch` Step 2e count = 2 (≥1) | `CLAUDE.md` OpenSpec section = 1 (≥1)
- `./scripts/validate-all-plugins.sh` — **ALL PASSED** (69 agents, 0 errors, 0 warnings, 0 command collisions)
- Only Z8-owned files staged (agents-pro and forgeplan-workflow changes from parallel Z6 wave left unstaged)

## Test plan

- [x] `test -f plugins/fpl-skills/templates/adr-supersede.md` passes
- [x] `test -f plugins/fpl-skills/skills/supersede/SKILL.md` passes
- [x] `grep -c "Delta-spec\|ADDED\|MODIFIED\|REMOVED" plugins/fpl-skills/templates/adr-supersede.md` → 7
- [x] `grep -c "Step 2e\|supersede chain" plugins/fpl-skills/skills/decay-watch/SKILL.md` → 2
- [x] `grep -c "OpenSpec delta-spec discipline" CLAUDE.md` → 1
- [x] `./scripts/validate-all-plugins.sh` → ALL PASSED

Refs: PRD-058, EPIC-001 S12 OpenSpec