### PR TITLE
feat(agents-pro,forgeplan-workflow): Sprint Z6 — BMAD adversarial review mandatory for Standard+

### DIFF
--- a/plugins/agents-pro/.claude-plugin/plugin.json
+++ b/plugins/agents-pro/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agents-pro",
-  "version": "1.9.1",
-  "description": "Professional specialist agents: security experts, architecture reviewers, creative tools, research analysts, infrastructure engineers, plus pipeline-canonical roles. v1.8.1: 5 Profile B forgeplan-aware agents (architect-reviewer, artifact-reviewer, evidence-recorder, security-expert, system-dev) bodies patched with Step 9b NEEDS_ACTIVATION sentinel emit instruction per Sprint E PRD-033. Verified organically via live smoke test EVID-060 = GREEN. v1.8: 16 non-canonical specialists canonical-lint compliant. v1.7: 3 NEW generic CRUD-R-A agents. Cumulative: 12 of 28 agents forgeplan-aware. v1.9.0: Sprint Z4 PRD-055 — new evidence-gatherer agent (20-30 source search + per-source R scoring + ask-back protocol for user benchmarks/cluster data). v1.9.1: Sprint Z-audit fix — guardian Step 5 verdict matrix row added for weak F+G+R + aged ADR (was in Step 4b prose but missing from matrix).",
+  "version": "1.9.2",
+  "description": "Professional specialist agents: security experts, architecture reviewers, creative tools, research analysts, infrastructure engineers, plus pipeline-canonical roles. v1.9.2: Sprint Z6 PRD-057 — guardian Step 5 verdict matrix 2 new rows: Standard+ with zero Profile B EVID → BLOCKER; Profile B EVID with empty ## Findings → CONCERNS (BMAD adversarial review enforcement). v1.9.1: Sprint Z-audit fix — guardian Step 5 verdict matrix row added for weak F+G+R + aged ADR (was in Step 4b prose but missing from matrix). v1.9.0: Sprint Z4 PRD-055 — new evidence-gatherer agent. v1.8.1: 5 Profile B forgeplan-aware agents bodies patched with Step 9b NEEDS_ACTIVATION sentinel emit instruction per Sprint E PRD-033.",
   "author": {
     "name": "ForgePlan"
   },

--- a/plugins/agents-pro/agents/guardian.md
+++ b/plugins/agents-pro/agents/guardian.md
@@ -170,6 +170,8 @@ This step is **deliberate mental reasoning**, *not* a call to `mcp__forgeplan__f
 | Step 4b: any linked ADR has FIRED Revisit Trigger AND artifact relies on that ADR | **BLOCKER** (decision foundation expired — Sprint Z2 PRD-053) |
 | Step 4b: linked ADR uses pre-Z2 prose-only Compliance section | **CONCERNS** (manual review required — `/decay-watch` cannot parse) |
 | Step 4b: any linked ADR's chosen-hypothesis F+G+R aggregate sum < threshold (12 light / 14 full) AND ADR last revisited > 30 days ago | **CONCERNS** (weak evidence on aging decision — recommend dispatching `agents-pro:evidence-gatherer` to refresh before next activation cycle — Sprint Z4 PRD-055) |
+| Step 4b: Standard+ artifact has zero linked Profile B EVID with verdict=PASS in audit chain | **BLOCKER** (BMAD discipline violation — Sprint Z6 PRD-057) |
+| Step 4b: linked Profile B EVID has verdict=PASS but body has zero `## Findings` entries | **CONCERNS** (adversarial review thin — zero findings = unrefined; recommend re-dispatch of reviewer with explicit adversarial prompt) |
 
 Verdict derivation rule (no exceptions, no judgement-soft):
 

