### PR TITLE
fix(interop): publish the 34 skills that were unreachable outside Claude Code, and gate it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,9 +185,25 @@ For multi-CLI environments, `forgeplan mcp-manifest` is planned (Batch F deliver
 
 Plugins publish skills in two locations:
 - `plugins/<name>/skills/` — Claude Code path (existing)
-- `plugins/<name>/.agents/skills/` — interop alias (agentskills.io standard) — symlinks to the existing skills
+- `plugins/<name>/.agents/skills/` — interop alias (agentskills.io standard) — one symlink per skill, pointing at `../../skills/<name>`
 
-Any CLI with agentskills.io support loads skills from `.agents/skills/`.
+Any CLI with agentskills.io support loads skills from `.agents/skills/`. **Codex reads only
+that path**, and OpenCode reads it alongside its own — so a skill missing from it is
+invisible in those runtimes, with no error anywhere.
+
+That silence is why this is gated rather than trusted. When the gate was added the
+convention had drifted badly: five plugins had no interop directory at all, and the
+flagship plugin carried 22 aliases for 41 skills. 34 skills were unreachable and nothing
+was looking.
+
+| | |
+|---|---|
+| Add a skill, then run | `node scripts/gen-interop-skills.js` |
+| CI asserts it with | `interop-skills-check` (present, symlink, resolving, no stale entries) |
+
+The gate treats a **dangling** symlink as worse than a missing one: it reads as present to
+a human and as absent to the loader. A real directory where a symlink belongs is reported
+rather than replaced — it may hold edits that never reached `skills/`.
 
 ### Agent identity
 

--- a/plugins/agents-canvas/.agents/skills/canvas
+++ b/plugins/agents-canvas/.agents/skills/canvas
@@ -1,0 +1,1 @@
+../../skills/canvas

--- a/plugins/agents-canvas/.agents/skills/canvas-conventions
+++ b/plugins/agents-canvas/.agents/skills/canvas-conventions
@@ -1,0 +1,1 @@
+../../skills/canvas-conventions

--- a/plugins/agents-canvas/.agents/skills/canvas-design
+++ b/plugins/agents-canvas/.agents/skills/canvas-design
@@ -1,0 +1,1 @@
+../../skills/canvas-design

--- a/plugins/agents-canvas/.agents/skills/canvas-port
+++ b/plugins/agents-canvas/.agents/skills/canvas-port
@@ -1,0 +1,1 @@
+../../skills/canvas-port

--- a/plugins/agents-canvas/.agents/skills/canvas-storybook-test
+++ b/plugins/agents-canvas/.agents/skills/canvas-storybook-test
@@ -1,0 +1,1 @@
+../../skills/canvas-storybook-test

--- a/plugins/agents-canvas/.agents/skills/canvas-truth-map
+++ b/plugins/agents-canvas/.agents/skills/canvas-truth-map
@@ -1,0 +1,1 @@
+../../skills/canvas-truth-map

--- a/plugins/forgeplan-map-pack/.agents/skills/edge-verifier
+++ b/plugins/forgeplan-map-pack/.agents/skills/edge-verifier
@@ -1,0 +1,1 @@
+../../skills/edge-verifier

--- a/plugins/forgeplan-map-pack/.agents/skills/map-emitter
+++ b/plugins/forgeplan-map-pack/.agents/skills/map-emitter
@@ -1,0 +1,1 @@
+../../skills/map-emitter

--- a/plugins/forgeplan-map-pack/.agents/skills/zone-extractor
+++ b/plugins/forgeplan-map-pack/.agents/skills/zone-extractor
@@ -1,0 +1,1 @@
+../../skills/zone-extractor

--- a/plugins/fpl-skills/.agents/skills/agent-advisor
+++ b/plugins/fpl-skills/.agents/skills/agent-advisor
@@ -1,0 +1,1 @@
+../../skills/agent-advisor

--- a/plugins/fpl-skills/.agents/skills/agent-fetcher
+++ b/plugins/fpl-skills/.agents/skills/agent-fetcher
@@ -1,0 +1,1 @@
+../../skills/agent-fetcher

--- a/plugins/fpl-skills/.agents/skills/conformance-vectors
+++ b/plugins/fpl-skills/.agents/skills/conformance-vectors
@@ -1,0 +1,1 @@
+../../skills/conformance-vectors

--- a/plugins/fpl-skills/.agents/skills/decay-watch
+++ b/plugins/fpl-skills/.agents/skills/decay-watch
@@ -1,0 +1,1 @@
+../../skills/decay-watch

--- a/plugins/fpl-skills/.agents/skills/decision
+++ b/plugins/fpl-skills/.agents/skills/decision
@@ -1,0 +1,1 @@
+../../skills/decision

--- a/plugins/fpl-skills/.agents/skills/forge-cleanup
+++ b/plugins/fpl-skills/.agents/skills/forge-cleanup
@@ -1,0 +1,1 @@
+../../skills/forge-cleanup

--- a/plugins/fpl-skills/.agents/skills/forge-heal
+++ b/plugins/fpl-skills/.agents/skills/forge-heal
@@ -1,0 +1,1 @@
+../../skills/forge-heal

--- a/plugins/fpl-skills/.agents/skills/forge-insight
+++ b/plugins/fpl-skills/.agents/skills/forge-insight
@@ -1,0 +1,1 @@
+../../skills/forge-insight

--- a/plugins/fpl-skills/.agents/skills/forgeplan-cookbook
+++ b/plugins/fpl-skills/.agents/skills/forgeplan-cookbook
@@ -1,0 +1,1 @@
+../../skills/forgeplan-cookbook

--- a/plugins/fpl-skills/.agents/skills/methodology-check
+++ b/plugins/fpl-skills/.agents/skills/methodology-check
@@ -1,0 +1,1 @@
+../../skills/methodology-check

--- a/plugins/fpl-skills/.agents/skills/progress-dashboard
+++ b/plugins/fpl-skills/.agents/skills/progress-dashboard
@@ -1,0 +1,1 @@
+../../skills/progress-dashboard

--- a/plugins/fpl-skills/.agents/skills/project-agent-scaffold
+++ b/plugins/fpl-skills/.agents/skills/project-agent-scaffold
@@ -1,0 +1,1 @@
+../../skills/project-agent-scaffold

--- a/plugins/fpl-skills/.agents/skills/smith
+++ b/plugins/fpl-skills/.agents/skills/smith
@@ -1,0 +1,1 @@
+../../skills/smith

--- a/plugins/fpl-skills/.agents/skills/smith-bootstrap
+++ b/plugins/fpl-skills/.agents/skills/smith-bootstrap
@@ -1,0 +1,1 @@
+../../skills/smith-bootstrap

--- a/plugins/fpl-skills/.agents/skills/smith-plan
+++ b/plugins/fpl-skills/.agents/skills/smith-plan
@@ -1,0 +1,1 @@
+../../skills/smith-plan

--- a/plugins/fpl-skills/.agents/skills/smith-routing
+++ b/plugins/fpl-skills/.agents/skills/smith-routing
@@ -1,0 +1,1 @@
+../../skills/smith-routing

--- a/plugins/fpl-skills/.agents/skills/spec-author
+++ b/plugins/fpl-skills/.agents/skills/spec-author
@@ -1,0 +1,1 @@
+../../skills/spec-author

--- a/plugins/fpl-skills/.agents/skills/supersede
+++ b/plugins/fpl-skills/.agents/skills/supersede
@@ -1,0 +1,1 @@
+../../skills/supersede

--- a/plugins/slopocop-code/.agents/skills/code-slop
+++ b/plugins/slopocop-code/.agents/skills/code-slop
@@ -1,0 +1,1 @@
+../../skills/code-slop

--- a/plugins/slopocop-design/.agents/skills/design-taste-frontend
+++ b/plugins/slopocop-design/.agents/skills/design-taste-frontend
@@ -1,0 +1,1 @@
+../../skills/design-taste-frontend

--- a/plugins/slopocop-design/.agents/skills/frontend-design
+++ b/plugins/slopocop-design/.agents/skills/frontend-design
@@ -1,0 +1,1 @@
+../../skills/frontend-design

--- a/plugins/slopocop-design/.agents/skills/hallmark
+++ b/plugins/slopocop-design/.agents/skills/hallmark
@@ -1,0 +1,1 @@
+../../skills/hallmark

--- a/plugins/slopocop/.agents/skills/humanizer-ru
+++ b/plugins/slopocop/.agents/skills/humanizer-ru
@@ -1,0 +1,1 @@
+../../skills/humanizer-ru

--- a/plugins/slopocop/.agents/skills/slop-humanizer
+++ b/plugins/slopocop/.agents/skills/slop-humanizer
@@ -1,0 +1,1 @@
+../../skills/slop-humanizer

--- a/scripts/ci/interop-skills-check.js
+++ b/scripts/ci/interop-skills-check.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Assert every published skill is reachable through the .agents/skills interop path.
+ *
+ * WHY
+ * ---
+ * AGENTS.md states that plugins publish skills in two locations:
+ *
+ *   plugins/<name>/skills/           — Claude Code path
+ *   plugins/<name>/.agents/skills/   — interop alias (agentskills.io standard)
+ *
+ * That second path is not decoration. Codex reads ONLY `.agents/skills`; OpenCode reads it
+ * alongside its own. A skill missing from it is invisible in those runtimes, with no error
+ * anywhere — the same silent-absence failure class as the MCP tool-name prefixes.
+ *
+ * The convention was drifting when this gate was written: 5 plugins had no interop
+ * directory at all, and the flagship plugin had 22 aliases for 41 skills. 34 skills were
+ * unreachable. Nothing caught it, because nothing was looking.
+ *
+ * WHAT IT CHECKS
+ * --------------
+ *   1. Every plugin with a skills/ directory has .agents/skills/
+ *   2. Every skill in skills/ has an entry in .agents/skills/
+ *   3. Every entry is a SYMLINK (a copied directory silently forks on the next edit)
+ *   4. Every symlink RESOLVES (a dangling link is worse than a missing one — it reads as
+ *      present to a human and as absent to the loader)
+ *   5. No stale entries pointing at skills that no longer exist
+ *
+ * Read-only. The fixer is scripts/gen-interop-skills.js.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const PLUGINS = path.join(REPO_ROOT, 'plugins');
+const FIX = 'node scripts/gen-interop-skills.js';
+
+const problems = [];
+let pluginsChecked = 0;
+let linksChecked = 0;
+
+const dirsIn = (p) =>
+  fs.existsSync(p)
+    ? fs.readdirSync(p, { withFileTypes: true }).filter((e) => e.isDirectory() || e.isSymbolicLink())
+    : [];
+
+for (const plugin of fs.readdirSync(PLUGINS, { withFileTypes: true })) {
+  if (!plugin.isDirectory()) continue;
+
+  const pluginDir = path.join(PLUGINS, plugin.name);
+  const skillsDir = path.join(pluginDir, 'skills');
+  if (!fs.existsSync(skillsDir)) continue;
+
+  pluginsChecked++;
+  const interopDir = path.join(pluginDir, '.agents', 'skills');
+
+  const skills = dirsIn(skillsDir).map((e) => e.name).sort();
+
+  if (!fs.existsSync(interopDir)) {
+    problems.push(
+      `${plugin.name}: no .agents/skills/ at all — ${skills.length} skill(s) are invisible ` +
+      `to runtimes that read only the interop path`
+    );
+    continue;
+  }
+
+  const entries = new Set(fs.readdirSync(interopDir));
+
+  for (const skill of skills) {
+    linksChecked++;
+    const link = path.join(interopDir, skill);
+
+    if (!entries.has(skill)) {
+      problems.push(`${plugin.name}: skill "${skill}" has no .agents/skills alias`);
+      continue;
+    }
+    if (!fs.lstatSync(link).isSymbolicLink()) {
+      problems.push(
+        `${plugin.name}: .agents/skills/${skill} is a real directory, not a symlink — ` +
+        `it will silently fork from skills/${skill} on the next edit`
+      );
+      continue;
+    }
+    if (!fs.existsSync(link)) {
+      problems.push(
+        `${plugin.name}: .agents/skills/${skill} is a DANGLING symlink -> ` +
+        `${fs.readlinkSync(link)} (reads as present, resolves to nothing)`
+      );
+    }
+  }
+
+  // stale aliases: an entry with no corresponding skill
+  for (const entry of entries) {
+    if (!skills.includes(entry)) {
+      problems.push(
+        `${plugin.name}: .agents/skills/${entry} has no matching skills/${entry} — stale alias`
+      );
+    }
+  }
+}
+
+if (problems.length > 0) {
+  console.error(`interop-skills-check FAILED: ${problems.length} problem(s)\n`);
+  for (const p of problems) console.error(`  - ${p}`);
+  console.error(`\nFix: ${FIX}`);
+  process.exit(1);
+}
+
+console.log(
+  `Interop skills OK: ${pluginsChecked} plugins with skills, ${linksChecked} aliases — ` +
+  `all present, all symlinks, all resolving, none stale.`
+);

--- a/scripts/gen-interop-skills.js
+++ b/scripts/gen-interop-skills.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Create the .agents/skills interop aliases for every published skill.
+ *
+ * Companion fixer for scripts/ci/interop-skills-check.js. Run it after adding a skill,
+ * or after adding a plugin that has any.
+ *
+ *   node scripts/gen-interop-skills.js
+ *
+ * Codex reads ONLY `.agents/skills`; OpenCode reads it alongside its own path. A skill
+ * without an alias there is invisible in those runtimes and nothing reports it.
+ *
+ * Idempotent: existing correct symlinks are left alone. Dangling or wrong-target symlinks
+ * are repointed. A real directory where a symlink belongs is reported and NOT deleted —
+ * that case needs a human, because the directory may hold edits that were never in
+ * skills/.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const PLUGINS = path.join(REPO_ROOT, 'plugins');
+
+let created = 0;
+let repointed = 0;
+const blocked = [];
+
+for (const plugin of fs.readdirSync(PLUGINS, { withFileTypes: true })) {
+  if (!plugin.isDirectory()) continue;
+
+  const pluginDir = path.join(PLUGINS, plugin.name);
+  const skillsDir = path.join(pluginDir, 'skills');
+  if (!fs.existsSync(skillsDir)) continue;
+
+  const interopDir = path.join(pluginDir, '.agents', 'skills');
+  fs.mkdirSync(interopDir, { recursive: true });
+
+  for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+
+    const link = path.join(interopDir, entry.name);
+    const target = `../../skills/${entry.name}`;   // matches the form already in the tree
+
+    if (fs.existsSync(link) || fs.lstatSync(link, { throwIfNoEntry: false })) {
+      const st = fs.lstatSync(link, { throwIfNoEntry: false });
+      if (!st) { /* fall through to create */ }
+      else if (st.isSymbolicLink()) {
+        if (fs.readlinkSync(link) === target && fs.existsSync(link)) continue;  // already right
+        fs.unlinkSync(link);
+        fs.symlinkSync(target, link);
+        repointed++;
+        console.log(`  ~ repointed ${plugin.name}/.agents/skills/${entry.name}`);
+        continue;
+      } else {
+        blocked.push(
+          `${plugin.name}/.agents/skills/${entry.name} is a real directory, not a symlink — ` +
+          `left alone; it may contain edits that never reached skills/. Resolve by hand.`
+        );
+        continue;
+      }
+    }
+
+    fs.symlinkSync(target, link);
+    created++;
+    console.log(`  + ${plugin.name}/.agents/skills/${entry.name}`);
+  }
+}
+
+console.log(`\nCreated ${created}, repointed ${repointed}.`);
+if (blocked.length > 0) {
+  console.log(`\n${blocked.length} case(s) need a human:`);
+  for (const b of blocked) console.log(`  - ${b}`);
+  process.exit(1);
+}

