### PR TITLE
fix(agents-bmad): reconcile plugin.json version to 0.3.0

### DIFF
--- a/plugins/agents-bmad/.claude-plugin/plugin.json
+++ b/plugins/agents-bmad/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-bmad",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "v0.1.2: ADR-012 internal codename rendered hook-gate in shipped artifacts — bmad-orchestrator + bmad-gate.sh comment; terminology only, no behavior change. v0.1.1: bmad-orchestrator denylist adds forgeplan_validate - B-orchestrator parity (DEFER-015 / EVID-157 F1); now matches smith/sparc + the AGENT-AUTHORING-GUIDE canon. BMAD greenfield methodology: bmad-orchestrator master walks the persona arc (Analyst → PM → Architect → Scrum-Master → Dev → QA) with a blocking quality-gate at every handoff and a fail-closed no-code-before-plan PreToolUse gate (second instance of the AD/AID-PDLC sub-cycle contract). Implements RFC-013 / ADR-010: reuses existing forgeplan-aware personas (brief-intake/specification/adr-architect/architecture/goal-planner/coder/tester/code-reviewer/guardian/evidence-recorder) + a new bmad-orchestrator + /bmad + /bmad-init + bmad-gate (permissionDecision:deny, exit2 fail-closed) reading a per-branch phase state file.",
   "author": {
     "name": "ForgePlan"


### PR DESCRIPTION
## Summary
Close the agents-bmad manifest split surfaced by the doc-sync verification workflow: `marketplace.json` shipped 0.3.0 while `plugins/agents-bmad/.claude-plugin/plugin.json` still read 0.2.0 — a catalog bump that never reached the manifest. The catalog is the install source of truth and already carries the 0.3.0 changelog content, so the manifest moves up to 0.3.0.

One-line change. After it: catalog 0.3.0 == plugin.json 0.3.0 == CLAUDE.md table 0.3.0.

## Verification
- validate-all-plugins.sh agents-bmad -> ALL PASSED; JSON valid.
- Only reference to 0.2.0 inside plugins/agents-bmad/ was the manifest version line itself.

## Test plan
- [x] catalog / plugin.json / CLAUDE table all read 0.3.0
- [x] validator ALL PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)