### PR TITLE
docs(cross-cli): PRE-5 ADR-025 — терминальная позиция в трёх управляемых файлах

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ The 14-row routing table is **CLI-agnostic** — it names methodologies and Prof
 ## Cross-CLI compatibility
 
 > **Full recipe: [`docs/CROSS-CLI.md`](docs/CROSS-CLI.md)** — per-client MCP wiring, the
-> `.agents/skills` interop path (producer *and* consumer side), what is not yet portable,
+> `.agents/skills` interop path (producer *and* consumer side), what is Claude-Code-native by design,
 > and the four portability traps that all fail silently. Read it before concluding that
 > something in this marketplace does not work in your runtime; three of the four traps
 > present as "it is broken" when the actual answer is "that runtime spells it differently".
@@ -183,7 +183,7 @@ command = "forgeplan"
 args = ["serve"]
 ```
 
-For multi-CLI environments, `forgeplan mcp-manifest` is planned (Batch F deliverable per RFC-003) to generate all three config files in one call. Until that command ships, run `forgeplan mcp install` once per client target. Verify the command's current availability with `forgeplan mcp --help` — as of forgeplan 0.32.1 the available sub-commands are `serve` and `install` only.
+For multi-CLI environments, per-client `forgeplan mcp install` is the **terminal supported path** — one run per client target (ADR-025: cross-CLI settles as compliance with open standards; no one-call generator is a commitment of this marketplace). `forgeplan mcp-manifest`, if the upstream ever ships it, is a convenience — verify availability with `forgeplan mcp --help`; as of forgeplan 0.32.1 the sub-commands are `serve` and `install` only.
 
 **Used by**: `/smith-bootstrap` Step 0b (active runner, calls `mcp install --scope project` automatically when `.mcp.json` lacks the forgeplan block) and `/fpl-init` Step 5 (same primitive).
 
@@ -412,7 +412,7 @@ forgeplan session                         # Current pipeline phase
 # Validation
 ./scripts/validate-all-plugins.sh
 
-# Cross-CLI setup (per-client; `forgeplan mcp-manifest --output-dir` is planned but not yet shipped)
+# Cross-CLI setup — per-client, and per-client is the terminal supported path (ADR-025)
 forgeplan mcp install --client claude --scope project    # one client at a time
 ```
 

--- a/docs/CROSS-CLI.md
+++ b/docs/CROSS-CLI.md
@@ -11,11 +11,11 @@ concerns and `CLAUDE.md` is the source of truth for Claude-Code specifics.
 
 Three things travel across CLIs, and they cross at different maturity levels:
 
-| Surface | Cross-CLI today? | How |
+| Surface | Cross-CLI? | How |
 |---|---|---|
 | **MCP server** (forgeplan tools) | Yes - any MCP client | Section (a) |
 | **Skills** (plugin knowledge bases) | Yes - any agentskills.io client | Section (b) |
-| **Agents / commands / hooks** | No - Claude-Code-native today | Section (c) |
+| **Agents / commands / hooks** | No - Claude-Code-native by design | Section (c) |
 
 ---
 
@@ -48,9 +48,9 @@ forgeplan mcp install --client claude --scope project --dry-run
 
 Verify the command's current sub-commands with `forgeplan mcp --help` - as of
 forgeplan 0.32.1 the available sub-commands are `serve` and `install` only.
-`forgeplan mcp-manifest` (one call generates all client configs) is planned as
-the Batch F deliverable per RFC-003 but is **not yet shipped**; until then, run
-`forgeplan mcp install` once per client target.
+Per-client `forgeplan mcp install` is the **terminal supported path** — one run
+per client target. `forgeplan mcp-manifest` (a one-call generator) is an upstream
+convenience this marketplace makes no commitment to (ADR-025).
 
 ### Per-client config (what the command writes, or write by hand)
 
@@ -185,15 +185,16 @@ tells you which of the two an agent actually read.
 
 ---
 
-## (c) What is NOT yet cross-CLI
+## (c) What is Claude-Code-native by design
 
-**Agents, commands, and hooks are Claude-Code-native today.**
+**Agents, commands, and hooks are Claude-Code-native — terminally, not pending emit (ADR-025).**
 
 - **Agents** (`plugins/<name>/agents/*.md`) - Claude Code subagent format
   (frontmatter `tools` / `disallowedTools` denylist per the PRD-026 B2 paradigm).
   Other CLIs dispatch through their own agent layers; the skill bodies an agent