--- a/scripts/validate-all-plugins.sh
+++ b/scripts/validate-all-plugins.sh
@@ -424,6 +424,7 @@ else
     run_gate "validate-workflow-security" node "$CI_DIR/validate-workflow-security.js"
     run_gate "validate-install-manifests" node "$CI_DIR/validate-install-manifests.js"
     run_gate "omp-catalog-check"         node "$CI_DIR/omp-catalog-check.js"
+    run_gate "interop-skills-check"      node "$CI_DIR/interop-skills-check.js"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Found while verifying #217 — **not filed by anyone**.

`AGENTS.md` states unconditionally that plugins publish skills in two places: `skills/` and `.agents/skills/`. **Codex reads only the second one**; OpenCode reads it alongside its own. A skill missing from it is invisible there, silently.

On disk the convention had drifted:

| | |
|---|---|
| Plugins with **no** `.agents/skills` | 5 — agents-canvas (6 skills), forgeplan-map-pack (3), slopocop (2), slopocop-code (1), slopocop-design (3) |
| `fpl-skills` | **22 aliases for 41 skills** — 19 more missing |
| **Total unreachable** | **34 skills** |

A quarter of the marketplace's skills were absent from the path its own root context file says they are published at.

Both halves are the same failure — a convention with nothing checking it. The five plugins with none are the newest; `fpl-skills` simply grew past its alias list.