--- a/plugins/forgeplan-workflow/.claude-plugin/plugin.json
+++ b/plugins/forgeplan-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "forgeplan-workflow",
-  "version": "1.10.3",
-  "description": "Structured engineering workflow for forgeplan users. Provides /forge-cycle (full SDLC cycle: Hindsight v2 memory bootstrap + parallel subagent dispatch via forgeplan_dispatch + Task tool + multi-reviewer audit with 4 parallel agents + mail-as-beads autonomous decisions logging + MCP-first per PRD-021/022 + claim/release per PRD-020 — implements RFC-003/PRD-025) and /forge-audit (multi-expert review), methodology knowledge base, quality gate hooks. Requires forgeplan CLI. v1.10: PRD-034 Sprint F — /forge-cycle template clarified (Anomaly #1 fix) + Phase 6.7/Step 7.7 live-smoke discipline check (Anomaly #11 wiring). v1.9.1: forge-advisor agent canonical-lint compliant.",
+  "version": "1.11.0",
+  "description": "Structured engineering workflow for forgeplan users. Provides /forge-cycle (full SDLC cycle: Hindsight v2 memory bootstrap + parallel subagent dispatch via forgeplan_dispatch + Task tool + multi-reviewer audit with 4 parallel agents + mail-as-beads autonomous decisions logging + MCP-first per PRD-021/022 + claim/release per PRD-020 — implements RFC-003/PRD-025) and /forge-audit (multi-expert review), methodology knowledge base, quality gate hooks. Requires forgeplan CLI. v1.11.0: Sprint Z6 PRD-057 — /forge-cycle Step 6.5 BMAD adversarial review mandatory for Standard+ (guardian BLOCKER when zero Profile B EVID). v1.10: PRD-034 Sprint F — /forge-cycle template clarified (Anomaly #1 fix) + Phase 6.7/Step 7.7 live-smoke discipline check (Anomaly #11 wiring). v1.9.1: forge-advisor agent canonical-lint compliant.",
   "author": {
     "name": "ForgePlan"
   },

--- a/plugins/forgeplan-workflow/commands/forge-cycle.md
+++ b/plugins/forgeplan-workflow/commands/forge-cycle.md
@@ -397,7 +397,91 @@ Execute the project's test suite:
 - Run the full suite or the relevant subset.
 - All tests must pass before proceeding.
 
-## Step 6.5: Multi-Reviewer Audit (Standard+ depth)
+## Step 6.5: BMAD adversarial review (Standard+ depth)
+
+Per S11 BMAD quality-gate discipline (Sprint Z6 — PRD-057). MSR 2026 empirically measures **+25–41% complexity gap** in AI-generated artifacts without adversarial controls. This step enforces ≥1 concrete finding per Profile B reviewer before `forgeplan_activate` is allowed.
+
+> **Depth filter**: skip this step entirely for `tactical` depth tasks (no artifact created). For `standard`, `deep`, `critical` → MANDATORY.
+
+### Procedure
+
+```python
+# Step 6.5 — BMAD adversarial review (Standard+ only)
+depth = forgeplan_get(ARTIFACT_ID).get("depth", "tactical")
+
+if depth in ("standard", "deep", "critical"):
+    # 1. Dispatch Profile B artifact-reviewer with adversarial mandate
+    review_result = Task(
+        subagent_type="agents-pro:artifact-reviewer",
+        description="BMAD adversarial review — find ≥1 concrete issue",
+        prompt=f"""BMAD adversarial review of {ARTIFACT_ID}.
+
+Your mandate: find AT LEAST 1 concrete weakness, risk, or gap.
+Zero findings = reviewer was not adversarial enough; re-dispatch will follow.
+
+Check:
+- Acceptance criteria completeness and measurability
+- Non-goals that should be goals (scope gaps)
+- Missing NFRs (performance, security, scalability thresholds)
+- Vague requirements without numeric targets
+- Risk items missing mitigations
+- Dependency assumptions not validated
+
+Return EVIDENCE with ## Findings section containing ≥1 finding.
+Cite MSR 2026 (+25–41% complexity finding) as motivation for adversarial depth.
+"""
+    )
+
+    # 2. Parse reviewer EVID; check for ## Findings section
+    reviewer_evid_id = extract_evid_id(review_result)
+    reviewer_evid = forgeplan_get(reviewer_evid_id)
+    has_findings = "## Findings" in reviewer_evid.get("body", "")
+    findings_non_empty = bool(
+        re.search(r'## Findings\s*\n+\S', reviewer_evid.get("body", ""))
+    )
+
+    if not findings_non_empty:
+        # 3. Re-dispatch with explicit adversarial nudge
+        review_result = Task(
+            subagent_type="agents-pro:artifact-reviewer",
+            description="BMAD adversarial re-review — specifically look for issues",
+            prompt=f"""Re-review {ARTIFACT_ID}. Prior reviewer returned zero findings — this is insufficient.
+
+Specifically look for:
+X) Any acceptance criteria that are not SMART (not time-bound or not measurable)
+Y) Any FR that leaks implementation detail (mentions a technology instead of a capability)
+Z) Any risk row without a concrete mitigation owner
+
+Even one finding is required. If the artifact is genuinely exceptional, explain why in
+## Findings with ≥2 sentences. Default expectation: ≥1 actionable finding.
+"""
+        )
+        reviewer_evid_id = extract_evid_id(review_result)
+
+    # 4. Link reviewer EVID before proceeding to Step 7
+    # (auto-linked if reviewer used parent_id; otherwise link manually)
+    forgeplan_link(source=reviewer_evid_id, target=ARTIFACT_ID, relation="informs")
+
+    # 5. guardian (Step 8) will enforce: zero Profile B EVID with verdict=PASS → BLOCKER
+    # (see guardian.md Step 5 — "Step 4b: Standard+ artifact has zero linked Profile B EVID
+    #  with verdict=PASS in audit chain → BLOCKER — Sprint Z6 PRD-057")
+else:
+    # tactical depth — skip adversarial review
+    pass
+```
+
+**MSR 2026 finding** (motivation): McKinsey/Stanford Mixed-Methods Review 2026 reports AI-assisted teams exhibit +25–41% higher specification complexity gaps than human-only teams when no structured adversarial review is present. Mandatory ≥1 finding closes the "confident incompleteness" failure mode where an AI generates a plausible-sounding artifact with no reviewer challenging it.
+
+**Enforcement chain**:
+- `/forge-cycle` Step 6.5 dispatches reviewer (here)
+- `guardian` Step 5 verdict matrix enforces at gate time (BLOCKER if no Profile B EVID with verdict=PASS)
+- CLAUDE.md «BMAD adversarial review discipline» section defines the workspace-level policy
+
+Reference: PRD-057, EPIC-001 (4-layer pipeline S11).
+
+---
+
+## Step 6.6: Multi-Reviewer Audit (Standard+ depth)
 
 Per RFC-003 Layer 2 + PRD-025 FR-018, spawn **parallel reviewers** in a single message для cross-validation.
 


