### PR TITLE
fix(ci): один правильный запрет глушил отчёт обо всех остальных у того же агента

### DIFF
--- a/scripts/ci/memory-denylist-check.js
+++ b/scripts/ci/memory-denylist-check.js
@@ -203,6 +203,7 @@ function main() {
       // file in the repository that got both spellings right — with nothing watching it. Now
       // something does.
       const asym = [];
+      const alien = [];
       let bothCount = 0;
       for (const name of required) {
         const present = PREFIXES.filter((p) => exact.has(p + name));
@@ -210,15 +211,23 @@ function main() {
         if (present.length === 1) {
           asym.push(`${name} (has ${present[0]}, missing ${PREFIXES.find((p) => p !== present[0])})`);
         }
+        // PER TOOL, not per agent. The first version tested the unknown prefix once for the whole
+        // agent, in an `else` branch — so a single correct both-prefix denial suppressed the report
+        // for every other denial on the same file, and one binding under no wiring this repository
+        // ships went unnamed while the agent counted as compliant. Demonstrated on a fixture by the
+        // activation gate (EVID-259 G3), not reasoned about.
+        if (present.length === 0 && anyPrefix.has(name)) {
+          const seen = deny.filter((e) => bare(e) === name).map((e) => String(e).trim());
+          alien.push(`${name} (named as ${seen.join(", ")} — neither known relay spelling)`);
+        }
       }
       if (asym.length) asymmetric.push({ rel, asym });
+      if (alien.length) unknownPrefix.push({ rel, alien });
       // Count an agent toward the symmetry tally only when it actually names BOTH spellings of
       // something. The earlier tally counted "mentions a write tool under any prefix", so an agent
       // naming its denials under a THIRD server name was counted in a sentence promising both known
-      // spellings — the summary line asserting more than the code checks (EVID-258 N3). Such an
-      // agent is now reported separately instead of silently inflating the compliant count.
+      // spellings — the summary line asserting more than the code checks (EVID-258 N3).
       if (bothCount > 0) symmetryChecked++;
-      else if (required.some((n) => anyPrefix.has(n))) unknownPrefix.push(rel);
 
       // CHECK TWO — completeness, applied only to agents that have DECIDED they do not write
       // memory. That decision is marked by denying `memory_retain`.
@@ -272,9 +281,9 @@ function main() {
   if (unknownPrefix.length) {
     fail(
       `memory-denylist-check FAILED: ${unknownPrefix.length} agent(s) deny a memory write tool under ` +
-        `a relay prefix this gate does not know. Neither known spelling is present, so the denial ` +
-        `binds under no wiring this repository ships — and it must not be counted as compliant.`,
-      unknownPrefix.map((rel) => `  ${rel}`),
+        `a relay prefix this gate does not know. Neither known spelling is present for that tool, so ` +
+        `the denial binds under no wiring this repository ships.`,
+      unknownPrefix.flatMap((u) => [`  ${u.rel}`, ...u.alien.map((l) => `    ${l}`)]),
     );
   }
 

--- a/scripts/ci/memory-denylist-check.selftest.sh
+++ b/scripts/ci/memory-denylist-check.selftest.sh
@@ -11,7 +11,7 @@
 # of the rule it was written for. A negative control that does not test the DECIDING property
 # constrains nothing (EVID-257 F2). Case 5 below is that missing control.
 #
-# Sixteen cases: ten must-fire, three must-refuse (rules it cannot trust), three must-NOT-fire
+# Seventeen cases: eleven must-fire, three must-refuse (rules it cannot trust), three must-NOT-fire
 # (legitimate shapes that would be false positives if the checker were too eager). The count is
 # stated here and printed at the end; if those two disagree, the summary is lying about its own work.
 set -uo pipefail
@@ -263,6 +263,19 @@ else
 fi
 rm -f "$work/plugins/probe/agents/third.md"
 
+# 13b. must-fire — the SAME agent gets one tool right under both spellings and another under a third
+#      server name. The first version of the unknown-prefix check ran once per AGENT in an `else`
+#      branch, so the correct denial suppressed the report for the bad one and the agent counted as
+#      compliant. Per tool now (EVID-259 G3, demonstrated on a fixture before this case existed).
+write_agent "complete.md" "$BOTH"
+write_agent "mixed.md" "mcp__hindsight__document_delete, mcp__plugin_fpl-hsmem_hindsight__document_delete, mcp__hs__bank_config_set"
+if node "$work/scripts/ci/memory-denylist-check.js" >/dev/null 2>&1; then
+  fail "gate PASSED on an agent mixing a correct denial with a third-prefix one — one right answer hid the wrong one"
+else
+  pass "must-fire      a third-prefix denial is caught even beside a correct both-prefix denial"
+fi
+rm -f "$work/plugins/probe/agents/mixed.md"
+
 # 14. must-fire, and it checks the REPORT rather than the verdict — two unrelated defects at once
 #     must both be named. Reporting only the first made an operator find the second on the next run
 #     (EVID-258 N6).
@@ -278,7 +291,7 @@ rm -f "$work/plugins/probe/agents/half.md"
 
 echo
 if [ "$fails" -eq 0 ]; then
-  echo "self-test OK: 16 cases (10 must-fire, 3 must-refuse, 3 must-NOT-fire)"
+  echo "self-test OK: 17 cases (11 must-fire, 3 must-refuse, 3 must-NOT-fire)"
   exit 0
 fi
 echo "self-test FAILED: $fails"


### PR DESCRIPTION
## Summary

Гейт активации (EVID-259 G3) нашёл, что проверка чужого префикса работала **на агента, а не на инструмент**: она стояла в ветке `else` после подсчёта симметрии, поэтому один корректный запрет под обеими формами выключал её для всего файла.

## Verification

Фикстура, контрольная пара — отличие ровно одно:

```
P-A  both-prefix document_delete + третий префикс на bank_config_set
     -> Memory denylist OK: … and none names only one …   EXIT=0   ← глушение

P-B  контроль: только третий префикс
     -> FAILED: 1 agent(s) deny a memory write tool under a relay prefix
        this gate does not know                            EXIT=1
```

Зелёная строка при этом остаётся **буквально верной** («ни один не назвал только одну форму»), пока запрет, не связывающий ни под одной проводкой репозитория, идёт незамеченным. Тот же класс, что и N3, который эта проверка должна была закрыть.

На дереве сегодня не встречается — все 96 агентов пользуются двумя известными формами. Закрывать надо именно поэтому: тот же довод был принят для N2 в прошлой правке и не применён здесь.

## Test plan

- ✅ `bash scripts/ci/memory-denylist-check.selftest.sh` — **17** случаев (было 16), из них **11** must-fire
- ✅ Новый случай — контрольная пара: корректный запрет рядом с третьим префиксом обязан падать
- ✅ `./scripts/validate-all-plugins.sh` — ALL PASSED
- ✅ Правка только в `scripts/ci/` — ни один плагин не изменён, версии не поднимаются

Refs: EVID-259 G3, ADR-026

🤖 Generated with [Claude Code](https://claude.com/claude-code)