## What shipped

- **33 aliases created**, in the same relative form (`../../skills/<name>`) the existing ones use
- **`scripts/gen-interop-skills.js`** — idempotent fixer
- **`scripts/ci/interop-skills-check.js`** — read-only gate, wired into `validate-all-plugins.sh`
- **AGENTS.md corrected** — it claimed this unconditionally while 34 skills were missing

## Gate design

Checks five things: directory exists, every skill has an entry, every entry is a **symlink**, every symlink **resolves**, and no stale entries remain.

Two deliberate choices:

**A dangling symlink is treated as worse than a missing one.** It reads as present to a human and as absent to the loader — exactly the silent-absence class this whole issue set is about.

**A real directory where a symlink belongs is reported, not replaced.** It may hold edits that never reached `skills/`; deleting it would destroy them. That case needs a human.

## Verification

- ✅ `./scripts/validate-all-plugins.sh` — **ALL PASSED**, new gate reports 19 plugins / 85 aliases
- ✅ **Negative-controlled twice**: removed an alias → `skill "ux-laws" has no .agents/skills alias`; replaced it with a dangling link → `DANGLING symlink -> ../../skills/does-not-exist (reads as present, resolves to nothing)`. Both exit 1 with the fix command named.
- ✅ Fixer restores the removed alias and is **idempotent** — second run reports `Created 0, repointed 0`

## Relationship to #217

This is the measurable half of #217's portability recipe. The issue proposes `.agents/skills` as the neutral discovery path; this makes the marketplace actually satisfy that for all 19 skill-bearing plugins, and stops it drifting again. The broader recipe — AGENTS.md guidance, command portability, the pointer-skill pattern — remains open.

> **Stacked.** Merge order: #220 → #221 → #222 → #223 → this.

Refs: #217, #219