-  orchestrates are portable Markdown, but the agent definition itself is not yet
-  emitted in a cross-CLI format.
+  orchestrates are portable Markdown; the agent definition itself is not emitted
+  in a cross-CLI format, and none will be built without a new decision — a
+  concrete request opens one (ADR-025 Trigger 2).
 
   **The denylist does not travel, and its absence is silent.** `disallowedTools`
   is a Claude Code key — verified absent from the OMP binary entirely. 42 agents
@@ -216,13 +217,15 @@ tells you which of the two an agent actually read.
   nobody keeps past the second edit.
 - **Hooks** (`plugins/<name>/hooks/hooks.json`) - Claude Code hook events
   (`PreToolUse`, `PostToolUse`, `SessionStart`, etc.). Other CLIs have their own
-  automation primitives; no cross-CLI hook emit is shipped yet.
+  automation primitives; no cross-CLI hook emit is shipped, and none will be
+  built without a new decision — a concrete request opens one (ADR-025 Trigger 2).
 
-**Roadmap.** Cross-CLI emit for agents/commands/hooks is the Tier-1 / Tier-2
-work, tracked under the multi-agent multi-CLI architecture (RFC-003, four layers:
-dispatch / agents / memory / cross-CLI) and the AGENTS.md cross-CLI section.
-Until that lands, the portable surface is **MCP tools + skills**; agents,
-commands, and hooks remain Claude-Code-first.
+**Posture (ADR-025).** The portable surface is **MCP tools + skills + AGENTS.md**
+— by design and terminally, as compliance with open standards (MCP,
+agentskills.io, AGENTS.md), not as Tier 0 of a deferred adapter programme.
+Agents, commands and hooks are Claude-Code-native, with **no cross-CLI emit on
+any horizon by decision**; a concrete request opens a **new** decision rather
+than unblocking an old programme (ADR-025 supersedes ADR-014).
 
 One thing already bridges all CLIs at the orchestration layer: **smith**, the
 master-orchestrator. Its routing logic is declared in `AGENTS.md` so the same

--- a/docs/c4/ADR-014.md
+++ b/docs/c4/ADR-014.md
@@ -1,8 +1,14 @@
-# C4 — ADR-014: Multi-CLI adapter layer (tiered)
+# C4 — ADR-014: Multi-CLI adapter layer (tiered) — SUPERSEDED
 
+> **SUPERSEDED BY ADR-025** (2026-09-04): cross-CLI settled at standards
+> compliance (MCP + agentskills.io + AGENTS.md); the Tier-1 / Tier-2 emit
+> programme depicted below was **never built and is not planned**. This file
+> is retained as the executed PRE-3 record of ADR-014 — the historical view
+> of a decision the graph has since superseded. Do not read the T1/T2 nodes
+> as roadmap. Deleting this file is not acceptable (ADR-025, Affected Files).
+>
 > Co-located C4 projection extracted from ADR-014 (PRD-060 Rule 4 / PRE-3).
-> ADR-014 is the source of truth; this file is the standalone C4 view the
-> Guardian gate expects when inter-module flow is discussed.
+> ADR-014 was the source of truth at the time; ADR-025 is now.
 
 The decision spans three modules — the marketplace canonical source, the
 tiered emit generator, and each target CLI runtime — plus an upstream


### PR DESCRIPTION
## Summary
- Исполнение PRE-5 решения ADR-025 (кросс-CLI сворачивается до соответствия стандартам; supersedes ADR-014): из трёх управляемых файлов убраны все форвардные обещания снятой программы ярусов — 8 мест в docs/CROSS-CLI.md, 3 в AGENTS.md, маркер SUPERSEDED в docs/c4/ADR-014.md (файл сохранён как исторический след исполненного PRE-3).

## Verification
- Постусловие POST-3 прогнано механически: широкий регистронезависимый греп → единственное выжившее — явно исключённая строка AGENTS.md:36.
- `./scripts/validate-all-plugins.sh` → ALL PASSED.
- Дословные предписания по каждой строке — в Affected Files ADR-025; гейт guardian (EVID-246, PASS rev5) сам их перепроверял по диску.

## Test plan
- [x] POST-3 греп чист (вывод в теле коммита)
- [x] ALL PASSED (13 гейтов + 5 наборов)
- [x] Маркер superseded на месте, файл C4 не удалён

Refs: ADR-025, EVID-244, EVID-246

🤖 Generated with [Claude Code](https://claude.com/claude-code)