### PR TITLE
feat(agents-tdd): /tdd-init setup + immutable-SPEC/supersede discipline (v0.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
     "url": "https://github.com/ForgePlan"
   },
   "metadata": {
-    "description": "Official ForgePlan plugin marketplace for Claude Code — UX, frontend, workflow, and developer tools",
-    "version": "1.82.1"
+    "description": "Official ForgePlan plugin marketplace for Claude Code \u2014 UX, frontend, workflow, and developer tools",
+    "version": "1.82.2"
   },
   "plugins": [
     {
       "name": "fpl-hsmem",
       "source": "./plugins/fpl-hsmem",
-      "description": "ForgePlan Hindsight memory plugin for Claude Code. Long-term cross-session memory wrapping Hindsight (vectorize-io). Provides 13 MCP tools (memory_* + mental_model_* + document_ingest_*), 3 auto-hooks (recall on UserPromptSubmit, retain on Stop, force-retain on SessionEnd), and 5 helper skills (/status, /bootstrap, /mental-model, /diagnose, /export-bank). Three activation modes: plugin install (default-on, bank derived from cwd), per-project setup CLI (explicit `.mcp.json`), or direct MCP wire-up (standalone bundle). v2.1.0 — full documentation set (GETTING-STARTED, CONFIGURATION, USAGE, TROUBLESHOOTING, CHANGELOG) and source code colocation.",
+      "description": "ForgePlan Hindsight memory plugin for Claude Code. Long-term cross-session memory wrapping Hindsight (vectorize-io). Provides 13 MCP tools (memory_* + mental_model_* + document_ingest_*), 3 auto-hooks (recall on UserPromptSubmit, retain on Stop, force-retain on SessionEnd), and 5 helper skills (/status, /bootstrap, /mental-model, /diagnose, /export-bank). Three activation modes: plugin install (default-on, bank derived from cwd), per-project setup CLI (explicit `.mcp.json`), or direct MCP wire-up (standalone bundle). v2.1.0 \u2014 full documentation set (GETTING-STARTED, CONFIGURATION, USAGE, TROUBLESHOOTING, CHANGELOG) and source code colocation.",
       "version": "2.1.0",
       "author": {
         "name": "ForgePlan"
@@ -35,7 +35,7 @@
     {
       "name": "fpl-skills",
       "source": "./plugins/fpl-skills",
-      "description": "Flagship workflow plugin for the ForgePlan ecosystem. 34 engineering skills + dev-advisor agent + 5 hooks (+ smith greeting + RIPER auto-route + decay Layer 3). v1.41.1: smith routing-map adds a 'TDD-first feature' context row routing to the agents-tdd dispatch sequence (RFC-012/ADR-010). v1.40.0: RFC-011 FR-3 ground-truth verification clause (generator≠verifier) — AGENT-AUTHORING-GUIDE 'Profile B Step 4.5' canonical section + universal HARD RULE 8 (empty git diff on a claimed change = BLOCKER even with green tests; makes ML-13 enforceable), smith routing-map methodology card (applies to every Build/Audit row), worktree under-claim corrected (isolation works for standalone subagents + Workflow + AgentTeams teammates). Refs PROB-002/RFC-011/ADR-009. v1.38.1: cookbook §07 + §14.4 fix — final-e2e found forgeplan#353 (CLI rejects `/` in agent ID, MCP accepts). Workaround: dash-form agent IDs. v1.38.0: /forgeplan-cookbook skill (66 MCP + 82 CLI across 14 sections). v1.37.x: MCP safety + --help audit.",
+      "description": "Flagship workflow plugin for the ForgePlan ecosystem. 34 engineering skills + dev-advisor agent + 5 hooks (+ smith greeting + RIPER auto-route + decay Layer 3). v1.41.1: smith routing-map adds a 'TDD-first feature' context row routing to the agents-tdd dispatch sequence (RFC-012/ADR-010). v1.40.0: RFC-011 FR-3 ground-truth verification clause (generator\u2260verifier) \u2014 AGENT-AUTHORING-GUIDE 'Profile B Step 4.5' canonical section + universal HARD RULE 8 (empty git diff on a claimed change = BLOCKER even with green tests; makes ML-13 enforceable), smith routing-map methodology card (applies to every Build/Audit row), worktree under-claim corrected (isolation works for standalone subagents + Workflow + AgentTeams teammates). Refs PROB-002/RFC-011/ADR-009. v1.38.1: cookbook \u00a707 + \u00a714.4 fix \u2014 final-e2e found forgeplan#353 (CLI rejects `/` in agent ID, MCP accepts). Workaround: dash-form agent IDs. v1.38.0: /forgeplan-cookbook skill (66 MCP + 82 CLI across 14 sections). v1.37.x: MCP safety + --help audit.",
       "version": "1.41.1",
       "author": {
         "name": "ForgePlan"
@@ -59,7 +59,7 @@
     {
       "name": "fp-cookbook",
       "source": "./plugins/fp-cookbook",
-      "description": "Practical cookbook of forgeplan CLI recipes. v1.2.1: Sprint T PRD-046 — recipes updated to v0.32.1 patterns (EVID 2-step parent_id auto-link via #295, MCP unlink primary + CLI fallback per #286). v1.2.0: Sprint R polyglot section. v1.1.0: Sprint Q evals. v1.0.0: 26 recipes Sprint P.",
+      "description": "Practical cookbook of forgeplan CLI recipes. v1.2.1: Sprint T PRD-046 \u2014 recipes updated to v0.32.1 patterns (EVID 2-step parent_id auto-link via #295, MCP unlink primary + CLI fallback per #286). v1.2.0: Sprint R polyglot section. v1.1.0: Sprint Q evals. v1.0.0: 26 recipes Sprint P.",
       "version": "1.2.1",
       "author": {
         "name": "ForgePlan"
@@ -80,7 +80,7 @@
     {
       "name": "agentic-rag",
       "source": "./plugins/agentic-rag",
-      "description": "Methodology skill for writing skills in agentic RAG format — SKILL.md as router + sections/_index.md + content files (~30-50 LOC each). 6 sections (when-to-use, structure, description-craft, content-quality, templates, distribution). v1.1.0: Sprint Q PRD-042 — added evals/evals.json (5 substantive prompts per ASM §6) + refactored anti-patterns to good/bad pair structure per ASM §5 Layer 2 (15 new pair files in references/anti-patterns/). v1.0.0 PRD-014 Sprint O.",
+      "description": "Methodology skill for writing skills in agentic RAG format \u2014 SKILL.md as router + sections/_index.md + content files (~30-50 LOC each). 6 sections (when-to-use, structure, description-craft, content-quality, templates, distribution). v1.1.0: Sprint Q PRD-042 \u2014 added evals/evals.json (5 substantive prompts per ASM \u00a76) + refactored anti-patterns to good/bad pair structure per ASM \u00a75 Layer 2 (15 new pair files in references/anti-patterns/). v1.0.0 PRD-014 Sprint O.",
       "version": "1.1.0",
       "author": {
         "name": "ForgePlan"
@@ -121,7 +121,7 @@
     {
       "name": "forgeplan-workflow",
       "source": "./plugins/forgeplan-workflow",
-      "description": "Structured engineering workflow for forgeplan users. Provides /forge-cycle (full SDLC cycle) and /forge-audit. v1.12.0: Sprint Z7 PRD-059 — Step 4.5 FPF ADI mandatory for Standard+ (≥3 hypotheses; guardian BLOCKER when no ADI EVID). v1.11.0: Sprint Z6 PRD-057 — Step 6.5 BMAD adversarial review mandatory for Standard+ activation. v1.10.3: Sprint T PRD-046 — forgeplan_unlink MCP adopted.",
+      "description": "Structured engineering workflow for forgeplan users. Provides /forge-cycle (full SDLC cycle) and /forge-audit. v1.12.0: Sprint Z7 PRD-059 \u2014 Step 4.5 FPF ADI mandatory for Standard+ (\u22653 hypotheses; guardian BLOCKER when no ADI EVID). v1.11.0: Sprint Z6 PRD-057 \u2014 Step 6.5 BMAD adversarial review mandatory for Standard+ activation. v1.10.3: Sprint T PRD-046 \u2014 forgeplan_unlink MCP adopted.",
       "version": "1.12.0",
       "author": {
         "name": "ForgePlan"
@@ -142,7 +142,7 @@
     {
       "name": "dev-toolkit",
       "source": "./plugins/dev-toolkit",
-      "description": "[DEPRECATED — superseded by fpl-skills] Universal engineering toolkit: multi-expert audit, wave-based sprints, session context recall, card-based structured reports with auto-trigger hooks, and safety hooks. New users should install fpl-skills@ForgePlan-marketplace instead. v1.6.3: dev-advisor agent canonical-lint compliant (LR-1..LR-3).",
+      "description": "[DEPRECATED \u2014 superseded by fpl-skills] Universal engineering toolkit: multi-expert audit, wave-based sprints, session context recall, card-based structured reports with auto-trigger hooks, and safety hooks. New users should install fpl-skills@ForgePlan-marketplace instead. v1.6.3: dev-advisor agent canonical-lint compliant (LR-1..LR-3).",
       "version": "1.6.3",
       "deprecated": true,
       "supersededBy": "fpl-skills",
@@ -165,7 +165,7 @@
     {
       "name": "fpf",
       "source": "./plugins/fpf",
-      "description": "First Principles Framework (FPF) — thinking amplifier for structured reasoning, decomposition, and decision-making. Enhanced plugin with /fpf command, applied patterns, forgeplan integration, and FPF advisor agent. Based on FPF by Anatoly Levenchuk. v1.4.1: fpf-advisor agent canonical-lint compliant (LR-1..LR-3).",
+      "description": "First Principles Framework (FPF) \u2014 thinking amplifier for structured reasoning, decomposition, and decision-making. Enhanced plugin with /fpf command, applied patterns, forgeplan integration, and FPF advisor agent. Based on FPF by Anatoly Levenchuk. v1.4.1: fpf-advisor agent canonical-lint compliant (LR-1..LR-3).",
       "version": "1.4.1",
       "author": {
         "name": "ForgePlan"
@@ -205,7 +205,7 @@
     {
       "name": "forgeplan-brownfield-pack",
       "source": "./plugins/forgeplan-brownfield-pack",
-      "description": "Brownfield extraction pack: 12 extraction skills + 2 playbooks + 3 integrations + 5 mappings (c4, ddd, madr, obsidian, autoresearch) + templates + examples. Two-tier extraction (Factum vs Intent) with confidence taxonomy and ADI cycle. v1.4.0: Sprint V (PRD-048) — discover agent migrated from standalone to plugin (canonical Profile A pattern, MCP-first 7-phase procedure, 9 brownfield MCP primitives wired).",
+      "description": "Brownfield extraction pack: 12 extraction skills + 2 playbooks + 3 integrations + 5 mappings (c4, ddd, madr, obsidian, autoresearch) + templates + examples. Two-tier extraction (Factum vs Intent) with confidence taxonomy and ADI cycle. v1.4.0: Sprint V (PRD-048) \u2014 discover agent migrated from standalone to plugin (canonical Profile A pattern, MCP-first 7-phase procedure, 9 brownfield MCP primitives wired).",
       "version": "1.4.0",
       "author": {
         "name": "ForgePlan"
@@ -228,7 +228,7 @@
     {
       "name": "agents-core",
       "source": "./plugins/agents-core",
-      "description": "Core development agents: debugger, code reviewer, error detective, performance engineer, production validator, plus complete dev team (coder, planner, researcher, reviewer, tester, TDD). v1.4.1: coder body gains a 'TDD GREEN-phase discipline' section (RFC-012 FR-4) — when dispatched in a TDD GREEN phase, never Write/Edit test files; on a wrong test STOP and emit TEST_BUG; lint after each change. v1.3.2: Sprint Q PRD-042 — ASM-canon frontmatter added to 3 forgeplan-aware agents (skills preload, maxTurns; coder gets isolation:worktree as only writer; code-reviewer + tester get memory:project as learners). v1.3.1: Sprint E body patches.",
+      "description": "Core development agents: debugger, code reviewer, error detective, performance engineer, production validator, plus complete dev team (coder, planner, researcher, reviewer, tester, TDD). v1.4.1: coder body gains a 'TDD GREEN-phase discipline' section (RFC-012 FR-4) \u2014 when dispatched in a TDD GREEN phase, never Write/Edit test files; on a wrong test STOP and emit TEST_BUG; lint after each change. v1.3.2: Sprint Q PRD-042 \u2014 ASM-canon frontmatter added to 3 forgeplan-aware agents (skills preload, maxTurns; coder gets isolation:worktree as only writer; code-reviewer + tester get memory:project as learners). v1.3.1: Sprint E body patches.",
       "version": "1.4.1",
       "author": {
         "name": "ForgePlan"
@@ -250,7 +250,7 @@
     {
       "name": "agents-pro",
       "source": "./plugins/agents-pro",
-      "description": "Professional specialist agents: security experts, architecture reviewers, creative tools, research analysts, infrastructure engineers, plus pipeline-canonical roles. v1.11.0: EPIC-003 / Sprint AA — guardian Step 5 +2 rows: C4 CONCERNS (Sprint Z9 PRD-060 gate) + OpenSpec BLOCKER (Sprint Z8 PRD-058 activation gate). Closes G2+G4. v1.10.1: EPIC-002 niceties patch. v1.10.0: EPIC-002 PRD-062 — new `smith` master-orchestrator agent (Profile B-orchestrator).",
+      "description": "Professional specialist agents: security experts, architecture reviewers, creative tools, research analysts, infrastructure engineers, plus pipeline-canonical roles. v1.11.0: EPIC-003 / Sprint AA \u2014 guardian Step 5 +2 rows: C4 CONCERNS (Sprint Z9 PRD-060 gate) + OpenSpec BLOCKER (Sprint Z8 PRD-058 activation gate). Closes G2+G4. v1.10.1: EPIC-002 niceties patch. v1.10.0: EPIC-002 PRD-062 \u2014 new `smith` master-orchestrator agent (Profile B-orchestrator).",
       "version": "1.12.0",
       "author": {
         "name": "ForgePlan"
@@ -261,7 +261,7 @@
     {
       "name": "agents-github",
       "source": "./plugins/agents-github",
-      "description": "GitHub operations agents: PR management, issue tracking, release automation, multi-repo coordination, project boards, workflow engineering, and repo architecture. v1.1: 7 agents canonical-lint compliant (LR-1..LR-3) — sonnet model, hex colors, bilingual EN/RU/Triggers descriptions.",
+      "description": "GitHub operations agents: PR management, issue tracking, release automation, multi-repo coordination, project boards, workflow engineering, and repo architecture. v1.1: 7 agents canonical-lint compliant (LR-1..LR-3) \u2014 sonnet model, hex colors, bilingual EN/RU/Triggers descriptions.",
       "version": "1.1.0",
       "author": {
         "name": "ForgePlan"
@@ -272,7 +272,7 @@
     {
       "name": "agents-sparc",
       "source": "./plugins/agents-sparc",
-      "description": "SPARC development methodology: orchestrator with quality gates plus 4 phase specialists (specification, pseudocode, architecture, refinement). v1.2.2: refinement notes enforced-TDD delegation (RFC-012) — RED test-writing delegates to agents-tdd:coder-tdd and GREEN to agents-core:coder; refinement retains refactor-after-green. v1.2.1: Sprint Q PRD-042 — ASM-canon frontmatter added to 2 forgeplan-aware agents (specification + architecture get skills preload + maxTurns; architecture gets memory:project as learner). v1.2: ALL 5 agents canonical-lint compliant.",
+      "description": "SPARC development methodology: orchestrator with quality gates plus 4 phase specialists (specification, pseudocode, architecture, refinement). v1.2.2: refinement notes enforced-TDD delegation (RFC-012) \u2014 RED test-writing delegates to agents-tdd:coder-tdd and GREEN to agents-core:coder; refinement retains refactor-after-green. v1.2.1: Sprint Q PRD-042 \u2014 ASM-canon frontmatter added to 2 forgeplan-aware agents (specification + architecture get skills preload + maxTurns; architecture gets memory:project as learner). v1.2: ALL 5 agents canonical-lint compliant.",
       "version": "1.2.2",
       "author": {
         "name": "ForgePlan"
@@ -283,8 +283,8 @@
     {
       "name": "agents-tdd",
       "source": "./plugins/agents-tdd",
-      "description": "Enforced-TDD methodology: tdd-orchestrator master + RED/GREEN phase agents + fail-closed PreToolUse gate (first instance of the AD/AID-PDLC sub-cycle contract, ADR-010). Implements RFC-012: tdd-planner (scenarios→plan) + coder-tdd (plan→failing tests, RED) + tdd-test-validator (independent C4 verifier) + PreToolUse tdd-gate (permissionDecision:deny, exit2 fail-closed) + normalized full-file SPEC hash freeze (FR-6). GREEN reuses agents-core:coder.",
-      "version": "0.1.0",
+      "description": "Enforced-TDD methodology: tdd-orchestrator master + RED/GREEN phase agents + fail-closed PreToolUse gate (first instance of the AD/AID-PDLC sub-cycle contract, ADR-010). Implements RFC-012: tdd-planner (scenarios\u2192plan) + coder-tdd (plan\u2192failing tests, RED) + tdd-test-validator (independent C4 verifier) + PreToolUse tdd-gate (permissionDecision:deny, exit2 fail-closed) + normalized full-file SPEC hash freeze (FR-6). GREEN reuses agents-core:coder.",
+      "version": "0.2.0",
       "author": {
         "name": "ForgePlan"
       },
@@ -298,7 +298,10 @@
           "coder-tdd",
           "tdd-test-validator"
         ],
-        "skills": ["skills/tdd"],
+        "skills": [
+          "skills/tdd",
+          "skills/tdd-init"
+        ],
         "hooks": [
           "hooks/hooks.json"
         ]
@@ -307,7 +310,7 @@
     {
       "name": "cc-best",
       "source": "./plugins/cc-best",
-      "description": "Claude Code ecosystem reference — opinionated guide for CLAUDE.md, plugins, agents, hooks, MCP, and anti-patterns. Synthesises 47+ audit findings from ForgePlan marketplace work into a navigable agentic-RAG skill. Initial release ships the claude-md section (file structure, hierarchy, patterns, anti-patterns, examples); 5 more sections (plugins, agents, hooks, mcp, antipatterns) queued via RFC-005..RFC-009.",
+      "description": "Claude Code ecosystem reference \u2014 opinionated guide for CLAUDE.md, plugins, agents, hooks, MCP, and anti-patterns. Synthesises 47+ audit findings from ForgePlan marketplace work into a navigable agentic-RAG skill. Initial release ships the claude-md section (file structure, hierarchy, patterns, anti-patterns, examples); 5 more sections (plugins, agents, hooks, mcp, antipatterns) queued via RFC-005..RFC-009.",
       "version": "1.0.0",
       "author": {
         "name": "ForgePlan"

--- a/plugins/agents-tdd/.claude-plugin/plugin.json
+++ b/plugins/agents-tdd/.claude-plugin/plugin.json
@@ -1,14 +1,28 @@
 {
   "name": "agents-tdd",
-  "version": "0.1.0",
-  "description": "Enforced-TDD methodology: tdd-orchestrator master + RED/GREEN phase agents + fail-closed PreToolUse gate (first instance of the AD/AID-PDLC sub-cycle contract). Implements RFC-012 / ADR-010: tdd-planner (scenarios→plan) + coder-tdd (plan→failing tests, RED) + tdd-test-validator (independent C4 verifier) + PreToolUse tdd-gate (permissionDecision:deny, exit2 fail-closed) + normalized full-file SPEC hash freeze (FR-6).",
-  "author": {"name": "ForgePlan"},
+  "version": "0.2.0",
+  "description": "Enforced-TDD methodology: tdd-orchestrator master + RED/GREEN phase agents + fail-closed PreToolUse gate (first instance of the AD/AID-PDLC sub-cycle contract). Implements RFC-012 / ADR-010: tdd-planner (scenarios\u2192plan) + coder-tdd (plan\u2192failing tests, RED) + tdd-test-validator (independent C4 verifier) + PreToolUse tdd-gate (permissionDecision:deny, exit2 fail-closed) + normalized full-file SPEC hash freeze (FR-6).",
+  "author": {
+    "name": "ForgePlan"
+  },
   "homepage": "https://github.com/ForgePlan/marketplace",
   "repository": "https://github.com/ForgePlan/marketplace",
   "license": "MIT",
-  "keywords": ["agents", "tdd", "methodology", "enforced-tdd", "quality-gates", "adr-010", "rfc-012"],
+  "keywords": [
+    "agents",
+    "tdd",
+    "methodology",
+    "enforced-tdd",
+    "quality-gates",
+    "adr-010",
+    "rfc-012"
+  ],
   "category": "workflow",
-  "requires": {"cli": [], "mcp": [], "plugins": []},
+  "requires": {
+    "cli": [],
+    "mcp": [],
+    "plugins": []
+  },
   "supersedes": {},
   "components": {
     "commands": [],
@@ -18,7 +32,12 @@
       "coder-tdd",
       "tdd-test-validator"
     ],
-    "skills": ["skills/tdd"],
-    "hooks": ["hooks/hooks.json"]
+    "skills": [
+      "skills/tdd",
+      "skills/tdd-init"
+    ],
+    "hooks": [
+      "hooks/hooks.json"
+    ]
   }
 }

--- a/plugins/agents-tdd/hooks/tdd-gate.sh
+++ b/plugins/agents-tdd/hooks/tdd-gate.sh
@@ -225,7 +225,7 @@ case "$PHASE" in
             fi
 
             if [ "$LIVE_HASH" != "$FROZEN_HASH" ]; then
-              _deny "TDD phase tdd-green: SPEC oracle drift DETECTED. The SPEC '${SPEC_PATH}' has changed since the oracle was frozen at tdd-test-validator PASS. Frozen hash: ${FROZEN_HASH:0:12}… Live hash: ${LIVE_HASH:0:12}… Re-run tdd-test-validator to re-certify before continuing GREEN. (RFC-012 FR-6 / ADR-010 C5)"
+              _deny "TDD phase tdd-green: SPEC oracle drift DETECTED. The SPEC '${SPEC_PATH}' changed after the oracle was frozen at tdd-test-validator PASS (frozen ${FROZEN_HASH:0:12}… vs live ${LIVE_HASH:0:12}…). Do NOT edit the SPEC in place — that erases requirement history. The SPEC is immutable once frozen; if it genuinely must change, SUPERSEDE it with a delta-spec (ADDED/MODIFIED/REMOVED) via /supersede (S12 OpenSpec discipline), then restart the TDD cycle so a fresh oracle is frozen. If the change was accidental, restore the SPEC to its frozen content. (RFC-012 FR-6 / ADR-010 C5)"
             fi
           fi
           # spec_path set but file absent → allow (may be a forgeplan artifact

--- a/plugins/agents-tdd/scripts/tdd-lib.sh
+++ b/plugins/agents-tdd/scripts/tdd-lib.sh
@@ -520,3 +520,58 @@ normalized_spec_hash() {
   fi
   return 1
 }
+
+# ---------------------------------------------------------------------------
+# detect_stack — infer the test stack from repo markers (best-effort)
+# ---------------------------------------------------------------------------
+# Emits tab-separated fields on one line:
+#   language <TAB> test_command <TAB> test_file_glob <TAB> source_file_glob <TAB> red_confirm <TAB> lint_command
+# Detection is by on-disk marker files relative to the repo root. Returns 0 on
+# a confident match, 1 if nothing matched (caller should ask the user). Advisory:
+# /tdd-init shows the result for human review before writing it.
+detect_stack() {
+  local root="${1:-$(repo_root 2>/dev/null || pwd)}"
+  local lang tc tfg sfg rc lc
+  if [ -f "$root/pyproject.toml" ] || [ -f "$root/setup.py" ] || [ -f "$root/pytest.ini" ] || [ -f "$root/tox.ini" ]; then
+    lang=python; tc="pytest -q"; tfg="test_*.py|*_test.py|tests/*.py"; sfg="*.py"; rc="FAILED"; lc="ruff check ."
+  elif [ -f "$root/Cargo.toml" ]; then
+    lang=rust; tc="cargo test"; tfg="tests/*.rs|src/**/*test*.rs"; sfg="*.rs"; rc="test result: FAILED"; lc="cargo clippy"
+  elif [ -f "$root/go.mod" ]; then
+    lang=go; tc="go test ./..."; tfg="*_test.go"; sfg="*.go"; rc="--- FAIL:"; lc="go vet ./..."
+  elif [ -f "$root/package.json" ]; then
+    if grep -q '"vitest"' "$root/package.json" 2>/dev/null; then
+      lang=typescript; tc="vitest run"; rc="FAIL"
+    elif grep -q '"jest"' "$root/package.json" 2>/dev/null; then
+      lang=typescript; tc="jest --ci"; rc="✕"
+    else
+      lang=javascript; tc="npm test"; rc="FAIL"
+    fi
+    tfg="*.test.ts|*.test.js|*.spec.ts|*.spec.js|*.test.tsx"; sfg="*.ts|*.tsx|*.js|*.jsx"; lc="eslint ."
+  elif [ -f "$root/composer.json" ]; then
+    lang=php; tc="vendor/bin/phpunit"; tfg="*Test.php|tests/*.php"; sfg="*.php"; rc="FAILURES!"; lc="vendor/bin/phpcs"
+  elif [ -f "$root/Gemfile" ]; then
+    lang=ruby; tc="bundle exec rspec"; tfg="*_spec.rb|spec/*.rb"; sfg="*.rb"; rc="failures"; lc="rubocop"
+  elif [ -f "$root/pom.xml" ]; then
+    lang=java; tc="mvn -q test"; tfg="*Test.java|*Tests.java"; sfg="*.java"; rc="Failures:"; lc=""
+  else
+    return 1
+  fi
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$lang" "$tc" "$tfg" "$sfg" "$rc" "$lc"
+  return 0
+}
+
+# write_stack_json — render stack.json from six fields into $FORGEPLAN_TDD_DIR.
+# Usage: write_stack_json LANG TEST_CMD TEST_GLOB SOURCE_GLOB RED_CONFIRM LINT_CMD
+# Writes <repo_root>/$FORGEPLAN_TDD_DIR/stack.json (creates the dir). Requires jq.
+write_stack_json() {
+  local lang="$1" tc="$2" tfg="$3" sfg="$4" rc="$5" lc="$6"
+  local dir; dir="$(tdd_dir 2>/dev/null)" || return 1
+  mkdir -p "$dir" || return 1
+  jq -n \
+    --arg language "$lang" --arg test_command "$tc" \
+    --arg test_file_glob "$tfg" --arg source_file_glob "$sfg" \
+    --arg red_confirm "$rc" --arg lint_command "$lc" \
+    '{language:$language, test_command:$test_command, test_file_glob:$test_file_glob, source_file_glob:$source_file_glob, red_confirm:$red_confirm, lint_command:$lint_command}' \
+    > "$dir/stack.json" || return 1
+  echo "$dir/stack.json"
+}

--- a/plugins/agents-tdd/skills/tdd-init/SKILL.md
+++ b/plugins/agents-tdd/skills/tdd-init/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: tdd-init
+description: |
+  One-time per-project setup for the enforced-TDD methodology — generates the `.forgeplan/tdd/stack.json`
+  language binding that the `tdd-gate.sh` hook reads (test command, test/source file globs, the
+  assertion-failure marker, lint command). Without it the gate cannot classify files and the TDD cycle
+  cannot start. Auto-detects the stack from repo markers (pyproject/go.mod/Cargo.toml/package.json/
+  composer.json/Gemfile/pom.xml), optionally reconciles with a stack-ADR if one exists, shows the result
+  for human review, then writes it.
+  EN: Run once before the first `/tdd` cycle on a project. Detects the test stack and writes
+  `.forgeplan/tdd/stack.json`. Re-run to update after a stack change.
+  RU: Запусти один раз перед первым циклом `/tdd` на проекте. Определяет тест-стек и пишет
+  `.forgeplan/tdd/stack.json`. Перезапусти, чтобы обновить после смены стека.
+  Triggers: "tdd init", "/tdd-init", "set up tdd", "tdd setup", "generate stack.json", "configure tdd",
+  "заведи tdd", "настрой tdd", "stack.json для tdd"
+---
+
+# /tdd-init — set up the TDD language binding for this project
+
+`/tdd` cannot run until `.forgeplan/tdd/stack.json` exists — it is the config the `tdd-gate.sh` hook
+reads to know **how to run tests** and **what counts as a test file vs a source file**. This skill
+creates it. Run it **once per project** (re-run to update after a stack change).
+
+## Why this is required
+
+The gate is dormant with no `stack.json` (it cannot classify files, so it allows everything — no
+enforcement). `stack.json` is the per-project binding that turns the generic, language-neutral
+methodology into a concrete enforced cycle. It is the derived cache the hook reads on every write —
+fast, no MCP call (hooks cannot call MCP).
+
+## Procedure
+
+### Step 1 — auto-detect the stack
+
+Source the lib and run the detector against the repo root:
+
+```bash
+. "${CLAUDE_PLUGIN_ROOT}/scripts/tdd-lib.sh"   # or plugins/agents-tdd/scripts/tdd-lib.sh
+detect_stack            # emits: language <TAB> test_command <TAB> test_file_glob <TAB> source_file_glob <TAB> red_confirm <TAB> lint_command
+```
+
+`detect_stack` recognises: Python (pyproject/setup.py/pytest.ini/tox.ini → `pytest -q`), Rust
+(`Cargo.toml` → `cargo test`), Go (`go.mod` → `go test ./...`), TypeScript/JS (`package.json` →
+vitest/jest/npm), PHP (`composer.json` → phpunit), Ruby (`Gemfile` → rspec), Java (`pom.xml` → mvn).
+
+- **Exit 0** → a confident match; carry its six fields to Step 3.
+- **Exit 1** → nothing matched (polyglot repo, or an unusual setup). Go to Step 2.
+
+### Step 2 — reconcile / fill (only if detection was uncertain or the user wants overrides)
+
+- If a **stack-ADR** exists in the graph (a `kind=adr` titled like "Stack: …"), read it via `forgeplan_get`
+  and prefer its declared `test_command` / globs over the auto-detected guess — the ADR is the source of
+  truth; `stack.json` is its derived cache.
+- If detection returned exit 1 and there is no stack-ADR, **ask the user** for: the test command, the
+  test-file glob, the source-file glob, the assertion-failure marker (`red_confirm` — the string that
+  appears in the runner's output on a real assertion failure, e.g. pytest `FAILED`, go `--- FAIL:`,
+  cargo `test result: FAILED`), and the lint command. Do not guess silently — a wrong `red_confirm`
+  makes the "valid RED" check unreliable.
+
+### Step 3 — show the result for review, then write
+
+Present the six fields to the user as a small table and confirm before writing. On confirmation:
+
+```bash
+write_stack_json "<language>" "<test_command>" "<test_file_glob>" "<source_file_glob>" "<red_confirm>" "<lint_command>"
+# writes <repo_root>/.forgeplan/tdd/stack.json and echoes the path
+```
+
+Then show the final `stack.json` and tell the user TDD is ready: "Run `/tdd` (or route a TDD-first
+feature through smith) to start the first cycle on an active PRD+SPEC."
+
+## `stack.json` shape
+
+```json
+{
+  "language": "python",
+  "test_command": "pytest -q",
+  "test_file_glob": "test_*.py|*_test.py|tests/*.py",
+  "source_file_glob": "*.py",
+  "red_confirm": "FAILED",
+  "lint_command": "ruff check ."
+}
+```
+
+- `test_file_glob` / `source_file_glob` — pipe-delimited globs; a pattern with `/` matches the full
+  relative path, without `/` matches the basename. The gate's `classify_file` uses these; test patterns
+  win over source when both could match.
+- `red_confirm` — the marker the orchestrator looks for to confirm a **valid RED** (an assertion
+  failure, not a compile/collection error).
+
+## HARD RULES
+
+1. **Do not hand-author `stack.json` blindly** — run `detect_stack` first; only fall back to asking the
+   user when detection is uncertain. A wrong glob silently breaks file classification (the gate's #1 job).
+2. **The stack-ADR (if present) is the source of truth; `stack.json` is its cache.** When both exist and
+   disagree, prefer the ADR and note the drift.
+3. **Re-run after a stack change** (e.g. migrating jest → vitest). A stale `stack.json` runs the wrong
+   test command.
+4. **This skill does not start a cycle** — it only writes config. The first `/tdd` run does the rest.
+
+## Related
+
+- `/tdd` — the cycle this config enables.
+- `scripts/tdd-lib.sh` — `detect_stack` + `write_stack_json`.
+- `hooks/tdd-gate.sh` — the consumer of `stack.json`.
+- RFC-012 (FR-2/FR-5 config-derived test command), ADR-010 (C5 enforcement reads this binding).

--- a/plugins/agents-tdd/skills/tdd/SKILL.md
+++ b/plugins/agents-tdd/skills/tdd/SKILL.md
@@ -153,6 +153,30 @@ sufficient). Activation follows ADR-006: the orchestrator emits the activation s
 
 ---
 
+## The SPEC is immutable once frozen (supersede, never edit in place)
+
+The frozen oracle is not just "don't touch the tests" — the **SPEC itself is append-only**. Once
+`tdd-test-validator` PASSes and the orchestrator stamps `spec_hash`, the SPEC must not be edited in
+place. Editing it mid-cycle erases requirement history and silently moves the target the tests were
+certified against — the gate detects this as oracle drift and BLOCKS.
+
+If a requirement genuinely must change:
+
+1. **Do NOT overwrite the SPEC.** Write a **delta-spec** — an explicit diff with `## ADDED Requirements`,
+   `## MODIFIED Requirements` (BEFORE/AFTER), `## REMOVED Requirements`. This is `git diff` for
+   requirements: six months later `git log` over the deltas explains *why* a requirement changed,
+   with its date and context.
+2. **Supersede** the SPEC via `/supersede` (S12 OpenSpec discipline — `adr-supersede` template).
+   The predecessor is marked `superseded`; the new SPEC carries the delta.
+3. **Restart the TDD cycle** on the new SPEC so a fresh oracle is frozen against the new requirements.
+
+The frozen `spec_hash` is the same idea as evidence decay: it pins "these tests were certified against
+*this* requirement state". When requirements move, the old oracle is stale — you reaffirm-or-supersede,
+you do not patch. Dependent SPECs (the DAG recorded in `## Related` / Triggers) should be reviewed when
+a SPEC supersedes — a change here may force a delta in a search/migration/API SPEC downstream.
+
+---
+
 ## Phase model (micro-states inside Build)
 
 State lives per-branch in `.forgeplan/tdd/state-<branch-slug>.json` (resolved via the git repo root;


### PR DESCRIPTION
## Summary
Follow-up to #132 — closes the two real gaps from the first ship + a teaching-correct gate fix.

- **`/tdd-init` setup** — `detect_stack` + `write_stack_json` in `tdd-lib.sh` auto-detect the test stack (python/rust/go/ts/php/ruby/java) and write `.forgeplan/tdd/stack.json`. Without it the gate was dormant on a fresh project (no config to read) — this was the blocker for first real use.
- **SPEC is immutable once frozen** — `tdd-gate.sh` drift message + `/tdd` skill now route to **supersede-via-delta-spec** (S12 OpenSpec / `/supersede`), not edit-in-place/re-certify. Editing a frozen SPEC erases requirement history — exactly what we must prevent.
- v0.2.0 (new skill = minor); catalog 1.82.2.

## Verification
- ✅ `./scripts/validate-all-plugins.sh` — ALL PASSED.
- ✅ `detect_stack` verified on 4 synthetic stacks + empty-repo fallback (exit 1 → ask user).
- ✅ **Dogfooded end-to-end** on a real python/pytest project against SPEC-001 semver scenarios: RED (real pytest `FAILED`, matches `red_confirm`) → freeze → GREEN (3 passed) → gate blocks test edits + oracle drift → drift message points to supersede. First honest run of the methodology.
- ✅ Version consistency (plugin.json == marketplace.json), leak-clean, bash syntax OK.

## Test plan
- ✅ Full marketplace validation green locally.
- ✅ Gate cycle on real runner (not simulation).
- ⬜ CI `validate` (runs on PR).

Refs: RFC-012 (FR-2/FR-5/FR-6), ADR-010 (C5), EVID-137, EVID-138

🤖 Generated with [Claude Code](https://claude.com/claude-code)
