### PR TITLE
fix(manifests): убрать components.hooks — ломает загрузку плагинов на Claude Code 2.1.257

### DIFF
--- a/plugins/dev-toolkit/.claude-plugin/plugin.json
+++ b/plugins/dev-toolkit/.claude-plugin/plugin.json
@@ -29,7 +29,6 @@
   "components": {
     "commands": ["audit", "sprint", "recall", "report"],
     "agents": ["dev-advisor"],
-    "skills": ["forge-report"],
-    "hooks": ["SessionStart", "PreToolUse:Bash", "PostToolUse:Write|Edit|MultiEdit", "PostToolUse:.*"]
+    "skills": ["forge-report"]
   }
 }

--- a/plugins/forgeplan-orchestra/.claude-plugin/plugin.json
+++ b/plugins/forgeplan-orchestra/.claude-plugin/plugin.json
@@ -31,7 +31,6 @@
   "components": {
     "commands": ["sync", "session"],
     "agents": ["orchestra-advisor"],
-    "skills": ["unified-workflow"],
-    "hooks": ["PostToolUse:Bash"]
+    "skills": ["unified-workflow"]
   }
 }

--- a/plugins/forgeplan-workflow/.claude-plugin/plugin.json
+++ b/plugins/forgeplan-workflow/.claude-plugin/plugin.json
@@ -32,7 +32,6 @@
   "components": {
     "commands": ["forge-cycle", "forge-audit"],
     "agents": ["forge-advisor"],
-    "skills": ["forgeplan-methodology"],
-    "hooks": ["PreToolUse:Bash", "PreToolUse:Write"]
+    "skills": ["forgeplan-methodology"]
   }
 }

--- a/plugins/fpl-skills/.claude-plugin/plugin.json
+++ b/plugins/fpl-skills/.claude-plugin/plugin.json
@@ -80,13 +80,6 @@
       "smith-bootstrap",
       "smith-plan",
       "smith-routing"
-    ],
-    "hooks": [
-      "SessionStart",
-      "PreToolUse:Bash",
-      "PostToolUse:Write|Edit|MultiEdit",
-      "PostToolUse:.*",
-      "UserPromptSubmit"
     ]
   }
 }

--- a/plugins/laws-of-ux/.claude-plugin/plugin.json
+++ b/plugins/laws-of-ux/.claude-plugin/plugin.json
@@ -27,7 +27,6 @@
   "components": {
     "commands": ["ux-review", "ux-law"],
     "agents": ["ux-reviewer"],
-    "skills": ["ux-laws"],
-    "hooks": ["PostToolUse:Write|Edit|MultiEdit"]
+    "skills": ["ux-laws"]
   }
 }

--- a/plugins/slopocop/.claude-plugin/plugin.json
+++ b/plugins/slopocop/.claude-plugin/plugin.json
@@ -28,7 +28,6 @@
   "components": {
     "commands": ["slop-audit", "slop-humanize"],
     "agents": ["slop-cop"],
-    "skills": ["humanizer-ru", "slop-humanizer"],
-    "hooks": ["PostToolUse:Write|Edit|MultiEdit"]
+    "skills": ["humanizer-ru", "slop-humanizer"]
   }
 }


### PR DESCRIPTION
Закрывает #242.

## Что

Убран ключ `hooks` из `components` у шести манифестов. `components` не входит в схему манифеста плагина Claude Code, а описательный список имён событий внутри него начиная с **Claude Code 2.1.257** отбраковывает манифест целиком — плагин не загружается вообще: ни скиллы, ни агенты, ни хуки.

## Почему это безопасно

Поле было чисто описательным — оно ничего не подключало. Реальные хуки берутся из `hooks/hooks.json` автоподхватом; файл на месте у всех шести плагинов, поведение не меняется:

| плагин | `hooks/hooks.json` |
|---|---|
| `dev-toolkit` | ✔ |
| `forgeplan-orchestra` | ✔ |
| `forgeplan-workflow` | ✔ |
| `fpl-skills` | ✔ |
| `laws-of-ux` | ✔ |
| `slopocop` | ✔ |

## Объём правки

Тронуты только манифесты, где `components.hooks` содержит имена событий — то есть ровно те, что ломаются. Остальные формы оставлены как есть, они валидатор не триггерят: пустой `[]` (`agents-core`, `agents-pro`, `fpf`, `cc-best`, `fp-cookbook`, `agentic-rag`, `forgeplan-brownfield-pack`), счётчики (`fpl-hsmem`), путь `["hooks/hooks.json"]` (`agents-bmad`, `agents-tdd`, `agents-canvas`, `forgeplan-map-pack`).

Правка текстовая, не через JSON round-trip — форматирование и порядок ключей сохранены байт-в-байт, диff минимальный. Каждый файл после правки проверен: валидный JSON, и разница с оригиналом ровно в удалённом ключе.

## Проверка

```
6 files changed, 5 insertions(+), 17 deletions(-)
```

Локально: после удаления ключа `/plugin` → Errors чист, `fpl-skills` отдаёт свои 40 скиллов и агента `dev-advisor`, хуки из `hooks/hooks.json` срабатывают.

## Что стоит решить отдельно

`components` целиком — мёртвое поле во всех 23 манифестах. Здесь оно не трогается: PR узкий, чинит регрессию. Если решите вычистить `components` полностью — отдельным PR, чтобы этот можно было залить быстро.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqBnXXhh1aiTn7UT3ve4iU
