### PR TITLE
fix(ci): половина запрета — это не запрет; проверка симметрии форм на всех агентов

### DIFF
--- a/scripts/ci/memory-denylist-check.js
+++ b/scripts/ci/memory-denylist-check.js
@@ -122,9 +122,11 @@ const bare = (entry) => String(entry).trim().split("__").pop();
 function main() {
   const required = loadRequired();
   const problems = [];
+  const asymmetric = [];
   const misspelled = [];
   let scanned = 0;
   let inScope = 0;
+  let symmetryChecked = 0;
 
   const packs = fs.existsSync(PLUGINS)
     ? fs.readdirSync(PLUGINS, { withFileTypes: true }).filter((d) => d.isDirectory())
@@ -151,6 +153,26 @@ function main() {
       if (!deny) continue;
       const exact = new Set(deny.map((e) => String(e).trim()));
       const anyPrefix = new Set(deny.map(bare));
+
+      // CHECK ONE — prefix symmetry, applied to EVERY agent that denies any memory write tool,
+      // in scope or not. Denying a tool under one spelling and not the other is never a decision;
+      // it is always a half-written denial that stops working the moment the relay is wired the
+      // other way. This is the half of EVID-257 F3 that closes cleanly: `fpl-hsmem`'s own
+      // memory-curator legitimately retains (so it never enters the scope below) and is the ONLY
+      // file in the repository that got both spellings right — with nothing watching it. Now
+      // something does.
+      const asym = [];
+      for (const name of required) {
+        const present = PREFIXES.filter((p) => exact.has(p + name));
+        if (present.length === 1) {
+          asym.push(`${name} (has ${present[0]}, missing ${PREFIXES.find((p) => p !== present[0])})`);
+        }
+      }
+      if (asym.length) asymmetric.push({ rel, asym });
+      if (required.some((n) => anyPrefix.has(n))) symmetryChecked++;
+
+      // CHECK TWO — completeness, applied only to agents that have DECIDED they do not write
+      // memory. That decision is marked by denying `memory_retain`.
       if (!anyPrefix.has("memory_retain")) continue; // not in scope
       inScope++;
 
@@ -188,6 +210,19 @@ function main() {
     process.exit(1);
   }
 
+  if (asymmetric.length) {
+    console.error(
+      `memory-denylist-check FAILED: ${asymmetric.length} agent(s) deny a memory write tool under ` +
+        `ONE relay spelling only. A denylist matches an exact string, so half a denial is no denial ` +
+        `under the other wiring.\n`,
+    );
+    for (const a of asymmetric) {
+      console.error(`  ${a.rel}`);
+      for (const line of a.asym) console.error(`    ${line}`);
+    }
+    process.exit(1);
+  }
+
   if (problems.length) {
     console.error(
       `memory-denylist-check FAILED: ${problems.length} of ${inScope} memory-restricted agent(s) ` +
@@ -209,9 +244,10 @@ function main() {
   }
 
   console.log(
-    `Memory denylist OK: ${scanned} agent(s) scanned, ${inScope} restrict memory writes, ` +
-      `each denying all ${required.length} write tools under both relay prefixes ` +
-      `(${required.length * PREFIXES.length} entries).`,
+    `Memory denylist OK: ${scanned} agent(s) scanned. ${symmetryChecked} deny at least one memory ` +
+      `write tool and every such denial names both relay spellings. ${inScope} of those have ` +
+      `decided they do not write memory at all, and each denies all ${required.length} write tools ` +
+      `under both prefixes (${required.length * PREFIXES.length} entries).`,
   );
 }
 

--- a/scripts/ci/memory-denylist-check.selftest.sh
+++ b/scripts/ci/memory-denylist-check.selftest.sh
@@ -11,7 +11,7 @@
 # of the rule it was written for. A negative control that does not test the DECIDING property
 # constrains nothing (EVID-257 F2). Case 5 below is that missing control.
 #
-# Nine cases: five must-fire, two must-refuse (rules it cannot trust), two must-NOT-fire
+# Eleven cases: six must-fire, two must-refuse (rules it cannot trust), three must-NOT-fire
 # (legitimate shapes that would be false positives if the checker were too eager). The count is
 # stated here and printed at the end; if those two disagree, the summary is lying about its own work.
 set -uo pipefail
@@ -147,7 +147,27 @@ else
 fi
 rm -f "$work/plugins/probe/agents/nobody.md"
 
-# 8. must-fire — shrinking the registry makes this gate GREENER, never redder. The pinned count is
+# 8. prefix symmetry OUTSIDE the completeness scope — the case the old gate could not see at all.
+#    An agent that legitimately retains (so it never enters scope) but denies some destructive tool
+#    must still name both spellings. `fpl-hsmem`'s own memory-curator is exactly this shape, and
+#    before this check nothing in the repository watched the file with the most bank-write authority
+#    in it (EVID-257 F3).
+write_agent "complete.md" "$BOTH"
+write_agent "curator.md" "mcp__plugin_fpl-hsmem_hindsight__document_delete, mcp__hindsight__document_delete"
+if node "$work/scripts/ci/memory-denylist-check.js" >/dev/null 2>&1; then
+  pass "must-NOT-fire  an out-of-scope agent denying one tool under BOTH spellings passes"
+else
+  fail "a symmetric partial denial was flagged — false positive on a legitimate shape"
+fi
+write_agent "curator.md" "mcp__plugin_fpl-hsmem_hindsight__document_delete"
+if node "$work/scripts/ci/memory-denylist-check.js" >/dev/null 2>&1; then
+  fail "gate PASSED on a half-written denial outside the completeness scope — nothing watches it"
+else
+  pass "must-fire      a one-spelling denial outside the completeness scope is caught"
+fi
+rm -f "$work/plugins/probe/agents/curator.md"
+
+# 9. must-fire — shrinking the registry makes this gate GREENER, never redder. The pinned count is
 #    the only thing that turns a silent shrink into a deliberate two-file edit.
 write_agent "complete.md" "$BOTH"
 python3 - "$work/plugins/fpl-hsmem/src/lib/tool-names.ts" <<'PY'
@@ -169,7 +189,7 @@ cp "$work/registry.bak" "$work/plugins/fpl-hsmem/src/lib/tool-names.ts"
 
 echo
 if [ "$fails" -eq 0 ]; then
-  echo "self-test OK: 9 cases (5 must-fire, 2 must-refuse, 2 must-NOT-fire)"
+  echo "self-test OK: 11 cases (6 must-fire, 2 must-refuse, 3 must-NOT-fire)"
   exit 0
 fi
 echo "self-test FAILED: $fails"


### PR DESCRIPTION
## Summary

Вторая половина находки аудита EVID-257 F3. Прошлый PR закрыл дыру у 27 агентов, которые **объявили**, что не пишут в память. Этот закрывает случай, который под то правило не попадает вовсе.

`plugins/fpl-hsmem/agents/memory-curator.md` законно не запрещает `memory_retain` — курировать банк значит в него писать. Поэтому правило полноты его не касается, и гейт его не читал. При этом он **единственный** файл в репозитории, который делал обе формы имени правильно ещё до вчерашней правки. Единственный, кто всё делал верно, оказался единственным, за кем никто не следил.

## Что добавлено

Проверка **симметрии**, а не полноты, и она идёт по всем агентам: если инструмент записи в память запрещён под одной формой имени, он обязан быть запрещён и под второй.

Ложных срабатываний у правила нет по построению — запретить инструмент под одной пропиской и не запретить под другой никогда не бывает решением, это всегда недописанный запрет.

## Verification

Настоящая мутация на рабочем дереве, а не фикстура:

```
$ (снял одну форму у document_delete в memory-curator)
$ node scripts/ci/memory-denylist-check.js
memory-denylist-check FAILED: 1 agent(s) deny a memory write tool under ONE relay spelling only.

  plugins/fpl-hsmem/agents/memory-curator.md
    document_delete (has mcp__plugin_fpl-hsmem_hindsight__, missing mcp__hindsight__)
EXIT=1

$ git checkout -- … && git status --porcelain
(пусто)
```

Зелёный вывод теперь считает обе области отдельно и не смешивает их:

```
Memory denylist OK: 96 agent(s) scanned. 28 deny at least one memory write tool and every
such denial names both relay spellings. 27 of those have decided they do not write memory
at all, and each denies all 12 write tools under both prefixes (24 entries).
```

## Test plan

- ✅ `bash scripts/ci/memory-denylist-check.selftest.sh` — **11** случаев (было 9), все зелёные
- ✅ Два новых случая: must-fire (недописанный запрет вне области полноты) и must-NOT-fire (частичный, но симметричный запрет — законная форма)
- ✅ `./scripts/validate-all-plugins.sh` — ALL PASSED
- ✅ Мутация роняет гейт, откат восстанавливает — проверено, а не предположено

Правка только в `scripts/ci/` — ни один плагин не изменён, поэтому версии не поднимаются.

Refs: EVID-257 F3, ADR-026

🤖 Generated with [Claude Code](https://claude.com/claude-code)