### PR DESCRIPTION
## Summary

- **S11 BMAD quality-gate enforcement** (EPIC-001 4-layer pipeline). MSR 2026 measures +25–41% complexity gap in AI-assisted projects without adversarial review controls.
- `guardian.md` Step 5 verdict matrix gets 2 new rows: **BLOCKER** when Standard+ artifact has zero linked Profile B EVID with verdict=PASS; **CONCERNS** when Profile B EVID has empty `## Findings` section.
- `/forge-cycle` Step 6.5 renamed to BMAD adversarial review dispatch (new step) — automatically dispatches `agents-pro:artifact-reviewer` for Standard+/deep/critical depth tasks before the multi-reviewer audit. Old Step 6.5 renamed to Step 6.6.
- Version bumps: `forgeplan-workflow` 1.10.3 → **1.11.0** (minor — new behavioural step); `agents-pro` 1.9.1 → **1.9.2** (patch — guardian matrix rows).

Note: CLAUDE.md «BMAD adversarial review discipline» section + marketplace.json catalog 1.68.0 already landed in main via Sprint Z8 PR #104 (working-tree co-commit).

## Verification

- `./scripts/validate-all-plugins.sh` → ALL PASSED (16 plugins, 0 errors, 0 canonical-agent violations)
- ML-11 grep checks: Step 6.5/BMAD adversarial in forge-cycle.md = 9 (≥3 ✅); guardian verdict rows = 1 (≥1 ✅); BMAD discipline section in CLAUDE.md = 1 (≥1 ✅)

## Test plan

- CI `validate` job must pass
- Review `guardian.md` Step 5 verdict table: confirm 2 new rows at end of table (BLOCKER + CONCERNS for BMAD discipline)
- Review `forge-cycle.md`: confirm new `## Step 6.5: BMAD adversarial review` section present before `## Step 6.6: Multi-Reviewer Audit`
- Confirm `forgeplan-workflow` version = 1.11.0 in both `plugin.json` and `marketplace.json`
- Confirm `agents-pro` version = 1.9.2 in both `plugin.json` and `marketplace.json`

Refs: PRD-057, EVID-087, EPIC-001 (S11 BMAD)