### PR TITLE
docs(c4): ADR-014 cross-CLI tiered-adapter C4 diagrams

### DIFF
--- a/docs/c4/ADR-014.md
+++ b/docs/c4/ADR-014.md
@@ -1,0 +1,107 @@
+# C4 — ADR-014: Multi-CLI adapter layer (tiered)
+
+> Co-located C4 projection extracted from ADR-014 (PRD-060 Rule 4 / PRE-3).
+> ADR-014 is the source of truth; this file is the standalone C4 view the
+> Guardian gate expects when inter-module flow is discussed.
+
+The decision spans three modules — the marketplace canonical source, the
+tiered emit generator, and each target CLI runtime — plus an upstream
+boundary (the `forgeplan mcp-manifest` generator lives in forgeplan CORE,
+not this repo). The two diagrams below frame the Decision and Scope.
+
+## C4 L1 — System Context
+
+Who/what the adapter layer sits between.
+
+```mermaid
+graph TB
+    maintainer["Maintainer<br/>(authors plugins + targets[])"]
+    ccUser["Claude Code user<br/>(today's audience)"]
+    altUser["Non-CC CLI user<br/>(Gemini / Codex / Cursor / OpenCode / Goose / …)<br/>— DEMAND UNCONFIRMED"]
+
+    subgraph system["ForgePlan Marketplace (this system)"]
+        mp["Marketplace<br/>canonical Claude-Code surface<br/>(source of truth)"]
+        adapter["Tiered multi-CLI adapter layer<br/>(T0 universal base · T1 agent emit · T2 cmd/hook emit) — NEW"]
+    end
+
+    forgeplanMcp["forgeplan MCP server + CLI<br/>(~50 tools — already portable;<br/>hosts mcp-manifest generator — UPSTREAM)"]
+    targetCli["Target CLI runtimes<br/>(~10: Gemini / Codex / Cursor / OpenCode / Goose / Windsurf / Cline / Aider)"]
+
+    maintainer -->|authors| mp
+    mp -->|drives tiered per-CLI emit| adapter
+    adapter -->|T0: MCP config + skills + AGENTS.md| targetCli
+    adapter -.->|T1/T2: agents/cmds/hooks DEMAND-GATED| targetCli
+    ccUser -->|native| mp
+    altUser -->|consumes emitted config| targetCli
+    targetCli -->|connects via MCP| forgeplanMcp
+    mp -->|wraps| forgeplanMcp
+    adapter -->|invokes mcp-manifest| forgeplanMcp
+```
+
+## C4 L2 — Container
+
+The modules inside the boundary + the tiered emit pipeline.
+
+```mermaid
+graph LR
+    subgraph source["Module 1: Canonical source (Claude-Code surface)"]
+        skills[".claude/skills/*/SKILL.md"]
+        agents["agents/*.md (CC-specific)"]
+        commands["commands/*.md (CC-specific)"]
+        hooksC["hooks/*.json (CC-specific)"]
+        targetsMeta["plugin.json targets[]"]
+    end
+
+    subgraph gen["Module 2: Tiered adapter / emit generator (NEW)"]
+        t0["TIER 0 — universal base<br/>(~80% built): .agents/skills emit +<br/>mcp-manifest call + AGENTS.md marker-block"]
+        t1["TIER 1 — agent emit (the real adapter)<br/>per-CLI frontmatter transform + denylist→X"]
+        t2["TIER 2 — cmd+hook emit<br/>(demand-gated, lowest portability)"]
+    end
+
+    subgraph targets["Module 3: Target CLI configs (emitted, never hand-edited)"]
+        universal["T0 → 8 MCP-capable CLIs:<br/>MCP config + skills + AGENTS.md"]
+        threeAgents["T1 → Cursor / Codex / OpenCode ONLY"]
+        somecmds["T2 → Cursor/Gemini/Windsurf/OpenCode cmds;<br/>Goose hooks (zero-transform)"]
+    end
+
+    upstream[["forgeplan CORE (UPSTREAM)<br/>forgeplan mcp-manifest generator"]]
+
+    targetsMeta -->|declares intended CLIs| t0
+    skills --> t0
+    t0 -->|calls| upstream
+    t0 --> universal
+    agents --> t1
+    t1 --> threeAgents
+    commands -.demand-gated.-> t2
+    hooksC -.demand-gated.-> t2
+    t2 --> somecmds
+    agents -. NO TARGET: Windsurf/Cline/Goose/Aider .-> targets
+```
+
+## Module boundaries (narrative)
+
+- **Module 1 — Canonical source**: the 18 plugins' Claude-Code surface
+  (skills / agents / commands / hooks + `targets[]`). Single source of truth
+  (INV-1); never branched to suit a target CLI.
+- **Module 2 — Tiered emit generator (NEW)**: Tier 0 (universal base, ~80%
+  already built) → Tier 1 (agent emit, 3 CLIs) → Tier 2 (commands / hooks,
+  demand-gated). Adopts ECC's 5-layer pattern (manifest / profiles /
+  adapter-factory / surgical-merge / install-state).
+- **Module 3 — Emitted target configs**: generated per-CLI config, never
+  hand-edited (INV-2). Tier 0 → 8 MCP-capable CLIs; Tier 1 →
+  Cursor / Codex / OpenCode; Tier 2 → per-CLI commands + Goose hooks.
+- **Upstream boundary**: `forgeplan mcp-manifest` lives in forgeplan CORE,
+  not this marketplace repo (DD-3) — Tier 0 consumes it or documents per-CLI
+  `forgeplan mcp install` until it ships.
+
+The L2 view makes the tier split explicit: Tier 0 is portable to all 8
+MCP-capable CLIs and is ~80% already built; Tier 1 (agent emit) reaches
+exactly 3 CLIs via a per-CLI denylist→X transform; Tier 2 (commands + hooks)
+is the lowest-portability, demand-gated tail. Windsurf / Cline / Goose / Aider
+have no subagent-file model and receive no agents — a documented gap, not a bug.
+
+## Reference
+
+- **ADR-014** — source of these diagrams (the tiered multi-CLI decision).
+- **PRD-060 Rule 4** — co-located C4 requirement for ≥3-module decisions.
+- **NOTE-030** — the surface×CLI matrix and tiered (T0/T1/T2) design.


### PR DESCRIPTION
## Summary
- New `docs/c4/ADR-014.md` — co-located C4 L1 (system context) + L2 (container) for the cross-CLI tiered-adapter decision (ADR-014, now active).
- Satisfies ADR-014 PRE-3 (co-located C4 file) for the pre-activation gate, per PRD-060 Rule 4 (>=3-module decision needs a co-located C4 view).

## Verification
- Diagrams extracted from the ADR-014 body inline mermaid (the ADR is the source of truth); mermaid arrow syntax corrected so the file renders standalone.
- ADR-014 activated (draft -> active) this session with two linked EVID: EVID-174 (FPF ADI, PASS/High) + EVID-175 (architecture-fitness review, CONCERNS -> targets[] location fixed).
- docs-only change — outside the `validate` workflow path filter, so CI does not run (by design).

## Test plan
- [x] git status clean except the one new file
- [x] mermaid arrows render (dashed-with-label `-.->|x|`, dashed-edge `-. x .->`)
- [x] no /Users path leak, no editing-process meta

Refs: ADR-014, EVID-174, EVID-175

🤖 Generated with [Claude Code](https://claude.com/claude-code)