### PR TITLE
feat(ci): гейт канона фаз — детектор для класса ошибок, породившего ADR-022

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -216,5 +216,6 @@ jobs:
           run_gate "omp-catalog-check"            node scripts/ci/omp-catalog-check.js
           run_gate "interop-skills-check"         node scripts/ci/interop-skills-check.js
           run_gate "frontmatter-check"            node scripts/ci/frontmatter-check.js
+          run_gate "phase-canon-check"           node scripts/ci/phase-canon-check.js
           run_gate "gate-parity-check"            node scripts/ci/gate-parity-check.js
           [ "$errors" -eq 0 ] || exit 1

--- a/docs/c4/ADR-022.md
+++ b/docs/c4/ADR-022.md
@@ -1,0 +1,186 @@
+# C4 — ADR-022: The three registers of the word "phase"
+
+> Co-located C4 projection extracted from ADR-022 (PRD-060 Rule 4).
+> ADR-022 is the source of truth; this file is the standalone C4 view the
+> Guardian gate expects when inter-module flow is discussed.
+
+The decision spans five modules — forgeplan core (binary + MCP surface), the
+`.forgeplan/` artifact graph, the two orchestrators that write the artifact
+phase marker, the repair/observability skills that read it and write it back,
+and a blocked downstream consumer that does not exist yet. The two diagrams below frame the
+Decision and Scope: one word, "phase", denotes three separate registers, and
+each gets its own normative source.
+
+## C4 L1 — System Context
+
+Who reads and who enforces each of the three registers.
+
+```mermaid
+graph TB
+    maintainer["Maintainer<br/>(reads the narrative, runs the cycle)"]
+    agent["Agent / orchestrator<br/>(/forge-cycle · /autorun)"]
+
+    subgraph system["ForgePlan — what the word phase denotes (this system)"]
+        r1["REGISTER 1 — Pipeline stages<br/>Brief → Shape → … → Activate → Wrap<br/>TWO CARRIERS: RFC-002 prose+table (human)<br/>+ project-agent-matrix.yaml (machine-readable,<br/>copied into each CANONIZED project —<br/>/fpl-init --canonize, opt-in, skip-if-exists)<br/>agree on the 11 NAMES, disagree on NUMBERING<br/>ordered list of names NORMATIVE · numbering NOT"]
+        r2["REGISTER 2 — Session phase machine<br/>idle → routing → shaping → coding → evidence → pr → idle<br/>source: forgeplan tool<br/>MACHINE-ENFORCED, monotonic per RFC-002 INV-4"]
+        r3["REGISTER 3 — Artifact lifecycle marker<br/>8 values: shape / validate / adi / code / test / audit / evidence / done<br/>source: forgeplan tool<br/>MACHINE-STORED but EXPLICITLY ADVISORY"]
+    end
+
+    tool["forgeplan tool — binary 0.34.0<br/>forgeplan_guard · forgeplan_phase · forgeplan_phase_advance<br/>forgeplan_validate · forgeplan_health"]
+    gatecheck["/gate-check + .forgeplan/quality-gates.yaml<br/>PLANNED — DOES NOT EXIST (marketplace#237)"]
+
+    maintainer -->|reads the work-cycle narrative| r1
+    agent -->|executes the cycle RFC-002 describes| r1
+    r1 -.->|binds via its Session-state column — PROSE binding, no code path| r2
+    agent -->|session guarded by| r2
+    agent -->|writes 4 of the 8 values| r3
+    r2 -->|owned and enforced by| tool
+    r3 -->|stored, read and written by| tool
+    r2 -.->|tool help verbatim: guards the SESSION machine,<br/>NOT the artifact lifecycle machine| r3
+    gatecheck -.->|cannot be built until it is settled<br/>WHICH register a gate gates| system
+```
+
+## C4 L2 — Container
+
+The five modules and the real read/write asymmetry on Register 3.
+
+```mermaid
+graph LR
+    subgraph core["Module 1: forgeplan core — binary 0.34.0 + MCP surface"]
+        guard["forgeplan_guard — MCP tool ONLY<br/>owns Register 2<br/>CLI forgeplan guard: unrecognized subcommand"]
+        phaseRead["forgeplan_phase<br/>READS Register 3"]
+        phaseWrite["forgeplan_phase_advance<br/>WRITES Register 3<br/>does NOT validate phase ordering"]
+        validateTool["forgeplan_validate<br/>writer class 3 — WRITES the value validate itself"]
+        health["forgeplan_health<br/>READS Register 3, emits phase_mismatch<br/>upstream anomaly forgeplan#332"]
+    end
+
+    subgraph graphmod["Module 2: the artifact graph .forgeplan/ + the shipped template"]
+        rfc["RFC-002 (active) — Register 1 carrier A (human)<br/>title claims 9 phases · prose lists 11 names<br/>table has 17 data rows (1..10 + 1.5/2.5/3.5/4.5/4.7/5.5/8.5)<br/>numbers Gate 5.5 · Wrap 10"]
+        matrix["project-agent-matrix.yaml — Register 1 carrier B<br/>plugins/fpl-skills/templates/ — MACHINE-READABLE<br/>11 keys, comments # Phase 1: .. # Phase 11:<br/>brief · shape · decompose · design · estimate · gate<br/>build · audit · evidence · activate · wrap<br/>numbers Gate 6 · Wrap 11"]
+        stateFile[(".forgeplan/state/&lt;id&gt;.yaml — Register 3 storage<br/>one file per artifact<br/>299 validate · 29 done · 1 shape · 2 with no file")]
+    end
+
+    subgraph orch["Module 3: Orchestrators — writer classes 1 and 2 of 4"]
+        cycle["/forge-cycle — forgeplan-workflow plugin<br/>writer class 1 — 4 call sites: shape · code · evidence · done"]
+        autorun["/autorun — fpl-skills plugin<br/>writer class 2 — same 4 values, CLI-only path"]
+    end
+
+    subgraph repair["Module 4: Repair + observability — readers that ACT, and writer class 4"]
+        heal["/forge-heal"]
+        cleanup["/forge-cleanup"]
+    end
+
+    scaffold["/fpl-init --canonize (step 8.5)<br/>cp template → .forgeplan/project-agent-matrix.yaml<br/>opt-in; skipped when the file already exists<br/>(/project-agent-scaffold only SUGGESTS overrides — never copies)"]
+    dead["adi · test · audit<br/>DEAD VALUES — zero call sites anywhere<br/>written by NOBODY"]
+    gatecheck["Module 5 — BLOCKED consumer<br/>/gate-check + .forgeplan/quality-gates.yaml<br/>DOES NOT EXIST YET (marketplace#237)"]
+
+    rfc -.->|Session-state column: prose-only binding| guard
+    matrix -.->|same 11 names, different numbering| rfc
+    scaffold -->|copies verbatim into each canonized project| matrix
+    cycle -->|session phase| guard
+    autorun -.->|defers entirely when forgeplan-workflow is installed| cycle
+    cycle -->|shape · code · evidence · done| phaseWrite
+    autorun -->|same 4 values| phaseWrite
+    phaseWrite -->|writes| stateFile
+    validateTool -->|writes validate — NOT via phase_advance| stateFile
+    stateFile -->|read| phaseRead
+    stateFile -->|read| health
+    health -->|phase_mismatch advisory| heal
+    health -->|phase_mismatch advisory| cleanup
+    heal -->|writer class 4 — repairs by calling| phaseWrite
+    cleanup -->|writer class 4 — repairs by calling| phaseWrite
+    dead -.->|no writer anywhere in the marketplace| stateFile
+    gatecheck -.->|blocked: which register does a gate gate| stateFile
+    gatecheck -.->|blocked: session phase or artifact phase| guard
+```
+
+## Module boundaries (narrative)
+
+- **Module 1 — forgeplan core (binary 0.34.0 + MCP surface)**: owns Registers 2
+  and 3. `forgeplan_guard` is an MCP tool only — `forgeplan guard` on the CLI
+  errors with "unrecognized subcommand". `forgeplan_phase` reads the artifact
+  marker, `forgeplan_phase_advance` writes it, `forgeplan_validate` writes the
+  `validate` value on its own, and `forgeplan_health` reads the marker and emits
+  `phase_mismatch`.
+- **Module 2 — the artifact graph `.forgeplan/` plus the shipped template**:
+  holds both Register 1 carriers and the Register 3 storage. Register 1 has
+  **two** carriers, not one. Carrier A is RFC-002 (active) — prose plus a table,
+  its `title:` claiming 9 phases while the body names 11 stages and the table
+  carries 17 data rows; its "Session state" column already binds Register 1 to
+  Register 2, but only in prose. Carrier B is
+  `plugins/fpl-skills/templates/project-agent-matrix.yaml`, which declares the
+  same 11 stage names as YAML keys under `phase_dispatch` with `# Phase 1:` ..
+  `# Phase 11:` comments — machine-readable, and copied verbatim into
+  `.forgeplan/project-agent-matrix.yaml` of each project canonized by
+  `/fpl-init --canonize` (step 8.5; opt-in, and skipped when the file already
+  exists). That copy reaches only the projects that opted in and had no prior
+  file, and on the reading this ADR adopts it is also permanent: `/fpl-init`
+  never overwrites an existing copy, so an error in the template freezes into
+  every already-canonized project and a re-run cannot repair it — only deleting
+  the file first can. Persistence, not reach, is the argument for fixing the
+  template first.
+  **This rests on an unresolved contradiction in the source** (DD-7, Open
+  questions): `fpl-init/SKILL.md:696` says the step still skips an existing
+  file, while `:417` says `--canonize` applies forced. The ADR adopts `:696`.
+  If `:417` turns out to be normative, a re-run *would* repair the copy and the
+  permanence argument weakens to an ordinary staleness one — the priority would
+  survive, its justification would not. The copy
+  lands in the target project's own tree and is read once per cycle by
+  `/forge-cycle` Step 0.5. (`/project-agent-scaffold` only
+  *suggests* an `overrides:` entry for an existing matrix; it never copies the
+  template.) The two carriers agree on the 11 **names** and
+  disagree on the **numbering**: RFC-002 gives Gate the half-number 5.5 and
+  numbers Wrap as 10, while `project-agent-matrix.yaml` numbers Gate as Phase 6
+  and Wrap as Phase 11. ADR-022 resolves this by declaring the ordered list of
+  11 names normative and the numbering non-normative. Register 3 lives one file
+  per artifact at `.forgeplan/state/<id>.yaml`.
+- **Module 3 — Orchestrators**: Register 3 has **four classes of writer**, of
+  which the orchestrators are the first two. (1) `/forge-cycle`
+  (forgeplan-workflow) — 4 `forgeplan_phase_advance` call sites emitting
+  `shape`, `code`, `evidence`, `done`. (2) `/autorun` (fpl-skills) — the same 4
+  values, but only on its CLI-only path (MCP call at `autorun/SKILL.md:451`,
+  shell fallback `forgeplan phase-advance --to code` at `:461`); it advances
+  nothing when forgeplan-workflow is installed and `/forge-cycle` drives the
+  artifact. (3) `forgeplan_validate` — writes the `validate` value itself, NOT
+  via `phase_advance`. (4) The repair skills — `/forge-heal` (SKILL.md:43, :92,
+  :131) and `/forge-cleanup` (SKILL.md:141, :154, :260) — both call
+  `forgeplan_phase_advance` as the AUTO-tier resolution of `phase_mismatch`.
+  Writer class 4 is precisely the one ADR-022's INV-3 constrains: it
+  auto-advances the marker to clear a health advisory, which is the bulk-backfill
+  behaviour the ADR forbids.
+- **Module 4 — Repair / observability**: `forgeplan_health` produces the
+  `phase_mismatch` advisory that `/forge-heal` and `/forge-cleanup` consume.
+  These are the only readers that act on Register 3 — and acting means writing
+  it back, which is writer class 4 above. Filed upstream as forgeplan#332.
+- **Module 5 — Blocked downstream consumer**: the `/gate-check` skill and
+  `.forgeplan/quality-gates.yaml` (marketplace#237) do not exist. They cannot be
+  built until it is settled which register a gate gates — the session machine or
+  the artifact marker.
+
+The L2 view makes the asymmetry explicit. Register 3 has 8 values but only 4 are
+ever emitted through `phase_advance` (`shape`, `code`, `evidence`, `done` — from
+`/forge-cycle`, from `/autorun` on its CLI-only path, and from the repair skills
+`/forge-heal` and `/forge-cleanup`); `validate` is written by
+`forgeplan_validate` itself rather than by `phase_advance`; and `adi`, `test`,
+`audit` have zero call sites anywhere in
+the marketplace — they are dead values with no writer. The on-disk distribution
+confirms it: 299 of 331 active artifacts sit at `validate`, 29 at `done`, 1 at
+`shape`, and 2 have no state file at all. The decisive separation between
+Registers 2 and 3 is the tool's own `forgeplan_guard` help text, which states
+verbatim that it guards the methodology session phase machine, NOT the artifact
+lifecycle phase machine (`shape/validate/adi/code/test/audit/evidence/done`).
+
+## Reference
+
+- **ADR-022** — source of these diagrams (the three-register separation).
+- **PRD-060 Rule 4** — co-located C4 requirement for ≥3-module decisions.
+- **RFC-002** (active) — Register 1 carrier A (human, prose + table); its phase
+  table binds Register 1 to Register 2 via the "Session state" column; INV-4
+  declares Register 2 monotonic.
+- **`plugins/fpl-skills/templates/project-agent-matrix.yaml`** — Register 1
+  carrier B (machine-readable); 11 `phase_dispatch` keys under `# Phase 1:` ..
+  `# Phase 11:`, copied into a project's `.forgeplan/` by `/fpl-init --canonize`
+  (step 8.5 — opt-in, skipped when the file already exists, and never
+  overwritten on a re-run) and read once per cycle by `/forge-cycle` Step 0.5.
+- **marketplace#237** — the blocked `/gate-check` + `quality-gates.yaml` consumer.
+- **forgeplan#332** — upstream anomaly for the `phase_mismatch` advisory loop.

--- a/plugins/cc-best/skills/cc-best/sections/claude-md/patterns.md
+++ b/plugins/cc-best/skills/cc-best/sections/claude-md/patterns.md
@@ -108,7 +108,7 @@ canonical frontmatter schema formalises skills:/maxTurns:/isolation: fields.
 
 | Artifact | Purpose |
 |---|---|
-| **PRD-024** (active) | Full SDLC Pipeline with Quality Gates — 9 phases, 9 kinds, 3 entrypoints |
+| **PRD-024** (active) | Full SDLC Pipeline with Quality Gates — 11 stages, 9 kinds, 3 entrypoints |
 | **ADR-005** (active, supersedes ADR-004) | Keep `/forge-cycle` and `/autorun` distinct |
 | **NOTE-004** (active) | Gas Town and Ruflo architectural patterns — what to adopt, what to reject |
 ```

--- a/plugins/fp-cookbook/skills/fp-cookbook/sections/recipes-workflow/route-shape-build-audit-activate.md
+++ b/plugins/fp-cookbook/skills/fp-cookbook/sections/recipes-workflow/route-shape-build-audit-activate.md
@@ -64,7 +64,7 @@ including NEEDS_ACTIVATION sentinel parsing (added Sprint D, PRD-032).
 
 ## Refs
 
-- PRD-024 (active) — Full SDLC Pipeline foundation (9 phases, 9 kinds)
+- PRD-024 (active) — Full SDLC Pipeline foundation (11 stages, 9 kinds)
 - PRD-032 (active) — NEEDS_ACTIVATION sentinel + /forge-cycle integration
 - RFC-002 (active) — Canonical pipeline architecture
 - `dogfood-inline-activate.md` — Stage 5 discipline detail

--- a/plugins/fpl-skills/skills/smith-bootstrap/README.md
+++ b/plugins/fpl-skills/skills/smith-bootstrap/README.md
@@ -82,7 +82,7 @@ User: новый проект, давай настраивай
 - **`/smith`** — parent default-mode skill; auto-delegates here for greenfield.
 - **`/smith-plan`** — once bootstrap completes, use this for the per-task Plan on the first PRD.
 - **`/smith-routing`** — if user wants to learn methodologies before bootstrapping.
-- **`/forge-cycle`** — the next step after bootstrap; activates the first PRD via the 9-phase pipeline.
+- **`/forge-cycle`** — the next step after bootstrap; activates the first PRD via the 11-stage pipeline.
 - **`forgeplan-brownfield-pack:discover`** — the brownfield counterpart (use this if pre-flight detects existing code).
 
 ## References

--- a/plugins/fpl-skills/skills/smith/README.md
+++ b/plugins/fpl-skills/skills/smith/README.md
@@ -140,7 +140,7 @@ Grouped by phase of the SDLC they cover. Every methodology has a one-page card i
 
 ## Related
 
-- **`/forge-cycle`** (in `forgeplan-workflow`) — reactive enforcer. Runs ONE task through the 9-phase pipeline. Smith picks WHICH task; `/forge-cycle` executes it.
+- **`/forge-cycle`** (in `forgeplan-workflow`) — reactive enforcer. Runs ONE task through the 11-stage pipeline. Smith picks WHICH task; `/forge-cycle` executes it.
 - **`/autorun`** (in `fpl-skills`) — autonomous long-running loop. On cold start, should dispatch `/smith` first to get a Plan, then walk the Plan task-by-task.
 - **`/forge-progress`** — real-time visibility into in-flight forgeplan work. Orthogonal to smith.
 - **`/methodology-check <ID>`** — pre-activation 4-layer coverage report (S10 FPF, S11 BMAD, S12 OpenSpec, S13 Forgeplan). Orthogonal to smith (smith routes; methodology-check audits one artifact).

--- a/plugins/fpl-skills/skills/smith/SKILL.md
+++ b/plugins/fpl-skills/skills/smith/SKILL.md
@@ -331,7 +331,7 @@ These rules are absolute. Violations are CONCERNS at the next Profile B review.
   - `/smith-routing` — educational walkthrough of the routing matrix.
 - **Related orchestration skills**:
   - `/forge-cycle` (in `forgeplan-workflow`) — reactive enforcer; runs ONE task through the
-    9-phase pipeline. Smith picks WHICH task; `/forge-cycle` executes it.
+    11-stage pipeline. Smith picks WHICH task; `/forge-cycle` executes it.
   - `/autorun` — autonomous long-running loop; on cold start, should dispatch `/smith` first to
     get a Plan, then walk the Plan task-by-task.
   - `/forge-progress` — real-time visibility into in-flight forgeplan work; orthogonal to smith.

--- a/scripts/ci/phase-canon-check.js
+++ b/scripts/ci/phase-canon-check.js
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Assert that every stated pipeline-stage count agrees with the machine-readable source.
+ *
+ * WHY
+ * ---
+ * ForgePlan calls three different things "phase", and conflating them produced a documented
+ * category error (ADR-022):
+ *
+ *   1. pipeline STAGE      brief · shape · decompose · design · estimate · gate ·
+ *                          build · audit · evidence · activate · wrap
+ *                          → carrier: templates/project-agent-matrix.yaml (machine-readable)
+ *   2. session PHASE       idle · routing · shaping · coding · evidence · pr
+ *   3. artifact MARKER     shape · validate · adi · code · test · audit · evidence · done
+ *
+ * RFC-002 was titled "9 phases" while its own prose named 11 stages and the matrix declared 11
+ * keys. Nobody noticed for months, because nothing compared the claim to the source — the same
+ * failure class as the agent counts before `catalog-check` learned to descend.
+ *
+ * The distinction itself is not new: `forgeplan-cookbook/sections/05-session-and-phase.md` has
+ * documented the two machines all along, citing upstream PROB-065. It lived in a reference doc
+ * while the normative artifact contradicted it. Prose does not hold a distinction — this does.
+ *
+ * WHAT IT CHECKS
+ * --------------
+ *   1. Every "<N> phases / stages / фаз / стадий" claim in shipped markdown matches the count
+ *      derived from `project-agent-matrix.yaml`
+ *   2. The three register vocabularies are not silently merged — a doc that lists the artifact
+ *      markers must not label them "stages", and vice versa
+ *
+ * WHAT THIS GATE DOES NOT COVER — stated, not hidden:
+ *
+ *  - **RFC-002 itself.** It lives in the PARENT workspace `.forgeplan/`, outside this git
+ *    repository, so CI cannot reach the one normative document that started this. Keeping it in
+ *    step is a Profile D job, tracked by ADR-022's Revisit Trigger — i.e. a human, again.
+ *  - **A Russian self-naming claim.** The second anchor matches the English noun `pipeline`; a
+ *    hypothetical `9-фазный конвейер` with no carrier named would slip. No live case exists, and
+ *    the anchor's safety was measured on English text, so widening it blind would trade a real
+ *    guarantee for a speculative one. The canon this ADR sets says «стадия конвейера» in Russian,
+ *    and that phrasing IS caught by the contextual anchor.
+ *  - **Semantics.** It compares a stated number to a derived one. A document can describe the
+ *    stages wrongly while stating the right count.
+ *
+ * The counting itself encodes the three-register model rather than just matching digits: 8 and 6
+ * are skipped deliberately, because they are the artifact-marker and session-phase vocabularies —
+ * correct as written, and conflating them is the very error this gate exists to prevent.
+ *
+ * Read-only. No --write: a tool that both asserts a number and rewrites it becomes a drift source
+ * when the two paths disagree.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const MATRIX = path.join(REPO_ROOT, 'plugins', 'fpl-skills', 'templates', 'project-agent-matrix.yaml');
+
+/** Keys in the matrix that are configuration, not pipeline stages. */
+const NON_STAGE_KEYS = new Set(['auto_approve', 'human_required', 'mental_models']);
+
+/**
+ * Files allowed to state a different number, because they are DESCRIBING the error rather than
+ * repeating it. Each needs a reason — an allowlist without reasons becomes a dumping ground.
+ */
+const DESCRIBES_THE_ERROR = new Map([
+  ['docs/c4/ADR-022.md', 'C4 for ADR-022 quotes the wrong title verbatim as the thing being fixed'],
+  ['docs/PROCESS-GAP-MAP-RU.md', 'the gap map records the pre-fix state as a dated snapshot'],
+]);
+
+/**
+ * "9 phases", "11 стадий" — but ONLY when the claim is about the forgeplan pipeline.
+ *
+ * The first version of this matched any "<N> phase" on any line mentioning the word "phase", and
+ * fired 96 times — of which exactly five were real. It flagged the Discover agent's 7-phase
+ * protocol, SPARC's five phases, TDD's three, CANVAS's stages: all different pipelines, all
+ * correctly stated. Worse, `(\d+)[\s-]+phase` matched artifact-id fragments — "PRD-026 Phase 4"
+ * became a claim of "026 phases".
+ *
+ * That is the same defect this repository documented in guardian's STRIDE row on the same day: a
+ * check that fires on two thirds of everything is not a gate, it is a tax, and reviewers learn to
+ * wave it through. Narrowed rather than exempted — an allowlist covering 90 false positives would
+ * be a confession, not a fix.
+ *
+ * `(?<![\w-])` keeps `PRD-026 Phase` and `#287 Phase` out: a digit run glued to an identifier is
+ * not a count.
+ */
+const CLAIM = /(?<![\w-])(\d{1,2})[\s-]+(phases?|stages?|фаз(?:ы|а)?|стади[йяи])\b/gi;
+
+/**
+ * The line must be talking about THIS pipeline. Other pipelines legitimately have other counts,
+ * and the canonical carriers are the only things that pin the number.
+ */
+const ABOUT_THIS_PIPELINE = /RFC-002|PRD-024|project-agent-matrix|canonical pipeline|канонич\w* конвейер/i;
+
+/**
+ * The bare noun `pipeline` right after the count is itself an anchor — and this was a real miss.
+ *
+ * Narrowing from 96 hits to 2 also swept out three live "9-phase pipeline" claims sitting in
+ * `plugins/`, because those lines never name RFC-002. The gate then reported clean while the exact
+ * error it exists to catch was still shipping — a false negative in the one place that matters,
+ * traded for the 94 false positives. Caught by the third reviewer, who was asked not to take the
+ * mechanism on trust.
+ *
+ * Safe to anchor on, verified over the whole tree: every other pipeline names its own thing —
+ * `7-phase protocol`, `7-phase discovery`, `6-phase debug`, `3 phase generator`, `2 stage-master`.
+ * Only the forgeplan pipeline is called `<N>-phase pipeline` with the noun unqualified.
+ */
+const PIPELINE_CLAIM = /(?<![\w-])(\d{1,2})[\s-]+(?:phase|stage)s?[\s-]+pipeline\b/gi;
+
+function stagesFromMatrix() {
+  if (!fs.existsSync(MATRIX)) return null;
+  const keys = fs
+    .readFileSync(MATRIX, 'utf8')
+    .split('\n')
+    .map((l) => /^ {2}([a-z_]+):\s*$/.exec(l))
+    .filter(Boolean)
+    .map((m) => m[1])
+    .filter((k) => !NON_STAGE_KEYS.has(k));
+  return keys;
+}
+
+function shippedMarkdown() {
+  const out = [];
+  const walk = (dir) => {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        if (e.name === 'node_modules' || e.name === '_archive' || e.name === 'fixtures') continue;
+        walk(p);
+      } else if (e.isFile() && e.name.endsWith('.md')) {
+        out.push(p);
+      }
+    }
+  };
+  for (const d of ['plugins', 'docs']) {
+    const full = path.join(REPO_ROOT, d);
+    if (fs.existsSync(full)) walk(full);
+  }
+  // CHANGELOG records history verbatim; its old numbers are the point.
+  return out.sort();
+}
+
+const stages = stagesFromMatrix();
+if (stages === null) {
+  console.error(
+    'phase-canon-check FAILED: the source of truth is missing at\n' +
+    `  ${path.relative(REPO_ROOT, MATRIX)}\n` +
+    'Without it no count can be derived, and a check that cannot derive its expected value must ' +
+    'fail rather than pass silently.',
+  );
+  process.exit(1);
+}
+
+const problems = [];
+let claimsChecked = 0;
+
+for (const file of shippedMarkdown()) {
+  const rel = path.relative(REPO_ROOT, file);
+  const exempt = DESCRIBES_THE_ERROR.get(rel);
+  const text = fs.readFileSync(file, 'utf8');
+
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Two ways a line can be about this pipeline: it names a canonical carrier, or it uses the
+    // bare phrase "<N>-phase pipeline", which nothing else in the tree does.
+    const anchored = ABOUT_THIS_PIPELINE.test(line);
+    PIPELINE_CLAIM.lastIndex = 0;
+    const selfNaming = PIPELINE_CLAIM.test(line);
+    if (!anchored && !selfNaming) continue;
+
+    const pattern = anchored ? CLAIM : PIPELINE_CLAIM;
+    pattern.lastIndex = 0;
+    let m;
+    while ((m = pattern.exec(line)) !== null) {
+      const n = Number(m[1]);
+      // 8 and 6 are the OTHER two registers — artifact markers and session phases. Correct as
+      // written, and conflating them is the very error this gate exists to prevent.
+      if (n === 8 || n === 6) continue;
+      claimsChecked++;
+      if (n === stages.length) continue;
+      if (exempt) continue;
+      problems.push(
+        `${rel}:${i + 1}: claims "${m[0]}" about the forgeplan pipeline, but the matrix declares ` +
+        `${stages.length} stages (${stages.join(', ')})`,
+      );
+    }
+  }
+}
+
+if (problems.length > 0) {
+  console.error(`phase-canon-check FAILED: ${problems.length} stale stage-count claim(s)\n`);
+  for (const p of problems) console.error(`  - ${p}`);
+  console.error(
+    `\nThe count is derived from ${path.relative(REPO_ROOT, MATRIX)}, which is the machine-readable\n` +
+    'carrier. If the pipeline really changed, change the matrix first and let the documents follow —\n' +
+    'never the other way round. If a file is quoting the historical error on purpose, add it to\n' +
+    'DESCRIBES_THE_ERROR with a reason.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Phase canon OK: ${stages.length} pipeline stages in the matrix, ${claimsChecked} count claim(s) ` +
+  `checked across shipped docs, all agreeing.`,
+);

--- a/scripts/validate-all-plugins.sh
+++ b/scripts/validate-all-plugins.sh
@@ -426,6 +426,7 @@ else
     run_gate "omp-catalog-check"         node "$CI_DIR/omp-catalog-check.js"
     run_gate "interop-skills-check"      node "$CI_DIR/interop-skills-check.js"
     run_gate "frontmatter-check"         node "$CI_DIR/frontmatter-check.js"
+    run_gate "phase-canon-check"      node "$CI_DIR/phase-canon-check.js"
     run_gate "gate-parity-check"         node "$CI_DIR/gate-parity-check.js"
 fi
 


### PR DESCRIPTION
Механизм удержания для **ADR-022** — решения, разводящего три регистра, которые в системе назывались одним словом «фаза».

Артефакты в графе: ADR-022, EVID-217 (ADI), EVID-218 / EVID-219 / EVID-220 / EVID-221 (четыре независимых ревью). Все в `draft` — активация ждёт `guardian`.

## Что было сломано

Слово «фаза» обозначало три разные вещи:

| Регистр | Значения | Носитель |
|---|---|---|
| **стадия конвейера** | `brief … wrap` — 11 | `templates/project-agent-matrix.yaml` (машинно-читаемо) |
| **фаза сессии** | `idle/routing/shaping/coding/evidence/pr` — 6 | инструмент |
| **маркер артефакта** | `shape/validate/adi/code/test/audit/evidence/done` — 8 | инструмент |

RFC-002 озаглавлен «9 phases», в тексте перечисляет 11, инструмент принимает 8 других. Наблюдаемое следствие — **336 из 368** state-файлов висят на маркере `validate`, и скиллы починки постоянно чинят это как `phase_mismatch`.

**Различение при этом не отсутствовало.** Оно описано в `forgeplan-cookbook/sections/05-session-and-phase.md` дословно, со ссылкой на PROB-065 — то есть жило в справочнике, пока нормативный документ противоречил ему заголовком. Прозой различение не удержать; поэтому гейт.

## Что делает гейт

Выводит число стадий из машинно-читаемого носителя и сверяет с каждым утверждением о числе в отгружаемых документах. Числа **8** и **6** пропускает намеренно — это два других регистра, названные верно, и их смешение с первым есть та самая ошибка, которую гейт предотвращает. То есть скрипт кодирует модель решения, а не просто считает цифры.

Пять утверждений «9 phases» исправлены на «11 stages».

## История детектора — она и есть содержание

| Итерация | Результат |
|---|---|
| 1. широкая | **96 срабатываний, 5 настоящих** — ловила `7-phase` brownfield, `5 phases` SPARC, `3 phase` TDD (другие конвейеры, названные верно) и `026 Phase` из `PRD-026 Phase 4` |
| 2. сужение по контексту | **поймано 2 из 5, потеряно 3** — «9-phase pipeline» лежит в сканируемом дереве, но не называет носитель |
| 3. второй якорь | **все 5** — голое существительное `pipeline` сразу после числа |

Итерация 2 — самое важное здесь. **Гейт сообщал «чисто», пока ошибка того самого класса, ради которого он существует, продолжала отгружаться.** Ложный пропуск ровно там, где он важен, обменянный на 94 ложных срабатывания.

Нашёл третий ревьюер, которому было поручено не принимать механизм на слово, а ломать его инъекциями.

Отдельно: неточность в отчёте и сам дефект были одним и тем же. Результат сначала описали как «96 → 2, обе настоящие» — это занижало истинные срабатывания и **тем самым прятало, что три пропадают**. Цифра «2» звучала как успех сужения, а была симптомом пропуска. Подтверждено по `git diff`: все пять файлов до правки действительно говорили «9 phases».

## Verification

**Негативный контроль в обе стороны**, воспроизведён независимо тремя участниками (инъекция во временный файл сканируемого дерева, затем откат):

| Сторона | Инъекция | Факт |
|---|---|---|
| ложный **пропуск** | `9-phase pipeline` без упоминания носителя | **exit 1** — ловит ту самую дыру |
| ложное **срабатывание** | `7-phase protocol`, `7-phase discovery`, `5 phases`, `3 phase generator`, `2 stage-master`, `6-phase debug`, `PRD-026 Phase 4`, `#287 Phase 2` | **exit 0** — ни одного |
| чистое дерево | — | **exit 0**, 7 утверждений сверено |

Безопасность якоря **измерена, а не предположена**: `<N>-phase pipeline` встречается 5 раз и все пять — этот конвейер; чужие всегда уточняют существительное (`7-phase MCP` ×14, `2 stage-master` ×12, `6-phase debug` ×7).

`./scripts/validate-all-plugins.sh` → **ALL PASSED**, 11 гейтов. `gate-parity-check` подтверждает подключение в оба списка.

## Что гейт НЕ покрывает — выписано в шапке

- **сам RFC-002** — лежит в родительском воркспейсе выше git-корня, CI недостижим. Страховка снова человек, но по событийному Revisit Trigger, а не по памяти.
- **русское самоназвание** — второй якорь англоязычный. Живых случаев нет; расширять регекс вслепую значило бы обменять доказанную гарантию на предполагаемую, потому что замер сделан на английском тексте.
- **смысл** — сверяется число, не содержание.

## Test plan

- [x] Негативный контроль в обе стороны, три независимых прогона
- [x] Безопасность якоря измерена по всему дереву
- [x] `validate-all-plugins.sh` — ALL PASSED, парность подтверждена
- [x] Четыре ревью: CONCERNS → CONCERNS → CONCERNS → **PASS** (EVID-221)
- [ ] `guardian` — не пройден, сессия агентов упёрлась в лимит; **артефакты остаются в `draft`**

## Чего этот PR не делает

- **Не активирует ADR-022 и пять EVID.** Без вердикта `guardian` активация нарушила бы Step 4b. Артефакты в `draft` сознательно.
- **Не правит RFC-002** — он active и лежит вне этого репозитория; это работа Profile D.
- Открытыми в ADR остаются: владелец отсечки в ядре, противоречие `fpl-init/SKILL.md:417` ↔ `:696`, судьба маркеров `adi`/`test`/`audit` (ноль мест вызова).

Refs: ADR-022, EVID-217, EVID-218, EVID-219, EVID-220, EVID-221, #237
